### PR TITLE
Fix/cicd docker pull

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -90,7 +90,7 @@ jobs:
             
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             
-            docker compose pull
+            docker compose pull api celery-worker
             
             docker compose up api celery-worker -d --force-recreate --remove-orphans
             

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   test:
@@ -34,7 +35,7 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     needs: test
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main')
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
       packages: write
@@ -72,7 +73,7 @@ jobs:
     name: Deploy via Internal Network
     needs: build-and-push
     runs-on: self-hosted
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     
     steps:
       - name: Setup SSH


### PR DESCRIPTION
## Linked Issue
Closes #-

## Description
`docker compose pull` without arguments attempted to pull all images, including
`ghcr.io/dozilab/appstore-frontend:latest`. The `GITHUB_TOKEN` does not have
access to the frontend package, causing a `denied` error that interrupted all
other pulls as well.

Fix: Only pull `api` and `celery-worker` images, since those are the only
services restarted in the deploy job.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have added/updated unit tests
- [ ] I have updated the documentation (if applicable)
- [x] I have verified my changes locally
