### PR TITLE
Feat/app passwords

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,9 @@ KEYCLOAK_JWKS_CACHE_TTL=3600
 # JWT Validation (Keycloak uses RS256)
 JWT_ALGORITHM=RS256
 
+# Encryption (generate with: python3 -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())")
+ENCRYPTION_KEY=your-generated-fernet-key-here
+
 # Grafana
 GRAFANA_ADMIN_USER=admin
 GRAFANA_ADMIN_PASSWORD=changeme_secure_password

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ This starts:
 - **PostgreSQL** at localhost:5432
 - **Redis** at localhost:6379
 - **Celery Worker** for async tasks
+- **Prometheus** at http://localhost:9090 (metrics)
 - **Loki** at localhost:3100 (log aggregation)
-- **Grafana** at http://localhost:3000 (monitoring dashboards)
+- **Grafana** at http://localhost:8888 (monitoring dashboards)
 - **Promtail** (log collection)
 
 ### 4. Verify Installation
@@ -90,4 +91,4 @@ docker compose down -v
 
 ## Monitoring & Observability
 
-Access Grafana at http://localhost:3000
+Access Grafana at http://localhost:8888

--- a/alembic/versions/encrypt_dia_secrets.py
+++ b/alembic/versions/encrypt_dia_secrets.py
@@ -1,0 +1,73 @@
+"""encrypt deployment instance access secrets and add database access type
+
+Revision ID: encrypt_dia_secrets
+Revises: 66e4c3287d2d
+Create Date: 2026-05-27
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'encrypt_dia_secrets'
+down_revision: Union[str, Sequence[str], None] = '66e4c3287d2d'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Switch deployment_instance_access password/ssh_private_key to encrypted storage
+    and extend the access_type enum with the new ``database`` member.
+
+    The on-disk column type stays TEXT-compatible; encryption is handled by the
+    EncryptedString TypeDecorator at the model layer. Because the columns have
+    never been populated in production, no data backfill is needed.
+    """
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+
+    # Enum extension is dialect-specific. Postgres needs ALTER TYPE; SQLite stores
+    # enums as plain strings via a CHECK constraint, so a no-op here is fine.
+    if dialect == 'postgresql':
+        op.execute("ALTER TYPE accesstype ADD VALUE IF NOT EXISTS 'database'")
+
+    # EncryptedString writes Fernet tokens (base64); existing TEXT type already fits.
+    # The alter_column calls below are intentionally minimal — they document the
+    # semantic change without altering on-disk types.
+    op.alter_column(
+        'deployment_instance_access',
+        'password',
+        existing_type=sa.Text(),
+        type_=sa.Text(),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        'deployment_instance_access',
+        'ssh_private_key',
+        existing_type=sa.Text(),
+        type_=sa.Text(),
+        existing_nullable=True,
+    )
+
+
+def downgrade() -> None:
+    """Revert column annotations. Cannot remove the ``database`` enum value safely
+    in PostgreSQL, so we leave it in place; downgrade is best-effort.
+    """
+    op.alter_column(
+        'deployment_instance_access',
+        'ssh_private_key',
+        existing_type=sa.Text(),
+        type_=sa.Text(),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        'deployment_instance_access',
+        'password',
+        existing_type=sa.Text(),
+        type_=sa.Text(),
+        existing_nullable=True,
+    )

--- a/bruno/Deployments/Create Deployment ubuntu.bru
+++ b/bruno/Deployments/Create Deployment ubuntu.bru
@@ -23,13 +23,16 @@ body:json {
       "stack_label": "multistudent",
       "image": "Ubuntu 22.04 2025-01",
       "flavor": "gp1.small",
+      "volume_size": 16,
+      "network": "NAT",
+      "external_network": "DHBW",
       "ssh_cidr": "141.72.0.0/16",
       "force_password_change": false,
       "workdir": "work",
-      "pw_min_length": 7,
-      "pw_require_digit": false,
-      "pw_require_upper": false,
-      "pw_require_special": false
+      "pw_min_length": 12,
+      "pw_require_digit": true,
+      "pw_require_upper": true,
+      "pw_require_special": true
     },
     "stack_assignments": [
       {
@@ -112,18 +115,22 @@ docs {
   required and optional parameters for the template. The backend automatically generates
   `user_json` and `admin_credentials` from stack_assignments and teacher data.
   
-  **Example Heat Parameters (PostgreSQL Group DB):**
+  **Example Heat Parameters (Multistudent Ubuntu):**
   ```json
   {
+    "stack_label": "multistudent",
     "image": "Ubuntu 22.04 2025-01",
     "flavor": "gp1.small",
+    "volume_size": 16,
     "network": "NAT",
     "external_network": "DHBW",
     "ssh_cidr": "141.72.0.0/16",
-    "web_cidr": "141.72.0.0/16"
-  }
-    "db_password": "securepassword123",
-    "postgres_version": 14
+    "force_password_change": true,
+    "workdir": "work",
+    "pw_min_length": 12,
+    "pw_require_digit": true,
+    "pw_require_upper": true,
+    "pw_require_special": true
   }
   ```
   

--- a/bruno/Deployments/Create Deployment.bru
+++ b/bruno/Deployments/Create Deployment.bru
@@ -131,15 +131,14 @@ docs {
   **Example Heat Parameters (PostgreSQL Group DB):**
   ```json
   {
+    "stack_label": "my-postgres",
     "image": "Ubuntu 22.04 2025-01",
     "flavor": "gp1.small",
+    "volume_size": 16,
     "network": "NAT",
     "external_network": "DHBW",
     "ssh_cidr": "141.72.0.0/16",
     "web_cidr": "141.72.0.0/16"
-  }
-    "db_password": "securepassword123",
-    "postgres_version": 14
   }
   ```
   

--- a/bruno/Deployments/Create Deployment.bru
+++ b/bruno/Deployments/Create Deployment.bru
@@ -78,7 +78,7 @@ body:json {
 }
 
 vars:pre-request {
-  template_version_id: f45ac4ac-fef1-4668-b458-14f28b1cc984
+  template_version_id: 74007335-ed37-42c4-bb6f-3160f7b98ef8
 }
 
 script:post-response {

--- a/bruno/Deployments/Delete Deployment.bru
+++ b/bruno/Deployments/Delete Deployment.bru
@@ -10,12 +10,16 @@ delete {
   auth: bearer
 }
 
+params:path {
+  deployment_id: 
+}
+
 auth:bearer {
   token: {{access_token}}
 }
 
-params:path {
-  deployment_id: 
+vars:pre-request {
+  deployment_id: 0fc73e47-99b7-4eb9-8bb1-de27de03297e
 }
 
 docs {

--- a/bruno/Deployments/Delete Deployment.bru
+++ b/bruno/Deployments/Delete Deployment.bru
@@ -19,7 +19,7 @@ auth:bearer {
 }
 
 vars:pre-request {
-  deployment_id: 0fc73e47-99b7-4eb9-8bb1-de27de03297e
+  deployment_id: 8a986b4f-0b39-4c98-85d1-e7f8784ca34d
 }
 
 docs {

--- a/bruno/Deployments/Get Deployment Credentials.bru
+++ b/bruno/Deployments/Get Deployment Credentials.bru
@@ -14,6 +14,10 @@ auth:bearer {
   token: {{access_token}}
 }
 
+vars:pre-request {
+  deployment_id: b0b54f41-d63c-45d8-8a15-ec9f55c86c4b
+}
+
 script:post-response {
   if (res.status === 200) {
     const data = res.body.data;
@@ -31,14 +35,14 @@ script:post-response {
 
 docs {
   # Get Deployment Credentials
-
+  
   Returns the generated user/admin credentials (group accounts, teacher admin, database users, ...) that were injected into the deployment's VMs. Passwords are stored Fernet-encrypted on the backend and decrypted only for this response.
-
+  
   **Required Role:** Admin, or the Lecturer who owns the deployment
-
+  
   **Path Parameters:**
   - `deployment_id`: ID of the deployment
-
+  
   **Returns:**
   - `deployment_id`: the deployment
   - `instances[]`: one entry per Heat stack
@@ -46,6 +50,6 @@ docs {
     - `accesses[]`: list of credential entries
       - `access_type`: `ssh` (Ubuntu user / teacher) or `database` (Postgres / pgAdmin)
       - `username`, `password`, `connection_url`, `port`
-
+  
   **Use Case:** Display credentials in the deployment UI so lecturers and students can sign in without reading them from cloud-init logs.
 }

--- a/bruno/Deployments/Get Deployment Credentials.bru
+++ b/bruno/Deployments/Get Deployment Credentials.bru
@@ -1,0 +1,51 @@
+meta {
+  name: Get Deployment Credentials
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{base_url}}/api/v1/deployments/{{deployment_id}}/credentials
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{access_token}}
+}
+
+script:post-response {
+  if (res.status === 200) {
+    const data = res.body.data;
+    console.log(`✅ Retrieved credentials for ${data.instances.length} instance(s)`);
+    data.instances.forEach((instance, idx) => {
+      console.log(`[Instance ${idx + 1}] ${instance.vm_name || instance.instance_id}`);
+      instance.accesses.forEach((acc) => {
+        console.log(`  - ${acc.access_type} ${acc.username}: ${acc.password}`);
+      });
+    });
+  } else {
+    console.log("❌ Failed to retrieve credentials:", res.status, res.body);
+  }
+}
+
+docs {
+  # Get Deployment Credentials
+
+  Returns the generated user/admin credentials (group accounts, teacher admin, database users, ...) that were injected into the deployment's VMs. Passwords are stored Fernet-encrypted on the backend and decrypted only for this response.
+
+  **Required Role:** Admin, or the Lecturer who owns the deployment
+
+  **Path Parameters:**
+  - `deployment_id`: ID of the deployment
+
+  **Returns:**
+  - `deployment_id`: the deployment
+  - `instances[]`: one entry per Heat stack
+    - `instance_id`, `vm_name`, `openstack_stack_id`
+    - `accesses[]`: list of credential entries
+      - `access_type`: `ssh` (Ubuntu user / teacher) or `database` (Postgres / pgAdmin)
+      - `username`, `password`, `connection_url`, `port`
+
+  **Use Case:** Display credentials in the deployment UI so lecturers and students can sign in without reading them from cloud-init logs.
+}

--- a/bruno/Deployments/Get Deployment Logs.bru
+++ b/bruno/Deployments/Get Deployment Logs.bru
@@ -14,6 +14,10 @@ auth:bearer {
   token: {{access_token}}
 }
 
+vars:pre-request {
+  deployment_id: 8a986b4f-0b39-4c98-85d1-e7f8784ca34d
+}
+
 script:post-response {
   if (res.status === 200) {
     const logs = res.body.data;

--- a/src/api/deployments.py
+++ b/src/api/deployments.py
@@ -263,11 +263,21 @@ async def get_deployment(
     deployment_dict["instances"] = [
         {
             "id": str(instance.id),
-            "instance_name": instance.instance_name,
-            "openstack_instance_id": instance.openstack_instance_id,
+            "instance_name": instance.vm_name,
+            "openstack_instance_id": instance.openstack_server_id,
             "status": instance.status.value if instance.status else None,
             "ip_address": instance.ip_address,
-            "access_urls": instance.access_urls_json,
+            "access_urls": [
+                {
+                    "id": str(access.id),
+                    "access_type": access.access_type.value if access.access_type else None,
+                    "connection_url": access.connection_url,
+                    "username": access.username,
+                    "port": access.port,
+                    "is_active": access.is_active,
+                }
+                for access in (instance.access_methods or [])
+            ],
             "created_at": instance.created_at.isoformat() if hasattr(instance.created_at, 'isoformat') else instance.created_at,
             "updated_at": instance.updated_at.isoformat() if hasattr(instance.updated_at, 'isoformat') else instance.updated_at,
         }

--- a/src/api/deployments.py
+++ b/src/api/deployments.py
@@ -13,10 +13,16 @@ from src.schemas.deployment import DeploymentResponse, DeploymentCreate
 from src.services.deployment_service import DeploymentService
 from src.services.deployment_log_service import DeploymentLogService
 from src.services.openstack_heat_service import HeatStackService
-from src.schemas.deployment import DeploymentLogResponse
+from src.schemas.deployment import (
+    DeploymentLogResponse,
+    DeploymentCredentialEntry,
+    DeploymentInstanceCredentials,
+    DeploymentCredentialsResponse,
+)
 from src.tasks.deploy_tasks import delete_deployment as delete_deployment_task
 from src.tasks.deploy_tasks import restart_deployment as restart_deployment_task
 from src.models.deployment import DeploymentStatus, Deployment
+from src.models.deployment_instance import DeploymentInstance
 from src.models.template_version import TemplateVersion
 
 router = APIRouter(
@@ -327,6 +333,70 @@ async def get_deployment_logs(
         data=[DeploymentLogResponse.model_validate(log) for log in logs],
         message=f"Retrieved {len(logs)} log entries for deployment",
         request_id=request_id
+    )
+
+
+@router.get("/{deployment_id}/credentials", response_model=dict)
+async def get_deployment_credentials(
+    deployment_id: str,
+    db: DBSession,
+    request_id: RequestID,
+    user: CurrentUser,
+):
+    """Return generated user credentials for a deployment.
+
+    Accessible to the lecturer who owns the deployment or any admin. Passwords
+    are decrypted on read by the EncryptedString TypeDecorator on the model.
+    """
+    deployment_repo = DeploymentRepository(db)
+    deployment = deployment_repo.get_by_id(deployment_id)
+    if not deployment:
+        raise NotFoundException(f"Deployment with ID {deployment_id} not found")
+
+    user_roles = user.get("roles", [])
+    is_admin = "admin" in [role.lower() for role in user_roles]
+    if not is_admin:
+        owner_id = get_deployment_owner_id(deployment, db)
+        if user["user_id"] != owner_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You do not have permission to access this deployment"
+            )
+
+    instances = (
+        db.query(DeploymentInstance)
+        .filter(DeploymentInstance.deployment_id == deployment_id)
+        .all()
+    )
+
+    instance_payloads = [
+        DeploymentInstanceCredentials(
+            instance_id=instance.id,
+            vm_name=instance.vm_name,
+            openstack_stack_id=instance.openstack_server_id,
+            accesses=[
+                DeploymentCredentialEntry(
+                    access_type=access.access_type.value,
+                    username=access.username,
+                    password=access.password,
+                    connection_url=access.connection_url,
+                    port=access.port,
+                )
+                for access in instance.access_methods
+            ],
+        )
+        for instance in instances
+    ]
+
+    payload = DeploymentCredentialsResponse(
+        deployment_id=deployment_id,
+        instances=instance_payloads,
+    )
+
+    return ResponseBuilder.success(
+        data=payload.model_dump(),
+        message=f"Retrieved credentials for {len(instance_payloads)} instance(s)",
+        request_id=request_id,
     )
 
 

--- a/src/models/deployment_instance_access.py
+++ b/src/models/deployment_instance_access.py
@@ -3,10 +3,11 @@ from datetime import datetime, timezone
 from enum import Enum
 from uuid import uuid4
 
-from sqlalchemy import String, DateTime, Enum as SQLEnum, Text, Integer, Boolean, ForeignKey
+from sqlalchemy import String, DateTime, Enum as SQLEnum, Integer, Boolean, ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.core.database import Base
+from src.services.secret_encryption_service import EncryptedString
 
 
 class AccessType(str, Enum):
@@ -16,34 +17,36 @@ class AccessType(str, Enum):
     GUACAMOLE = "guacamole"
     RDP = "rdp"
     VNC = "vnc"
+    DATABASE = "database"
 
 
 class DeploymentInstanceAccess(Base):
     """Deployment Instance Access database model.
-    
+
     Stores access credentials and connection details for deployment instances.
     Supports multiple access methods per instance (SSH, web, RDP, etc.).
     """
-    
+
     __tablename__ = "deployment_instance_access"
-    
+
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
     deployment_instance_id: Mapped[str] = mapped_column(String(36), ForeignKey("deployment_instances.id"), nullable=False)
     access_type: Mapped[AccessType] = mapped_column(SQLEnum(AccessType), nullable=False)
-    
-    # Connection details
+
+    # Connection details. password and ssh_private_key are Fernet-encrypted at rest
+    # via EncryptedString and decrypted transparently on read; never log them.
     connection_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
     username: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    password: Mapped[str | None] = mapped_column(Text, nullable=True)  # Should be encrypted in production
-    ssh_private_key: Mapped[str | None] = mapped_column(Text, nullable=True)  # Should be encrypted in production
+    password: Mapped[str | None] = mapped_column(EncryptedString(), nullable=True)
+    ssh_private_key: Mapped[str | None] = mapped_column(EncryptedString(), nullable=True)
     port: Mapped[int | None] = mapped_column(Integer, nullable=True)
-    
+
     # Access control
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     expires_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
-    
+
     created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
     updated_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
-    
+
     # Relationships
     deployment_instance: Mapped["DeploymentInstance"] = relationship("DeploymentInstance", back_populates="access_methods")

--- a/src/schemas/deployment.py
+++ b/src/schemas/deployment.py
@@ -145,7 +145,7 @@ class DeploymentLogResponse(BaseModel):
     details: Optional[dict[str, Any]] = Field(None, description="Additional details as JSON")
     request_id: Optional[str] = Field(None, description="Request ID for tracing")
     created_at: datetime = Field(..., description="Log timestamp")
-    
+
     model_config = ConfigDict(
         from_attributes=True,
         json_schema_extra={
@@ -161,4 +161,29 @@ class DeploymentLogResponse(BaseModel):
             }
         }
     )
+
+
+class DeploymentCredentialEntry(BaseModel):
+    """One credential entry for a deployment instance."""
+    access_type: str = Field(..., description="Access type, e.g. ssh or database")
+    username: Optional[str] = Field(None, description="Account username")
+    password: Optional[str] = Field(None, description="Plaintext password (decrypted on read)")
+    connection_url: Optional[str] = Field(None, description="Connection URL if applicable")
+    port: Optional[int] = Field(None, description="Port number if applicable")
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class DeploymentInstanceCredentials(BaseModel):
+    """Credentials grouped by deployment instance (one per Heat stack)."""
+    instance_id: str = Field(..., description="Deployment instance ID")
+    vm_name: Optional[str] = Field(None, description="Stack name / VM name")
+    openstack_stack_id: Optional[str] = Field(None, description="OpenStack Heat stack ID")
+    accesses: list[DeploymentCredentialEntry] = Field(..., description="Credential entries for this instance")
+
+
+class DeploymentCredentialsResponse(BaseModel):
+    """Response payload for GET /deployments/{id}/credentials."""
+    deployment_id: str = Field(..., description="Deployment ID")
+    instances: list[DeploymentInstanceCredentials] = Field(..., description="Per-instance credential bundles")
 

--- a/src/services/deployment_credential_service.py
+++ b/src/services/deployment_credential_service.py
@@ -1,0 +1,103 @@
+"""Persist deployment credentials produced by the per-stack ``user_json``.
+
+After a Heat stack is created, this service writes one ``DeploymentInstance``
+row per stack and one ``DeploymentInstanceAccess`` row per credential entry
+(group account, teacher admin, postgres user, pgAdmin user, ...). Passwords
+are auto-encrypted by the ``EncryptedString`` type decorator on the model.
+"""
+from __future__ import annotations
+
+from typing import Any
+from sqlalchemy.orm import Session
+
+from src.models.deployment_instance import DeploymentInstance, DeploymentInstanceStatus
+from src.models.deployment_instance_access import AccessType, DeploymentInstanceAccess
+
+
+class DeploymentCredentialService:
+    """Write the credentials embedded in a stack's ``user_json`` to the database."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    def persist_credentials_for_stack(
+        self,
+        deployment_id: str,
+        stack_name: str,
+        openstack_stack_id: str,
+        user_json: dict[str, Any],
+    ) -> DeploymentInstance:
+        """Persist credentials for one Heat stack.
+
+        Creates a single ``DeploymentInstance`` for the stack and attaches one
+        ``DeploymentInstanceAccess`` row per credential entry found in
+        ``user_json``. Both the Ubuntu shape (credentials nested under
+        ``instance``) and the Postgres shape (credentials inside
+        ``applications[*]``) are supported.
+
+        The instance status is set to ``RUNNING`` because this is called only
+        after the Heat stack creation API returned successfully.
+        """
+        instance = DeploymentInstance(
+            deployment_id=deployment_id,
+            vm_name=stack_name,
+            openstack_server_id=openstack_stack_id,
+            status=DeploymentInstanceStatus.RUNNING,
+        )
+        self.db.add(instance)
+        self.db.flush()  # populate instance.id for FK use below
+
+        for entry in self._extract_access_entries(user_json):
+            self.db.add(
+                DeploymentInstanceAccess(
+                    deployment_instance_id=instance.id,
+                    access_type=entry["access_type"],
+                    username=entry.get("username"),
+                    password=entry.get("password"),
+                )
+            )
+
+        self.db.commit()
+        return instance
+
+    @staticmethod
+    def _extract_access_entries(user_json: dict[str, Any]) -> list[dict[str, Any]]:
+        """Flatten a ``user_json`` payload into a list of access-row payloads.
+
+        Returns dicts shaped like ``{access_type, username, password}``. Username
+        for Postgres entries falls back to ``db_user`` since that's the field
+        the postgres template uses; pgAdmin entries use ``email``.
+        """
+        entries: list[dict[str, Any]] = []
+
+        instance = user_json.get("instance") or {}
+        for cred in instance.get("credentials") or []:
+            entries.append({
+                "access_type": AccessType.SSH,
+                "username": cred.get("username"),
+                "password": cred.get("password"),
+            })
+        admin = instance.get("admin_credentials")
+        if admin:
+            entries.append({
+                "access_type": AccessType.SSH,
+                "username": admin.get("username"),
+                "password": admin.get("password"),
+            })
+
+        for application in user_json.get("applications") or []:
+            for cred in application.get("credentials") or []:
+                entries.append({
+                    "access_type": AccessType.DATABASE,
+                    "username": cred.get("db_user") or cred.get("email") or cred.get("username"),
+                    "password": cred.get("password"),
+                })
+            app_admin = application.get("admin_credentials")
+            if app_admin:
+                entries.append({
+                    "access_type": AccessType.DATABASE,
+                    "username": app_admin.get("db_user") or app_admin.get("email") or app_admin.get("username"),
+                    "password": app_admin.get("password"),
+                })
+
+        return [e for e in entries if e.get("password")]

--- a/src/services/openstack_heat_service.py
+++ b/src/services/openstack_heat_service.py
@@ -112,7 +112,7 @@ class HeatStackService:
             logger.debug(f"Stack parameters: {parameters}")
             
             # Create stack
-            stack = conn.orchestration.create_stack(**stack_params)
+            stack = conn.orchestration.create_stack(preview=False, **stack_params)
             
             logger.info(f"Heat stack created successfully: {stack.id}")
             

--- a/src/services/template_user_management_service.py
+++ b/src/services/template_user_management_service.py
@@ -25,12 +25,12 @@ Expected Template Structures (per stack):
               "group": 1,
               "database_name": "db_g01",
               "db_user": "grp1",
-              "password": "Grp1DbPw_2026!"
+              "password": "Grp1Db-azure-tiger-42"
             }
           ],
           "admin_credentials": {
             "db_user": "teacher",
-            "password": "TeacherDbPw_2026!"
+            "password": "TeacherDb-mango-cobalt-91"
           }
         }
       ]
@@ -43,12 +43,12 @@ Expected Template Structures (per stack):
       "course_label": "ubuntu-kurs",
       "instance": {
         "credentials": [
-          { "username": "gruppe-1", "password": "Grp2026!grupp" },
-          { "username": "gruppe-2", "password": "Grp2026!grupp" }
+          { "username": "gruppe-1", "password": "Grp1-azure-tiger-42" },
+          { "username": "gruppe-2", "password": "Grp2-mellow-raven-07" }
         ],
         "admin_credentials": {
           "username": "prof-berg",
-          "password": "Tch2026!prof-"
+          "password": "Teacher-witty-cedar-58"
         }
       },
       "applications": []
@@ -77,6 +77,7 @@ Usage Example:
 """
 from typing import Any
 from src.schemas.deployment import StackAssignment, TeacherInfo
+from src.utils.secure_password import generate_memorable_password
 
 
 class TemplateUserManagementService:
@@ -149,29 +150,25 @@ class TemplateUserManagementService:
                 "group": group_idx,
                 "database_name": f"db_g{group_idx:02d}",
                 "db_user": f"grp{group_idx}",
-                "password": TemplateUserManagementService._generate_password(
-                    f"Grp{group_idx}Db"
-                )
+                "password": generate_memorable_password(f"Grp{group_idx}Db")
             })
-            
+
             # pgAdmin credentials per group
             pgadmin_credentials.append({
                 "group": group_idx,
                 "email": f"grp{group_idx}@{course_label_to_domain(stack_assignment.groups[0].group_name if stack_assignment.groups else 'course')}.de",
-                "password": TemplateUserManagementService._generate_password(
-                    f"Grp{group_idx}Pg"
-                )
+                "password": generate_memorable_password(f"Grp{group_idx}Pg")
             })
-        
+
         # Teacher admin credentials
         postgres_admin = {
             "db_user": "teacher",
-            "password": TemplateUserManagementService._generate_password("TeacherDb")
+            "password": generate_memorable_password("TeacherDb")
         }
-        
+
         pgadmin_admin = {
             "email": f"teacher@{course_label_to_domain(teacher.username)}.de",
-            "password": TemplateUserManagementService._generate_password("TeacherPg")
+            "password": generate_memorable_password("TeacherPg")
         }
         
         return [
@@ -195,34 +192,31 @@ class TemplateUserManagementService:
         teacher: TeacherInfo
     ) -> dict[str, Any]:
         """Generate instance data for multistudent-ubuntu template.
-        
+
         This template expects credentials directly in the instance object,
         not nested in applications. Each GROUP gets one shared VM account.
-        
-        Password format: Grp2026!{username[:5]} (min 12 chars, e.g., "Grp2026!dozil")
-        Meets requirements: ≥12 chars, 1 uppercase, 1 lowercase, 1 digit, 1 special char
-        
+
         Returns:
             Dictionary with credentials (one per group) and admin_credentials
         """
         credentials = []
-        
+
         # One credential per group (shared account for all students in group)
         for group in stack_assignment.groups:
             # Sanitize group name for Unix username (lowercase, alphanumeric + dash/underscore)
             unix_username = sanitize_unix_username(group.group_name)
             credentials.append({
                 "username": unix_username,
-                "password": f"Grp2026!{unix_username[:5]}"
+                "password": generate_memorable_password(f"Grp{group.group_index}")
             })
-        
+
         # Teacher admin account
         unix_teacher = sanitize_unix_username(teacher.username)
         admin_credentials = {
             "username": unix_teacher,
-            "password": f"Tch2026!{unix_teacher[:5]}"
+            "password": generate_memorable_password("Teacher")
         }
-        
+
         return {
             "credentials": credentials,
             "admin_credentials": admin_credentials
@@ -247,7 +241,7 @@ class TemplateUserManagementService:
                     "email": student.email,
                     "first_name": student.first_name,
                     "last_name": student.last_name,
-                    "suggested_password": TemplateUserManagementService._generate_password(
+                    "suggested_password": generate_memorable_password(
                         f"{student.first_name}{student.last_name}"
                     )
                 }
@@ -271,26 +265,12 @@ class TemplateUserManagementService:
                     "email": teacher.email,
                     "first_name": teacher.first_name,
                     "last_name": teacher.last_name,
-                    "suggested_password": TemplateUserManagementService._generate_password(
+                    "suggested_password": generate_memorable_password(
                         f"{teacher.first_name}{teacher.last_name}"
                     )
                 }
             }
         ]
-    
-    @staticmethod
-    def _generate_password(prefix: str) -> str:
-        """Generate a secure password with prefix.
-        
-        Format: Prefix_Pw_2026!
-        
-        Args:
-            prefix: Prefix for the password (e.g., "TeacherDb", "Grp1Pg", "MaxMustermann")
-            
-        Returns:
-            Generated password string
-        """
-        return f"{prefix}Pw_2026!"
 
 
 def sanitize_unix_username(name: str) -> str:

--- a/src/services/template_user_management_service.py
+++ b/src/services/template_user_management_service.py
@@ -88,50 +88,54 @@ class TemplateUserManagementService:
         template_name: str,
         course_label: str,
         stack_assignment: StackAssignment,
-        teacher: TeacherInfo
+        teacher: TeacherInfo,
+        min_password_length: int = 12,
     ) -> dict[str, Any]:
         """Generate user_json for a SINGLE Heat stack.
-        
+
         This creates the structure that templates expect. Different templates
         get different applications based on their needs.
-        
+
         Args:
             template_name: Name of the template (e.g., "postgres-group-db")
             course_label: Name/label for the course (displayed in templates)
             stack_assignment: Single stack with its groups and students
             teacher: Teacher information
-            
+            min_password_length: Minimum length for generated passwords. Used to
+                satisfy per-deployment pwquality policies (Heat ``pw_min_length``).
+
         Returns:
             Dictionary matching the structure templates expect
         """
         # Normalize template name for comparison
         template_key = template_name.lower().replace("_", "-").replace(" ", "-")
-        
+
         # Route to template-specific generator
         # Currently only two template types: postgres or ubuntu
         if "postgres" in template_key:
             # PostgreSQL template: credentials in applications
             instance_data = {}
             applications = TemplateUserManagementService._generate_postgres_group_db_applications(
-                stack_assignment, teacher
+                stack_assignment, teacher, min_password_length
             )
         else:
             # Ubuntu/VM template: credentials in instance (default)
             instance_data = TemplateUserManagementService._generate_multistudent_ubuntu_instance(
-                stack_assignment, teacher
+                stack_assignment, teacher, min_password_length
             )
             applications = []
-        
+
         return {
             "course_label": course_label,
             "instance": instance_data,
             "applications": applications
         }
-    
+
     @staticmethod
     def _generate_postgres_group_db_applications(
         stack_assignment: StackAssignment,
-        teacher: TeacherInfo
+        teacher: TeacherInfo,
+        min_password_length: int = 12,
     ) -> list[dict[str, Any]]:
         """Generate applications for postgres-group-db template.
         
@@ -150,25 +154,25 @@ class TemplateUserManagementService:
                 "group": group_idx,
                 "database_name": f"db_g{group_idx:02d}",
                 "db_user": f"grp{group_idx}",
-                "password": generate_memorable_password(f"Grp{group_idx}Db")
+                "password": generate_memorable_password(f"Grp{group_idx}Db", min_length=min_password_length)
             })
 
             # pgAdmin credentials per group
             pgadmin_credentials.append({
                 "group": group_idx,
                 "email": f"grp{group_idx}@dozi.local",
-                "password": generate_memorable_password(f"Grp{group_idx}Pg")
+                "password": generate_memorable_password(f"Grp{group_idx}Pg", min_length=min_password_length)
             })
 
         # Teacher admin credentials
         postgres_admin = {
             "db_user": "teacher",
-            "password": generate_memorable_password("TeacherDb")
+            "password": generate_memorable_password("TeacherDb", min_length=min_password_length)
         }
 
         pgadmin_admin = {
             "email": "teacher@dozi.local",
-            "password": generate_memorable_password("TeacherPg")
+            "password": generate_memorable_password("TeacherPg", min_length=min_password_length)
         }
         
         return [
@@ -189,7 +193,8 @@ class TemplateUserManagementService:
     @staticmethod
     def _generate_multistudent_ubuntu_instance(
         stack_assignment: StackAssignment,
-        teacher: TeacherInfo
+        teacher: TeacherInfo,
+        min_password_length: int = 12,
     ) -> dict[str, Any]:
         """Generate instance data for multistudent-ubuntu template.
 
@@ -207,14 +212,14 @@ class TemplateUserManagementService:
             unix_username = sanitize_unix_username(group.group_name)
             credentials.append({
                 "username": unix_username,
-                "password": generate_memorable_password(f"Grp{group.group_index}")
+                "password": generate_memorable_password(f"Grp{group.group_index}", min_length=min_password_length)
             })
 
         # Teacher admin account
         unix_teacher = sanitize_unix_username(teacher.username)
         admin_credentials = {
             "username": unix_teacher,
-            "password": generate_memorable_password("Teacher")
+            "password": generate_memorable_password("Teacher", min_length=min_password_length)
         }
 
         return {

--- a/src/services/template_user_management_service.py
+++ b/src/services/template_user_management_service.py
@@ -156,7 +156,7 @@ class TemplateUserManagementService:
             # pgAdmin credentials per group
             pgadmin_credentials.append({
                 "group": group_idx,
-                "email": f"grp{group_idx}@{course_label_to_domain(stack_assignment.groups[0].group_name if stack_assignment.groups else 'course')}.de",
+                "email": f"grp{group_idx}@dozi.local",
                 "password": generate_memorable_password(f"Grp{group_idx}Pg")
             })
 
@@ -167,7 +167,7 @@ class TemplateUserManagementService:
         }
 
         pgadmin_admin = {
-            "email": f"teacher@{course_label_to_domain(teacher.username)}.de",
+            "email": "teacher@dozi.local",
             "password": generate_memorable_password("TeacherPg")
         }
         
@@ -309,17 +309,3 @@ def sanitize_unix_username(name: str) -> str:
     
     # Truncate to max 32 chars (Unix username limit)
     return username[:32]
-
-
-def course_label_to_domain(label: str) -> str:
-    """Convert course label to valid domain name.
-    
-    Args:
-        label: Course or username label
-        
-    Returns:
-        Sanitized domain-safe string
-    """
-    # Remove special chars, keep alphanumeric and dash
-    domain = ''.join(c if c.isalnum() or c == '-' else '' for c in label.lower())
-    return domain or "course"

--- a/src/tasks/deploy_tasks.py
+++ b/src/tasks/deploy_tasks.py
@@ -12,6 +12,7 @@ from src.repositories.deployment_log_repository import DeploymentLogRepository
 from src.repositories.openstack_project_repository import OpenstackProjectRepository
 from src.services.template_version_file_service import TemplateVersionFileService
 from src.services.deployment_log_service import DeploymentLogService
+from src.services.deployment_credential_service import DeploymentCredentialService
 from src.services.openstack_heat_service import HeatStackService
 
 logger = logging.getLogger(__name__)
@@ -236,13 +237,11 @@ def deploy_stack(self, deployment_id: str) -> dict:
                     teacher=teacher
                 )
 
-                print(f"user_json_data: {user_json_data}")
                 # Base64-encode JSON to avoid YAML parsing issues when inserted via str_replace
                 # Cloud-init will decode it back to JSON
                 import base64
                 user_json_string = json.dumps(user_json_data, ensure_ascii=False)
                 user_json_b64 = base64.b64encode(user_json_string.encode('utf-8')).decode('ascii')
-                print(f"user_json_b64: {user_json_b64}")
                 logger.debug(f"Generated user_json for stack {idx}: {len(user_json_string)} chars, {len(user_json_b64)} chars base64")
                 
                 # Merge base parameters with stack-specific user_json (base64-encoded)
@@ -302,6 +301,26 @@ def deploy_stack(self, deployment_id: str) -> dict:
                         "status": stack_result['status'],
                     }
                 )
+
+                try:
+                    DeploymentCredentialService(db).persist_credentials_for_stack(
+                        deployment_id=deployment_id,
+                        stack_name=stack_name,
+                        openstack_stack_id=stack_id,
+                        user_json=user_json_data,
+                    )
+                except Exception as cred_error:
+                    # Best-effort: a failure to record credentials must not roll back the
+                    # stack itself. Surface the error in the deployment log so the lecturer
+                    # knows credentials need to be retrieved another way.
+                    logger.error(f"Failed to persist credentials for stack {idx}: {cred_error}", exc_info=True)
+                    log_service.log(
+                        deployment_id=deployment_id,
+                        event_type=DeploymentLogEventType.FAILED,
+                        message=f"Stack {idx} created but credential persistence failed",
+                        level=DeploymentLogLevel.ERROR,
+                        details={"stack_index": idx, "error": str(cred_error)}
+                    )
                 
             except Exception as stack_error:
                 error_msg = f"Failed to create Heat stack {idx}: {str(stack_error)}"

--- a/src/tasks/deploy_tasks.py
+++ b/src/tasks/deploy_tasks.py
@@ -230,11 +230,16 @@ def deploy_stack(self, deployment_id: str) -> dict:
                 teacher = TeacherInfo(**teacher_info)
                 
                 # Generate user_json for THIS specific stack
+                # Pass pw_min_length from heat_parameters so generated passwords
+                # satisfy the per-deployment pwquality policy that cloud-init enforces
+                # via PAM (chpasswd would otherwise reject overly short passwords).
+                min_pw = int(base_heat_parameters.get("pw_min_length", 12))
                 user_json_data = TemplateUserManagementService.generate_user_json_for_stack(
                     template_name=template_name,
                     course_label=deployment.name,
                     stack_assignment=stack_assignment,
-                    teacher=teacher
+                    teacher=teacher,
+                    min_password_length=min_pw,
                 )
 
                 # Base64-encode JSON to avoid YAML parsing issues when inserted via str_replace

--- a/src/utils/secure_password.py
+++ b/src/utils/secure_password.py
@@ -1,0 +1,58 @@
+"""Memorable-but-random password generator for deployment user accounts.
+
+The generated passwords look like ``Grp1-azure-tiger-42`` or ``Teacher-mango-cobalt-91``:
+a caller-supplied prefix that students recognize, followed by a random adjective,
+noun, and two-digit number drawn with :mod:`secrets`.
+
+Entropy is roughly ``len(_ADJECTIVES) * len(_NOUNS) * 100`` distinct suffixes per
+prefix, which is plenty to defeat guessing within a class while staying typeable
+and easy to dictate aloud.
+"""
+from __future__ import annotations
+
+import secrets
+
+
+_ADJECTIVES: tuple[str, ...] = (
+    "azure", "amber", "brave", "calm", "clever", "cobalt", "coral", "crisp",
+    "daring", "eager", "fancy", "fierce", "gentle", "happy", "icy", "jolly",
+    "keen", "lively", "lucky", "mellow", "merry", "mighty", "nimble", "noble",
+    "olive", "plucky", "proud", "quick", "quiet", "rapid", "royal", "rusty",
+    "sage", "scarlet", "silver", "sleek", "snappy", "sturdy", "sunny", "swift",
+    "tidy", "tough", "vivid", "warm", "wise", "witty", "young", "zesty",
+)
+
+_NOUNS: tuple[str, ...] = (
+    "anchor", "arrow", "badger", "beacon", "bison", "canyon", "cedar", "comet",
+    "copper", "delta", "ember", "falcon", "flint", "forest", "garnet", "gecko",
+    "harbor", "heron", "ibex", "iris", "jaguar", "juniper", "kestrel", "lagoon",
+    "lantern", "lynx", "maple", "marble", "meadow", "moose", "narwhal", "nebula",
+    "ocelot", "onyx", "panda", "pebble", "pine", "quartz", "raven", "ridge",
+    "river", "saffron", "spruce", "summit", "tiger", "topaz", "valley", "willow",
+)
+
+
+def _random_suffix() -> str:
+    """Return a memorable random suffix like ``azure-tiger-42``."""
+    adjective = secrets.choice(_ADJECTIVES)
+    noun = secrets.choice(_NOUNS)
+    number = secrets.randbelow(100)
+    return f"{adjective}-{noun}-{number:02d}"
+
+
+def generate_memorable_password(prefix: str) -> str:
+    """Generate a memorable but cryptographically random password.
+
+    The result is ``{prefix}-{adjective}-{noun}-{NN}``. The adjective and noun
+    come from short curated wordlists; the trailing number is two random digits.
+
+    Args:
+        prefix: Stable, human-readable prefix that ties the password to its
+            owner (e.g. ``"Grp1"``, ``"Teacher"``). Not validated; the caller is
+            responsible for keeping it short and printable.
+
+    Returns:
+        A password string guaranteed to be unique with high probability across
+        deployments and impossible to guess from the prefix alone.
+    """
+    return f"{prefix}-{_random_suffix()}"

--- a/src/utils/secure_password.py
+++ b/src/utils/secure_password.py
@@ -40,19 +40,37 @@ def _random_suffix() -> str:
     return f"{adjective}-{noun}-{number:02d}"
 
 
-def generate_memorable_password(prefix: str) -> str:
+def generate_memorable_password(prefix: str, *, min_length: int = 12) -> str:
     """Generate a memorable but cryptographically random password.
 
-    The result is ``{prefix}-{adjective}-{noun}-{NN}``. The adjective and noun
-    come from short curated wordlists; the trailing number is two random digits.
+    The base format is ``{prefix}-{adjective}-{noun}-{NN}``. If the result is
+    shorter than ``min_length``, additional ``-{noun}`` tokens are inserted
+    before the trailing 2-digit number until the threshold is met. This keeps
+    the recognizable prefix at the start and the numeric token at the end,
+    while letting the password grow long enough for strict pwquality policies
+    (e.g. ``pw_min_length=30`` configured per Heat parameter).
+
+    The adjective and noun come from short curated wordlists; the trailing
+    number is two random digits.
 
     Args:
         prefix: Stable, human-readable prefix that ties the password to its
             owner (e.g. ``"Grp1"``, ``"Teacher"``). Not validated; the caller is
             responsible for keeping it short and printable.
+        min_length: Minimum length of the generated password. The result is
+            guaranteed to be at least this many characters; in practice it may
+            be a few characters longer because tokens are inserted whole.
 
     Returns:
         A password string guaranteed to be unique with high probability across
         deployments and impossible to guess from the prefix alone.
     """
-    return f"{prefix}-{_random_suffix()}"
+    adjective = secrets.choice(_ADJECTIVES)
+    noun = secrets.choice(_NOUNS)
+    number = f"{secrets.randbelow(100):02d}"
+
+    parts: list[str] = [prefix, adjective, noun]
+    while len("-".join(parts)) + 1 + len(number) < min_length:
+        parts.append(secrets.choice(_NOUNS))
+    parts.append(number)
+    return "-".join(parts)

--- a/tests/api/test_deployment_routes.py
+++ b/tests/api/test_deployment_routes.py
@@ -470,12 +470,12 @@ def test_get_deployment_as_owner(mock_repo_class):
     # Mock instances
     mock_instance = MagicMock()
     mock_instance.id = "instance-123"
-    mock_instance.instance_name = "vm-1"
-    mock_instance.openstack_instance_id = "os-instance-456"
+    mock_instance.vm_name = "vm-1"
+    mock_instance.openstack_server_id = "os-instance-456"
     mock_instance.status = MagicMock()
     mock_instance.status.value = "ACTIVE"
     mock_instance.ip_address = "192.168.1.10"
-    mock_instance.access_urls_json = '{"ssh": "ssh://192.168.1.10"}'
+    mock_instance.access_methods = []
     mock_instance.created_at = "2024-11-27T10:00:00"
     mock_instance.updated_at = "2024-11-27T10:00:00"
     mock_deployment.instances = [mock_instance]

--- a/tests/unit/test_deployment_credential_service.py
+++ b/tests/unit/test_deployment_credential_service.py
@@ -1,0 +1,68 @@
+"""Tests for DeploymentCredentialService._extract_access_entries."""
+from src.models.deployment_instance_access import AccessType
+from src.services.deployment_credential_service import DeploymentCredentialService
+
+
+def test_extracts_ubuntu_credentials():
+    user_json = {
+        "course_label": "x",
+        "instance": {
+            "credentials": [
+                {"username": "gruppe-1", "password": "Grp1-azure-tiger-42"},
+                {"username": "gruppe-2", "password": "Grp2-warm-bison-08"},
+            ],
+            "admin_credentials": {"username": "prof-berg", "password": "Teacher-witty-cedar-58"},
+        },
+        "applications": [],
+    }
+
+    rows = DeploymentCredentialService._extract_access_entries(user_json)
+
+    assert len(rows) == 3
+    assert all(r["access_type"] == AccessType.SSH for r in rows)
+    assert rows[2]["username"] == "prof-berg"
+
+
+def test_extracts_postgres_credentials():
+    user_json = {
+        "course_label": "x",
+        "instance": {},
+        "applications": [
+            {
+                "name": "postgres",
+                "version": "1.3.2",
+                "credentials": [
+                    {"group": 1, "db_user": "grp1", "password": "Grp1Db-azure-tiger-42"},
+                ],
+                "admin_credentials": {"db_user": "teacher", "password": "TeacherDb-mango-cobalt-91"},
+            },
+            {
+                "name": "pgadmin",
+                "version": "4.3.2",
+                "credentials": [
+                    {"group": 1, "email": "grp1@x.de", "password": "Grp1Pg-warm-bison-08"},
+                ],
+                "admin_credentials": {"email": "teacher@x.de", "password": "TeacherPg-witty-cedar-58"},
+            },
+        ],
+    }
+
+    rows = DeploymentCredentialService._extract_access_entries(user_json)
+
+    assert len(rows) == 4
+    assert all(r["access_type"] == AccessType.DATABASE for r in rows)
+    # Postgres credentials use db_user; pgAdmin uses email when db_user absent.
+    assert rows[0]["username"] == "grp1"
+    assert rows[1]["username"] == "teacher"
+    assert rows[2]["username"] == "grp1@x.de"
+    assert rows[3]["username"] == "teacher@x.de"
+
+
+def test_skips_entries_without_password():
+    user_json = {
+        "instance": {
+            "credentials": [{"username": "ghost", "password": None}],
+        },
+        "applications": [],
+    }
+    assert DeploymentCredentialService._extract_access_entries(user_json) == []

--- a/tests/unit/test_secure_password.py
+++ b/tests/unit/test_secure_password.py
@@ -6,7 +6,9 @@ from src.utils.secure_password import generate_memorable_password
 
 def test_generated_password_format():
     pw = generate_memorable_password("Grp1")
-    assert re.match(r"^Grp1-[a-z]+-[a-z]+-\d{2}$", pw), pw
+    # Default min_length=12 may add extra noun tokens, so the format is
+    # "Grp1" followed by one or more "-word" tokens, ending in "-NN".
+    assert re.match(r"^Grp1(-[a-z]+)+-\d{2}$", pw), pw
 
 
 def test_generated_password_uses_prefix_verbatim():
@@ -27,3 +29,27 @@ def test_generated_passwords_differ_for_different_prefixes():
     assert a != b
     assert a.startswith("Grp1-")
     assert b.startswith("Grp2-")
+
+
+def test_min_length_is_respected_for_strict_pwquality_policies():
+    """When the deployment configures pw_min_length=30, every generated password
+    must be at least 30 characters — otherwise cloud-init's chpasswd will reject
+    them and the user accounts will never be created."""
+    for _ in range(100):
+        pw = generate_memorable_password("Grp1", min_length=30)
+        assert len(pw) >= 30, f"got {len(pw)}-char password: {pw!r}"
+
+
+def test_default_min_length_still_satisfies_default_policy():
+    """The Heat default pw_min_length is 12, so default-call output must be >= 12."""
+    for _ in range(100):
+        pw = generate_memorable_password("Grp1")
+        assert len(pw) >= 12, f"got {len(pw)}-char password: {pw!r}"
+
+
+def test_min_length_extension_keeps_numeric_suffix_at_end():
+    """Sanity check: even after extension with extra noun tokens, the trailing
+    2-digit number stays at the end (so the format remains visually consistent)."""
+    pw = generate_memorable_password("Grp1", min_length=40)
+    assert re.match(r"^Grp1(-[a-z]+){2,}-\d{2}$", pw), pw
+

--- a/tests/unit/test_secure_password.py
+++ b/tests/unit/test_secure_password.py
@@ -1,0 +1,29 @@
+"""Tests for the memorable password generator."""
+import re
+
+from src.utils.secure_password import generate_memorable_password
+
+
+def test_generated_password_format():
+    pw = generate_memorable_password("Grp1")
+    assert re.match(r"^Grp1-[a-z]+-[a-z]+-\d{2}$", pw), pw
+
+
+def test_generated_password_uses_prefix_verbatim():
+    pw = generate_memorable_password("TeacherDb")
+    assert pw.startswith("TeacherDb-")
+
+
+def test_generated_passwords_are_random_enough():
+    """Same prefix should produce mostly distinct outputs across many calls."""
+    seen = {generate_memorable_password("Grp1") for _ in range(100)}
+    # 50 * 50 * 100 = 250k combinations, so 100 draws should virtually never collide.
+    assert len(seen) >= 95, f"only {len(seen)} unique values in 100 draws"
+
+
+def test_generated_passwords_differ_for_different_prefixes():
+    a = generate_memorable_password("Grp1")
+    b = generate_memorable_password("Grp2")
+    assert a != b
+    assert a.startswith("Grp1-")
+    assert b.startswith("Grp2-")

--- a/tests/unit/test_template_user_management.py
+++ b/tests/unit/test_template_user_management.py
@@ -94,3 +94,20 @@ def test_postgres_passwords_are_random_per_call():
     first_pg = [c["password"] for c in first["applications"][0]["credentials"]]
     second_pg = [c["password"] for c in second["applications"][0]["credentials"]]
     assert first_pg != second_pg
+
+
+def test_pgadmin_emails_use_fixed_dozi_local_host():
+    """All pgAdmin emails must end with @dozi.local — no leaking of group/teacher names into the email host."""
+    stack = _make_stack(group_count=2)
+    teacher = _make_teacher()
+
+    payload = TemplateUserManagementService.generate_user_json_for_stack(
+        template_name="postgres-group-db",
+        course_label="course-x",
+        stack_assignment=stack,
+        teacher=teacher,
+    )
+    pgadmin_app = next(app for app in payload["applications"] if app["name"] == "pgadmin")
+    for cred in pgadmin_app["credentials"]:
+        assert cred["email"].endswith("@dozi.local"), cred["email"]
+    assert pgadmin_app["admin_credentials"]["email"] == "teacher@dozi.local"

--- a/tests/unit/test_template_user_management.py
+++ b/tests/unit/test_template_user_management.py
@@ -1,0 +1,96 @@
+"""Tests for randomized credential generation in the user-management service."""
+from src.schemas.deployment import GroupInfo, StackAssignment, StudentInfo, TeacherInfo
+from src.services.template_user_management_service import TemplateUserManagementService
+
+
+def _make_stack(group_count: int = 2) -> StackAssignment:
+    return StackAssignment(
+        stack_index=1,
+        groups=[
+            GroupInfo(
+                group_name=f"gruppe-{i}",
+                group_index=i,
+                students=[
+                    StudentInfo(
+                        id=f"kc-{i}-1",
+                        username=f"student{i}1",
+                        email=f"s{i}1@example.de",
+                        first_name=f"S{i}1",
+                        last_name="Doe",
+                    )
+                ],
+            )
+            for i in range(1, group_count + 1)
+        ],
+    )
+
+
+def _make_teacher() -> TeacherInfo:
+    return TeacherInfo(
+        id="kc-teacher",
+        username="prof.berg",
+        email="berg@example.de",
+        first_name="Eva",
+        last_name="Berg",
+    )
+
+
+def test_ubuntu_passwords_are_random_per_call():
+    """Two calls with identical input must produce different group passwords."""
+    stack = _make_stack()
+    teacher = _make_teacher()
+
+    first = TemplateUserManagementService.generate_user_json_for_stack(
+        template_name="multistudent-ubuntu",
+        course_label="course-x",
+        stack_assignment=stack,
+        teacher=teacher,
+    )
+    second = TemplateUserManagementService.generate_user_json_for_stack(
+        template_name="multistudent-ubuntu",
+        course_label="course-x",
+        stack_assignment=stack,
+        teacher=teacher,
+    )
+
+    first_pwds = [c["password"] for c in first["instance"]["credentials"]]
+    second_pwds = [c["password"] for c in second["instance"]["credentials"]]
+    assert first_pwds != second_pwds
+    assert first["instance"]["admin_credentials"]["password"] != second["instance"]["admin_credentials"]["password"]
+
+
+def test_ubuntu_password_uses_group_prefix():
+    """The new prefix uses the stable group_index, not the Unix-sanitized name."""
+    stack = _make_stack(group_count=1)
+    teacher = _make_teacher()
+
+    payload = TemplateUserManagementService.generate_user_json_for_stack(
+        template_name="multistudent-ubuntu",
+        course_label="course-x",
+        stack_assignment=stack,
+        teacher=teacher,
+    )
+    assert payload["instance"]["credentials"][0]["password"].startswith("Grp1-")
+    assert payload["instance"]["admin_credentials"]["password"].startswith("Teacher-")
+
+
+def test_postgres_passwords_are_random_per_call():
+    stack = _make_stack()
+    teacher = _make_teacher()
+
+    first = TemplateUserManagementService.generate_user_json_for_stack(
+        template_name="postgres-group-db",
+        course_label="course-x",
+        stack_assignment=stack,
+        teacher=teacher,
+    )
+    second = TemplateUserManagementService.generate_user_json_for_stack(
+        template_name="postgres-group-db",
+        course_label="course-x",
+        stack_assignment=stack,
+        teacher=teacher,
+    )
+
+    first_pg = [c["password"] for c in first["applications"][0]["credentials"]]
+    second_pg = [c["password"] for c in second["applications"][0]["credentials"]]
+    assert first_pg != second_pg


### PR DESCRIPTION
## Description

Fixes a 500 on `GET /api/v1/deployments/{id}` when instances are persisted, adds a new credentials endpoint for the frontend team, plus several improvements bundled from a parallel session (password generator robustness, pgAdmin email domain fix, Bruno test files, tests).

### 1. Deployment detail endpoint — `AttributeError` → 500

The response builder in `src/api/deployments.py` (`get_deployment`) iterated `deployment.instances` and accessed three attributes that do not exist on the `DeploymentInstance` model:

| Old code                         | Real model field                                    |
| -------------------------------- | --------------------------------------------------- |
| `instance.instance_name`         | `vm_name`                                           |
| `instance.openstack_instance_id` | `openstack_server_id`                               |
| `instance.access_urls_json`      | does not exist — access lives in `instance.access_methods` (1:n to `DeploymentInstanceAccess`) |

The bug stayed dormant on the deployed instance because `deployment_instances` is empty there (verified on prod: `SELECT COUNT(*) FROM deployment_instances` → 0). Locally, against the real OpenStack at the university, instance rows actually get persisted, so the comprehension ran, hit the missing attribute, and returned 500. The frontend then rendered the misleading "Deployment nicht gefunden" message because `Promise.all` in `DeploymentDetailsPage.tsx` has no `.catch` for `getDeployment` — any 5xx falls through to the generic catch and `setDeploymentData` is never called.

Fix: read the actual model fields and serialize `access_methods` as a list of objects (`access_type`, `connection_url`, `username`, `port`, `is_active`). Encrypted secrets (`password`, `ssh_private_key`) are intentionally excluded — they belong to the new credentials endpoint below. Response keys (`instance_name`, `openstack_instance_id`, `access_urls`) are preserved, so the change is non-breaking for existing consumers.

### 2. New `GET /api/v1/deployments/{id}/credentials` endpoint

For the frontend team to surface SSH/DB/Web credentials without sending them on every detail-page load.

- **Authorization**: owner-lecturer of the deployment or admin only (403 otherwise).
- **Returns** per instance: `instance_id`, `vm_name`, `openstack_stack_id`, plus an `accesses` array with `access_type`, `username`, `password` (decrypted on read via the `EncryptedString` TypeDecorator), `connection_url`, `port`.
- **Schemas**: `DeploymentCredentialsResponse` → `DeploymentInstanceCredentials` → `DeploymentCredentialEntry` (`src/schemas/deployment.py`).
- Passwords stay Fernet-encrypted at rest; decryption only happens inside this endpoint, behind the auth check.

### 3. pgAdmin email domain — wrong values via course-label conversion

`template_user_management_service.py` was building the pgAdmin email through `course_label_to_domain(group_name)`, which produced nonsense like `grp1@gruppe1.de`. Replaced with a fixed `@dozi.local` domain and removed the now-dead helper.

### 4. Password generator vs. cloud-init pwquality

Triggered by a live test with `pw_min_length=30`: cloud-init aborted with `BAD PASSWORD: shorter than 30 characters`, the user was never created, SSH never came up.

- `secure_password.py`: `generate_memorable_password(prefix, *, min_length=12)` now appends extra word tokens until `min_length` is satisfied.
- `template_user_management_service.py`: `min_password_length` is threaded through all 6 generator call sites.
- `deploy_tasks.py`: reads `pw_min_length` from `heat_parameters` and passes it down.

The other UI knobs (`force_password_change`, `workdir`, the three `pw_require_*` toggles) don't touch generator output — they're either VM-side (`chage`, `workdir`) or satisfied by construction (uppercase via prefix, digits via `NN` suffix, `-` as special character).

### 5. Bruno files for local testing

- `Create Deployment ubuntu.bru`: added missing Heat params (`volume_size`, `network`, `external_network`), replaced a broken PostgreSQL doc block.
- `Create Deployment.bru`: cleaned up a broken doc block.

### 6. Tests

3 new tests (`min_length=30`/`40`/default), 1 adjusted (regex now allows multiple appended words), 1 unrelated test mock fixed (`vm_name` schema drift). Suite: **162 passed, 0 failed**.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have added/updated unit tests
- [ ] I have updated the documentation (if applicable)
- [x] I have verified my changes locally
