### PR TITLE
Feat/integrate ansible

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,15 +14,9 @@ DB_NAME=dozilab
 REDIS_URL=redis://localhost:6379/0
 
 # Keycloak Authentication
-# Base URL of your Keycloak server
 KEYCLOAK_URL=http://localhost:8080
-# Keycloak realm name
 KEYCLOAK_REALM=appstore
-
-# Client ID (must match frontend client in Keycloak)
 KEYCLOAK_CLIENT_ID=appstore-backend
-
-# JWKS cache TTL in seconds (default: 3600 = 1 hour)
 KEYCLOAK_JWKS_CACHE_TTL=3600
 
 # JWT Validation (Keycloak uses RS256)
@@ -30,6 +24,15 @@ JWT_ALGORITHM=RS256
 
 # Encryption (generate with: python3 -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())")
 ENCRYPTION_KEY=your-generated-fernet-key-here
+# Ansible SSH Key
+# Pfad zur privaten Key-Datei (chmod 600, nie ins Repository einchecken!)
+# Der Public Key muss einmalig in OpenStack registriert werden:
+#   ssh-keygen -t ed25519 -f dozilab_ansible -C "dozilab-ansible" -N ""
+#   openstack keypair create --public-key dozilab_ansible.pub dozilab-ansible-key
+# Lokal:      ANSIBLE_SSH_KEY_PATH=~/.ssh/dozilab_ansible
+# Produktion: ANSIBLE_SSH_KEY_PATH=/secrets/dozilab_ansible.pem
+ANSIBLE_SSH_KEY_PATH=~/.ssh/dozilab_ansible
+ANSIBLE_SSH_KEY_NAME=dozilab-ansible-key
 
 # Grafana
 GRAFANA_ADMIN_USER=admin

--- a/.env.example
+++ b/.env.example
@@ -24,14 +24,25 @@ JWT_ALGORITHM=RS256
 
 # Encryption (generate with: python3 -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())")
 ENCRYPTION_KEY=your-generated-fernet-key-here
-# Ansible SSH Key
-# Pfad zur privaten Key-Datei (chmod 600, nie ins Repository einchecken!)
-# Der Public Key muss einmalig in OpenStack registriert werden:
-#   ssh-keygen -t ed25519 -f dozilab_ansible -C "dozilab-ansible" -N ""
-#   openstack keypair create --public-key dozilab_ansible.pub dozilab-ansible-key
-# Lokal:      ANSIBLE_SSH_KEY_PATH=~/.ssh/dozilab_ansible
-# Produktion: ANSIBLE_SSH_KEY_PATH=/secrets/dozilab_ansible.pem
-ANSIBLE_SSH_KEY_PATH=~/.ssh/dozilab_ansible
+
+# ------------------------------------------------------------------------------
+# Ansible SSH Key (one-time server setup required)
+#
+# 1. Generate the key once on the server:
+#      ssh-keygen -t ed25519 -f ~/.ssh/dozilab_ansible -C "dozilab-ansible" -N ""
+#      chmod 600 ~/.ssh/dozilab_ansible
+#
+# 2. Set the path here:
+#      Local:      ANSIBLE_SSH_KEY_PATH=~/.ssh/dozilab_ansible
+#      Production: ANSIBLE_SSH_KEY_PATH=/run/secrets/dozilab_ansible
+#
+# 3. Registering the public key in OpenStack is NOT required manually —
+#    it happens automatically when a lecturer registers their OpenStack project
+#    in the AppStore (via AnsibleKeypairService.ensure_keypair).
+#
+# ANSIBLE_SSH_KEY_NAME must match the keypair name in OpenStack.
+# ------------------------------------------------------------------------------
+ANSIBLE_SSH_KEY_PATH=/run/secrets/dozilab_ansible
 ANSIBLE_SSH_KEY_NAME=dozilab-ansible-key
 
 # Grafana

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,11 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-# Install system dependencies
+# Install system dependencies + Ansible
 RUN apt-get update && apt-get install -y \
     gcc \
+    ansible \
+    openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy project files

--- a/alembic/versions/add_unique_constraint_template_version_file_path.py
+++ b/alembic/versions/add_unique_constraint_template_version_file_path.py
@@ -1,0 +1,38 @@
+"""add unique constraint on template_version_files(template_version_id, file_path)
+
+Revision ID: b3f9c1d2e4a5
+Revises: 66e4c3287d2d
+Create Date: 2026-06-01
+
+"""
+from alembic import op
+
+revision = 'b3f9c1d2e4a5'
+down_revision = '66e4c3287d2d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Remove duplicate rows first — keep the oldest entry per (template_version_id, file_path)
+    op.execute("""
+        DELETE FROM template_version_files
+        WHERE id NOT IN (
+            SELECT DISTINCT ON (template_version_id, file_path) id
+            FROM template_version_files
+            ORDER BY template_version_id, file_path, created_at ASC
+        )
+    """)
+    op.create_unique_constraint(
+        'uq_template_version_file_path',
+        'template_version_files',
+        ['template_version_id', 'file_path']
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        'uq_template_version_file_path',
+        'template_version_files',
+        type_='unique'
+    )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,8 +41,12 @@ services:
       - KEYCLOAK_URL=${KEYCLOAK_URL}
       - KEYCLOAK_REALM=${KEYCLOAK_REALM}
       - KEYCLOAK_CLIENT_ID=${KEYCLOAK_CLIENT_ID}
-      - KEYCLOAK_JWKS_CACHE_TTL=${KEYCLOAK_JWKS_CACHE_TTL:-3600}
+      - KEYCLOAK_JWKS_CACHE_TTL=${KEYCLOAK_JWKS_CACHE_TTl:-3600}
       - ENCRYPTION_KEY=${ENCRYPTION_KEY}
+      - ANSIBLE_SSH_KEY_PATH=/run/secrets/dozilab_ansible.pem
+      - ANSIBLE_SSH_KEY_NAME=${ANSIBLE_SSH_KEY_NAME:-dozilab-ansible-key}
+    volumes:
+      - ${ANSIBLE_SSH_KEY_PATH}:/run/secrets/dozilab_ansible.pem:ro
     depends_on:
       db:
         condition: service_healthy
@@ -67,6 +71,10 @@ services:
       - KEYCLOAK_CLIENT_ID=${KEYCLOAK_CLIENT_ID}
       - KEYCLOAK_JWKS_CACHE_TTL=${KEYCLOAK_JWKS_CACHE_TTL:-3600}
       - ENCRYPTION_KEY=${ENCRYPTION_KEY}
+      - ANSIBLE_SSH_KEY_PATH=/run/secrets/dozilab_ansible.pem
+      - ANSIBLE_SSH_KEY_NAME=${ANSIBLE_SSH_KEY_NAME:-dozilab-ansible-key}
+    volumes:
+      - ${ANSIBLE_SSH_KEY_PATH}:/run/secrets/dozilab_ansible.pem:ro
     depends_on:
       redis:
         condition: service_healthy

--- a/scripts/upload_template.py
+++ b/scripts/upload_template.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""
+Upload alle Dateien eines Templates in die DB via API.
+
+Usage:
+  python upload_template.py <template_version_id> <token>
+
+Beispiel:
+  python upload_template.py 48fc1abb-495f-411a-b221-819e1242be38 eyJhbGc...
+"""
+import sys
+import os
+import httpx
+from pathlib import Path
+
+BASE_URL = "http://127.0.0.1:8000"
+TEMPLATE_DIR = Path(__file__).parent.parent / "appstore-apps" / "ansible_multiuser"
+
+# Mapping: (ordner, dateiname) → (file_type, is_primary, order)
+FILE_MAP = {
+    "app.yaml":                           ("APP_MANIFEST",      False, 0),
+    "heat/main.yaml":                     ("HEAT_TEMPLATE",     True,  0),
+    "playbooks/main.yml":                 ("ANSIBLE_PLAYBOOK",  False, 1),
+    "scripts/check_student_setup.sh":     ("SHELL_SCRIPT",      False, 1),
+    "scripts/reset_password.sh":          ("SHELL_SCRIPT",      False, 2),
+    "files/bashrc":                       ("CONFIG_FILE",       False, 1),
+    "files/motd":                         ("CONFIG_FILE",       False, 2),
+}
+
+
+def upload(template_version_id: str, token: str):
+    headers = {"Authorization": f"Bearer {token}"}
+
+    # Fetch existing files to detect duplicates
+    existing = {}
+    resp = httpx.get(
+        f"{BASE_URL}/api/v1/template-versions/{template_version_id}/files",
+        headers=headers,
+        timeout=30,
+    )
+    if resp.status_code == 200:
+        for f in resp.json().get("data", []):
+            key = f["file_path"]
+            # Keep only the oldest entry per path (avoid duplicate keys)
+            if key not in existing:
+                existing[key] = f["id"]
+
+    for rel_path, (file_type, is_primary, order) in FILE_MAP.items():
+        full_path = TEMPLATE_DIR / rel_path
+        if not full_path.exists():
+            print(f"  ⚠ Nicht gefunden: {full_path} — übersprungen")
+            continue
+
+        content = full_path.read_text(encoding="utf-8")
+        payload = {
+            "template_version_id": template_version_id,
+            "file_name":           full_path.name,
+            "file_type":           file_type,
+            "file_path":           rel_path,
+            "content":             content,
+            "file_size":           len(content.encode()),
+            "is_primary":          is_primary,
+            "order":               order,
+        }
+
+        if rel_path in existing:
+            # Update existing file
+            file_id = existing[rel_path]
+            resp = httpx.put(
+                f"{BASE_URL}/api/v1/template-version-files/{file_id}",
+                json=payload,
+                headers=headers,
+                timeout=30,
+            )
+            action = "updated"
+        else:
+            # Create new file
+            resp = httpx.post(
+                f"{BASE_URL}/api/v1/template-version-files",
+                json=payload,
+                headers=headers,
+                timeout=30,
+            )
+            action = "created"
+
+        if resp.status_code in (200, 201):
+            print(f"  ✓ {rel_path} ({file_type}) [{action}]")
+        else:
+            print(f"  ✗ {rel_path} → {resp.status_code}: {resp.text[:200]}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print(__doc__)
+        sys.exit(1)
+
+    version_id, token = sys.argv[1], sys.argv[2]
+    print(f"Uploading to template version: {version_id}")
+    upload(version_id, token)
+    print("Fertig.")

--- a/src/_common/playbooks/base.yml
+++ b/src/_common/playbooks/base.yml
@@ -1,0 +1,50 @@
+---
+# DoziLab Base Playbook — läuft automatisch bei jedem Template-Deployment.
+#
+# Variablen: teacher.linux.{username, password}
+#            ssh_allow_users[]  ← Backend berechnet aus students mit ssh_access: true
+
+- name: DoziLab Base Setup
+  hosts: all
+  remote_user: ubuntu
+  become: true
+
+  tasks:
+
+    # --- Lehrer Linux-Account ---
+
+    - name: Lehrer Linux-Account erstellen
+      user:
+        name:        "{{ teacher.linux.username }}"
+        shell:       /bin/bash
+        create_home: true
+        groups:      sudo
+        append:      true
+        state:       present
+
+    - name: Lehrer Linux-Passwort setzen
+      shell: "echo '{{ teacher.linux.username }}:{{ teacher.linux.password }}' | chpasswd"
+      no_log: true
+
+    # --- SSH konfigurieren ---
+
+    - name: SSH Passwort-Login aktivieren
+      copy:
+        dest: /etc/ssh/sshd_config.d/99-dozilab.conf
+        mode: "0644"
+        content: |
+          PasswordAuthentication yes
+          KbdInteractiveAuthentication yes
+          UsePAM yes
+          PermitRootLogin no
+
+    - name: SSH auf erlaubte Benutzer einschränken
+      copy:
+        dest: /etc/ssh/sshd_config.d/98-dozilab-allowusers.conf
+        mode: "0644"
+        content: "AllowUsers ubuntu {{ teacher.linux.username }}{{ ' ' + ssh_allow_users | join(' ') if ssh_allow_users | default([]) | length > 0 else '' }}\n"
+
+    - name: SSH neu starten
+      service:
+        name:  ssh
+        state: restarted

--- a/src/_common/playbooks/base.yml
+++ b/src/_common/playbooks/base.yml
@@ -1,8 +1,5 @@
 ---
 # DoziLab Base Playbook — läuft automatisch bei jedem Template-Deployment.
-#
-# Variablen: teacher.linux.{username, password}
-#            ssh_allow_users[]  ← Backend berechnet aus students mit ssh_access: true
 
 - name: DoziLab Base Setup
   hosts: all

--- a/src/api/deployments.py
+++ b/src/api/deployments.py
@@ -401,7 +401,7 @@ async def stream_deployment_logs(
 
                 # Fetch all logs and emit unseen ones
                 logs = log_service.get_deployment_logs(deployment_id)
-                new_logs = [l for l in logs if str(l.id) not in seen_ids]
+                new_logs = [log for log in logs if str(log.id) not in seen_ids]
                 for log in new_logs:
                     seen_ids.add(str(log.id))
                     payload = json.dumps({

--- a/src/api/deployments.py
+++ b/src/api/deployments.py
@@ -1,7 +1,9 @@
 """Deployment API endpoints."""
 from uuid import UUID
+import asyncio
 import json
 from fastapi import APIRouter, status, Query, Depends, HTTPException
+from fastapi.responses import StreamingResponse
 from src.core.exceptions import NotFoundException
 from src.models.user import UserRole, User
 from src.core.dependencies import DBSession
@@ -343,6 +345,91 @@ async def get_deployment_logs(
         data=[DeploymentLogResponse.model_validate(log) for log in logs],
         message=f"Retrieved {len(logs)} log entries for deployment",
         request_id=request_id
+    )
+
+
+@router.get("/{deployment_id}/logs/stream")
+async def stream_deployment_logs(
+    deployment_id: str,
+    db: DBSession,
+    user: CurrentUser,
+    since_id: str = Query(None, description="Only send logs newer than this log ID"),
+):
+    """
+    Stream deployment logs as Server-Sent Events (SSE).
+
+    Sends all existing logs immediately, then polls for new ones every second
+    until the deployment reaches a terminal state (RUNNING, FAILED, DELETED).
+    The stream closes automatically when done.
+    """
+    deployment_repo = DeploymentRepository(db)
+    deployment = deployment_repo.get_by_id(deployment_id)
+
+    if not deployment:
+        raise NotFoundException(f"Deployment with ID {deployment_id} not found")
+
+    user_roles = user.get("roles", [])
+    is_admin = "admin" in [role.lower() for role in user_roles]
+    if not is_admin:
+        owner_id = get_deployment_owner_id(deployment, db)
+        if user["user_id"] != owner_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You do not have permission to access this deployment",
+            )
+
+    TERMINAL_STATUSES = {"RUNNING", "FAILED", "DELETED", "CANCELLED"}
+
+    async def event_generator():
+        log_service = DeploymentLogService(db)
+        seen_ids: set[str] = set()
+
+        # Seed seen_ids from since_id position
+        if since_id:
+            all_logs = log_service.get_deployment_logs(deployment_id)
+            for log in all_logs:
+                if str(log.id) == since_id:
+                    break
+                seen_ids.add(str(log.id))
+
+        try:
+            while True:
+                # Refresh deployment status
+                db.expire(deployment)
+                current = deployment_repo.get_by_id(deployment_id)
+                current_status = (current.status.value if hasattr(current.status, "value") else str(current.status)).upper()
+
+                # Fetch all logs and emit unseen ones
+                logs = log_service.get_deployment_logs(deployment_id)
+                new_logs = [l for l in logs if str(l.id) not in seen_ids]
+                for log in new_logs:
+                    seen_ids.add(str(log.id))
+                    payload = json.dumps({
+                        "id": str(log.id),
+                        "deployment_id": str(log.deployment_id),
+                        "event_type": log.event_type.value if hasattr(log.event_type, "value") else str(log.event_type),
+                        "message": log.message,
+                        "level": log.level.value if hasattr(log.level, "value") else str(log.level),
+                        "details": json.loads(log.details_json) if log.details_json else None,
+                        "created_at": log.created_at.isoformat() if hasattr(log.created_at, "isoformat") else str(log.created_at),
+                    })
+                    yield f"data: {payload}\n\n"
+
+                if current_status in TERMINAL_STATUSES:
+                    yield "event: done\ndata: {}\n\n"
+                    break
+
+                await asyncio.sleep(1)
+        except asyncio.CancelledError:
+            pass
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
     )
 
 

--- a/src/api/template_versions.py
+++ b/src/api/template_versions.py
@@ -83,14 +83,20 @@ async def get_version(
         )
         version = result_with_params["version"]
         parameters = result_with_params.get("parameters", [])
+        user_files = result_with_params.get("user_files", [])
+        allow_user_files = result_with_params.get("allow_user_files", False)
 
         if with_file_count:
             version_data = TemplateVersionWithFilesResponse.model_validate(version).model_dump(mode="json")
             version_data["file_count"] = result_with_params["file_count"]
             version_data["parameters"] = parameters
+            version_data["user_files"] = user_files
+            version_data["allow_user_files"] = allow_user_files
         else:
             version_data = TemplateVersionResponse.model_validate(version).model_dump(mode="json")
             version_data["parameters"] = parameters
+            version_data["user_files"] = user_files
+            version_data["allow_user_files"] = allow_user_files
         
         return ResponseBuilder.success(
             data=version_data,
@@ -162,6 +168,8 @@ async def list_template_versions(
             )
             version_data = TemplateVersionResponse.model_validate(result["version"]).model_dump(mode="json")
             version_data["parameters"] = result.get("parameters", [])
+            version_data["user_files"] = result.get("user_files", [])
+            version_data["allow_user_files"] = result.get("allow_user_files", False)
             version_responses.append(version_data)
     else:
         version_responses = [
@@ -215,6 +223,8 @@ async def get_active_version(
         )
         version_data = TemplateVersionResponse.model_validate(result["version"]).model_dump(mode="json")
         version_data["parameters"] = result.get("parameters", [])
+        version_data["user_files"] = result.get("user_files", [])
+        version_data["allow_user_files"] = result.get("allow_user_files", False)
         
         return ResponseBuilder.success(
             data=version_data,

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -29,6 +29,27 @@ class Settings(BaseSettings):
     
     # Encryption key for secrets (Fernet key)
     encryption_key: str | None = None
+
+    # Ansible SSH key — Pfad zur privaten Key-Datei (chmod 600)
+    # Der zugehörige Public Key muss in OpenStack als key_name registriert sein.
+    ansible_ssh_key_path: str | None = None
+    ansible_ssh_key_name: str = "dozilab-ansible-key"  # Name des keypairs in OpenStack
+
+    # Pfad zum appstore-apps Verzeichnis (für _common Playbooks)
+    appstore_apps_path: str = "/app/appstore-apps"
+
+    @property
+    def ansible_ssh_private_key(self) -> str | None:
+        """Read SSH private key content from file path."""
+        if not self.ansible_ssh_key_path:
+            return None
+        try:
+            from pathlib import Path
+            return Path(self.ansible_ssh_key_path).read_text()
+        except OSError as e:
+            import logging
+            logging.getLogger(__name__).error(f"Cannot read SSH key from {self.ansible_ssh_key_path}: {e}")
+            return None
     
     @property
     def database_url(self) -> str:

--- a/src/core/seed_data.py
+++ b/src/core/seed_data.py
@@ -1616,27 +1616,410 @@ def create_lecturer_user(db: Session) -> User:
     return user
 
 
+ANSIBLE_MULTIUSER_APP_YAML = """
+app:
+  name: ansible-multiuser
+  label: Ansible Multi-User Ubuntu
+  version: 2.0.0
+  description: >
+    Ubuntu VM mit mehreren Benutzerkonten, verwaltet durch Ansible.
+    Pro Gruppe wird ein Linux-Account mit eigenem Arbeitsverzeichnis erstellt.
+  owner_team: dozilab-app-team
+
+  allow_user_files: true
+
+parameters:
+
+  - name: stack_label
+    label: Stack-Label
+    step: template
+    type: string
+    default: ansible
+    required: true
+    description: "Kurzes Label für diesen Stack (z.B. kurs-ws2026)."
+
+  - name: image
+    label: Betriebssystem-Image
+    step: konfiguration
+    type: string
+    default: "Ubuntu 22.04 2025-01"
+    required: true
+    enum:
+      - "Ubuntu 22.04 2025-01"
+      - "Ubuntu 24.04 2025-01"
+      - "Ubuntu 24.04 2026-01"
+
+  - name: flavor
+    label: VM-Größe (Flavor)
+    step: konfiguration
+    type: string
+    default: "gp1.small"
+    required: true
+    enum:
+      - "gp1.small"
+      - "gp1.medium"
+
+  - name: ssh_cidr
+    label: SSH-Zugriff (CIDR)
+    step: netzwerk
+    type: string
+    default: "141.72.0.0/16"
+    required: true
+    description: "Nur dieses Netz darf per SSH zugreifen. Standard: DHBW/VPN."
+
+  - name: force_password_change
+    label: Passwort-Änderung beim ersten Login erzwingen
+    step: zugriff
+    type: boolean
+    default: true
+    required: true
+
+credentials:
+
+  per_student:
+    - linux:
+        username: "{{ username }}"
+        password: generate
+
+  teacher:
+
+user_files:
+  - name:        aufgabe_pdf
+    label:       "Aufgabenstellung (PDF)"
+    description: "Wird auf alle VMs kopiert — gleiche Aufgabe für alle Gruppen."
+    required:    false
+    accept:      "*.pdf"
+    destination: /opt/dozilab/user-files/aufgabe.pdf
+    mode:        all_stacks
+
+  - name:        material_gruppe
+    label:       "Gruppenmaterial"
+    description: "Pro Gruppe eigene Dateien — z.B. unterschiedliche Datensätze oder Aufgaben."
+    required:    false
+    accept:      "*"
+    destination: /opt/dozilab/user-files/{{ group_name }}/material
+    mode:        per_group
+
+outputs:
+  - name: floating_ip
+    label: Floating IP
+    from_heat_output: floating_ip
+
+  - name: server_id
+    label: Server ID
+    from_heat_output: server_id
+"""
+
+ANSIBLE_MULTIUSER_HEAT_TEMPLATE = """
+heat_template_version: 2018-08-31
+
+description: >
+  DoziLab Ansible Multi-User VM.
+  Nur Infrastruktur — keine user_data, keine cloud-init.
+  Konfiguration übernimmt Ansible vom Backend aus per SSH.
+
+parameters:
+  image:
+    type: string
+    default: "Ubuntu 22.04 2025-01"
+    constraints:
+      - allowed_values:
+          - "Ubuntu 22.04 2025-01"
+          - "Ubuntu 24.04 2025-01"
+          - "Ubuntu 24.04 2026-01"
+
+  flavor:
+    type: string
+    default: "gp1.small"
+    constraints:
+      - allowed_values: ["gp1.small", "gp1.medium"]
+
+  ssh_cidr:
+    type: string
+    default: "141.72.0.0/16"
+    constraints:
+      - allowed_pattern: '^(\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2}$'
+
+  stack_label:
+    type: string
+    default: "ansible"
+    constraints:
+      - allowed_pattern: '^[a-z0-9][a-z0-9-]{0,30}$'
+
+  network:
+    type: string
+    default: "NAT"
+    constraints:
+      - allowed_values: ["NAT"]
+
+  external_network:
+    type: string
+    default: "DHBW"
+    constraints:
+      - allowed_values: ["DHBW"]
+
+  key_name:
+    type: string
+
+resources:
+  secgroup:
+    type: OS::Neutron::SecurityGroup
+    properties:
+      description: SSH + ICMP aus erlaubtem CIDR
+      rules:
+        - direction: ingress
+          protocol: tcp
+          port_range_min: 22
+          port_range_max: 22
+          remote_ip_prefix: { get_param: ssh_cidr }
+        - direction: ingress
+          protocol: icmp
+          remote_ip_prefix: { get_param: ssh_cidr }
+
+  port:
+    type: OS::Neutron::Port
+    properties:
+      network: { get_param: network }
+      security_groups:
+        - { get_resource: secgroup }
+
+  server:
+    type: OS::Nova::Server
+    properties:
+      name:
+        str_replace:
+          template: "dozilab-LABEL"
+          params:
+            LABEL: { get_param: stack_label }
+      image:    { get_param: image }
+      flavor:   { get_param: flavor }
+      key_name: { get_param: key_name }
+      networks:
+        - port: { get_resource: port }
+
+  fip:
+    type: OS::Neutron::FloatingIP
+    properties:
+      floating_network: { get_param: external_network }
+
+  fip_assoc:
+    type: OS::Neutron::FloatingIPAssociation
+    properties:
+      floatingip_id: { get_resource: fip }
+      port_id:       { get_resource: port }
+
+outputs:
+  floating_ip:
+    value: { get_attr: [fip, floating_ip_address] }
+
+  server_id:
+    value: { get_resource: server }
+"""
+
+ANSIBLE_MULTIUSER_PLAYBOOK = """
+---
+- name: DoziLab Multi-User Setup
+  hosts: all
+  remote_user: ubuntu
+  become: true
+
+  tasks:
+
+    - name: /opt/dozilab nur für root zugänglich machen
+      file:
+        path:  /opt/dozilab
+        state: directory
+        owner: root
+        group: root
+        mode:  "0700"
+
+    - name: Student Accounts erstellen
+      user:
+        name:        "{{ item.username }}"
+        shell:       /bin/bash
+        create_home: true
+        state:       present
+      loop: "{{ students }}"
+      no_log: true
+
+    - name: Passwörter setzen
+      user:
+        name:     "{{ item.username }}"
+        password: "{{ item.linux.password | password_hash('sha512') }}"
+        update_password: always
+      loop: "{{ students }}"
+      no_log: true
+
+    - name: Passwort-Änderung beim ersten Login erzwingen
+      command: chage -d 0 {{ item.username }}
+      loop: "{{ students }}"
+      no_log: true
+      when: force_password_change | bool
+
+    - name: Arbeitsverzeichnis erstellen
+      file:
+        path:  "/home/{{ item.username }}/work"
+        state: directory
+        owner: "{{ item.username }}"
+        group: "{{ item.username }}"
+        mode:  "0700"
+      loop: "{{ students }}"
+      no_log: true
+
+    - name: .bashrc für jeden Student setzen
+      copy:
+        src:   /opt/dozilab/files/bashrc
+        dest:  "/home/{{ item.username }}/.bashrc"
+        owner: "{{ item.username }}"
+        group: "{{ item.username }}"
+        mode:  "0644"
+        remote_src: true
+      loop: "{{ students }}"
+      no_log: true
+
+    - name: MOTD setzen
+      shell: |
+        sed 's/__STACK_LABEL__/{{ stack_label }}/g' \\
+          /opt/dozilab/files/motd > /etc/update-motd.d/99-dozilab
+        chmod +x /etc/update-motd.d/99-dozilab
+
+    - name: Scripts ausführbar machen
+      file:
+        path:  "{{ item }}"
+        mode:  "0755"
+      loop:
+        - /opt/dozilab/scripts/check_student_setup.sh
+        - /opt/dozilab/scripts/reset_password.sh
+
+    - name: Student-Setup verifizieren
+      command: /opt/dozilab/scripts/check_student_setup.sh {{ item.username }}
+      loop: "{{ students }}"
+      register: check_result
+      changed_when: false
+      no_log: true
+
+    - name: Aufgabenstellung in Arbeitsverzeichnis kopieren
+      copy:
+        src:   /opt/dozilab/user-files/aufgabe.pdf
+        dest:  "/home/{{ item.username }}/work/aufgabe.pdf"
+        owner: "{{ item.username }}"
+        mode:  "0644"
+        remote_src: true
+      loop: "{{ students }}"
+      no_log: true
+      when: user_files.aufgabe_pdf.exists | default(false)
+
+    - name: Gruppenverzeichnis für Material erstellen
+      file:
+        path:  "/home/{{ item.username }}/work/material"
+        state: directory
+        owner: "{{ item.username }}"
+        mode:  "0700"
+      loop: "{{ students }}"
+      no_log: true
+      when: user_files.material_gruppe[item.group_name].exists | default(false)
+
+    - name: Gruppenmaterial in Arbeitsverzeichnis kopieren
+      copy:
+        src:   "/opt/dozilab/user-files/{{ item.group_name }}/material"
+        dest:  "/home/{{ item.username }}/work/material/"
+        owner: "{{ item.username }}"
+        mode:  "0600"
+        remote_src: true
+      loop: "{{ students }}"
+      no_log: true
+      when: user_files.material_gruppe[item.group_name].exists | default(false)
+"""
+
+
+ANSIBLE_MULTIUSER_BASHRC = """# ==============================================================================
+# DoziLab: .bashrc für Student-Accounts
+# ==============================================================================
+export HISTSIZE=1000
+export HISTFILESIZE=2000
+export EDITOR=nano
+
+force_color_prompt=yes
+PS1='\\[\\033[01;32m\\]\\u@\\h\\[\\033[00m\\]:\\[\\033[01;34m\\]\\w\\[\\033[00m\\]\\$ '
+
+alias ll='ls -alF'
+alias la='ls -A'
+alias l='ls -CF'
+alias ..='cd ..'
+alias work='cd ~/work'
+
+echo ""
+echo "  Willkommen, $(whoami)!"
+echo "  Dein Arbeitsverzeichnis: ~/work"
+echo ""
+"""
+
+ANSIBLE_MULTIUSER_MOTD = """#!/usr/bin/env bash
+# ==============================================================================
+# DoziLab: Message of the Day
+# Platzhalter __STACK_LABEL__ wird vom Playbook ersetzt.
+# ==============================================================================
+echo ""
+echo "  ██████╗  ██████╗ ███████╗██╗██╗      █████╗ ██████╗ "
+echo "  ██╔══██╗██╔═══██╗╚══███╔╝██║██║     ██╔══██╗██╔══██╗"
+echo "  ██║  ██║██║   ██║  ███╔╝ ██║██║     ███████║██████╔╝"
+echo "  ██║  ██║██║   ██║ ███╔╝  ██║██║     ██╔══██║██╔══██╗"
+echo "  ██████╔╝╚██████╔╝███████╗██║███████╗██║  ██║██████╔╝"
+echo "  ╚═════╝  ╚═════╝ ╚══════╝╚═╝╚══════╝╚═╝  ╚═╝╚═════╝ "
+echo ""
+echo "  Kurs:    __STACK_LABEL__"
+echo "  Support: Wende dich an deinen Dozenten"
+echo ""
+"""
+
+ANSIBLE_MULTIUSER_CHECK_SCRIPT = """#!/usr/bin/env bash
+set -euo pipefail
+USERNAME="${1:?Usage: check_student_setup.sh <username>}"
+ERRORS=0
+
+check() {
+    local desc="$1"; local result="$2"
+    if [[ "$result" == "ok" ]]; then echo "  ✓ $desc"
+    else echo "  ✗ $desc → $result"; ERRORS=$((ERRORS + 1)); fi
+}
+
+echo "Checking setup for: $USERNAME"
+id "$USERNAME" &>/dev/null && check "Account existiert" "ok" || check "Account existiert" "nicht gefunden"
+[[ -d "/home/$USERNAME" ]] && check "Home-Verzeichnis" "ok" || check "Home-Verzeichnis" "fehlt"
+[[ -d "/home/$USERNAME/work" ]] && check "Arbeitsverzeichnis" "ok" || check "Arbeitsverzeichnis" "fehlt"
+passwd -S "$USERNAME" 2>/dev/null | grep -qv " L " && check "Passwort gesetzt" "ok" || check "Passwort gesetzt" "gesperrt"
+SHELL=$(getent passwd "$USERNAME" | cut -d: -f7)
+[[ "$SHELL" == "/bin/bash" ]] && check "Shell ist /bin/bash" "ok" || check "Shell ist /bin/bash" "ist $SHELL"
+
+echo ""
+if [[ $ERRORS -eq 0 ]]; then echo "✓ Setup OK für $USERNAME"; exit 0
+else echo "✗ $ERRORS Fehler für $USERNAME"; exit 1; fi
+"""
+
+ANSIBLE_MULTIUSER_RESET_SCRIPT = """#!/usr/bin/env bash
+set -euo pipefail
+USERNAME="${1:?Usage: reset_password.sh <username> <new_password>}"
+NEW_PASSWORD="${2:?Usage: reset_password.sh <username> <new_password>}"
+if ! id "$USERNAME" &>/dev/null; then echo "ERROR: Account '$USERNAME' nicht gefunden" >&2; exit 1; fi
+echo "${USERNAME}:${NEW_PASSWORD}" | chpasswd
+echo "✓ Passwort für '$USERNAME' zurückgesetzt"
+chage -d 0 "$USERNAME"
+echo "✓ Passwort-Änderung beim nächsten Login erzwungen"
+"""
+
+
 def create_mock_templates(db: Session, owner_id: str) -> list[Template]:
     """Create mock templates."""
     templates_data = [
         {
-            "name": "Multi-User Ubuntu",
-            "description": "Deploy one Ubuntu VM for a course with multiple local student accounts (username/password), SSH allowed only from DHBW/VPN",
+            "name": "Ansible Multi-User Ubuntu",
+            "description": "Ubuntu VM mit mehreren Benutzerkonten, verwaltet durch Ansible. Pro Gruppe wird ein Linux-Account mit eigenem Arbeitsverzeichnis erstellt.",
             "repo_url": "https://github.com/dozilab/appstore-templates",
-            "icon_url": "mdi:server-network",
-            "visibility": TemplateVisibility.PUBLIC,
-            "approval_status": TemplateApprovalStatus.APPROVED,
-        },
-        {
-            "name": "PostgreSQL Group Database",
-            "description": "Deploy a PostgreSQL database server where each student group gets its own database and role. Optional pgAdmin4 web interface for database management",
-            "repo_url": "https://github.com/dozilab/appstore-templates",
-            "icon_url": "mdi:database",
+            "icon_url": "mdi:ansible",
             "visibility": TemplateVisibility.PUBLIC,
             "approval_status": TemplateApprovalStatus.APPROVED,
         }
-            
-      ]
+    ]
     
     templates = []
     for data in templates_data:
@@ -1729,16 +2112,10 @@ def create_mock_template_files(db: Session, versions: list[TemplateVersion]) -> 
             logger.info(f"Creating files for version {version.id} (template: {template.name})")
             
             # Determine which template files to use based on template name
-            if template.name == "Multi-User Ubuntu":
-                app_yaml_content = MULTISTUDENT_APP_YAML
-                heat_template_content = MULTISTUDENT_HEAT_TEMPLATE
-                cloud_init_content = MULTISTUDENT_CLOUD_INIT
-                heat_file_name = "main.yaml"
-                heat_file_path = "heat/main.yaml"
-            elif template.name == "PostgreSQL Group Database":
-                app_yaml_content = POSTGRES_APP_YAML
-                heat_template_content = POSTGRES_HEAT_TEMPLATE
-                cloud_init_content = POSTGRES_CLOUD_INIT
+            if template.name == "Ansible Multi-User Ubuntu":
+                app_yaml_content = ANSIBLE_MULTIUSER_APP_YAML
+                heat_template_content = ANSIBLE_MULTIUSER_HEAT_TEMPLATE
+                cloud_init_content = None
                 heat_file_name = "main.yaml"
                 heat_file_path = "heat/main.yaml"
             else:
@@ -1757,7 +2134,7 @@ def create_mock_template_files(db: Session, versions: list[TemplateVersion]) -> 
             )
             db.add(app_yaml)
             logger.debug(f"Added app.yaml for version {version.id}")
-            
+
             # Create heat template
             heat_template = TemplateVersionFile(
                 template_version_id=version.id,
@@ -1769,22 +2146,64 @@ def create_mock_template_files(db: Session, versions: list[TemplateVersion]) -> 
             )
             db.add(heat_template)
             logger.debug(f"Added heat template for version {version.id}")
-            
-            # Create cloud-init user-data
-            cloud_init = TemplateVersionFile(
-                template_version_id=version.id,
-                file_name="user-data.yaml",
-                file_type=FileType.CLOUD_INIT,
-                file_path="cloud-init/user-data.yaml",
-                content=cloud_init_content,
-                is_primary=False
-            )
-            db.add(cloud_init)
-            logger.debug(f"Added cloud-init for version {version.id}")
-            
+
+            files_in_version = 2
+
+            # Create cloud-init user-data (only for templates that use it)
+            if cloud_init_content is not None:
+                cloud_init = TemplateVersionFile(
+                    template_version_id=version.id,
+                    file_name="user-data.yaml",
+                    file_type=FileType.CLOUD_INIT,
+                    file_path="cloud-init/user-data.yaml",
+                    content=cloud_init_content,
+                    is_primary=False
+                )
+                db.add(cloud_init)
+                logger.debug(f"Added cloud-init for version {version.id}")
+                files_in_version += 1
+
+            # Create ansible playbook (only for ansible-based templates)
+            if template.name == "Ansible Multi-User Ubuntu":
+                playbook = TemplateVersionFile(
+                    template_version_id=version.id,
+                    file_name="main.yml",
+                    file_type=FileType.ANSIBLE_PLAYBOOK,
+                    file_path="playbooks/main.yml",
+                    content=ANSIBLE_MULTIUSER_PLAYBOOK,
+                    is_primary=False
+                )
+                db.add(playbook)
+                files_in_version += 1
+
+                for name, content in [("bashrc", ANSIBLE_MULTIUSER_BASHRC), ("motd", ANSIBLE_MULTIUSER_MOTD)]:
+                    db.add(TemplateVersionFile(
+                        template_version_id=version.id,
+                        file_name=name,
+                        file_type=FileType.CONFIG_FILE,
+                        file_path=f"files/{name}",
+                        content=content,
+                        is_primary=False
+                    ))
+                    files_in_version += 1
+
+                for name, content in [
+                    ("check_student_setup.sh", ANSIBLE_MULTIUSER_CHECK_SCRIPT),
+                    ("reset_password.sh", ANSIBLE_MULTIUSER_RESET_SCRIPT),
+                ]:
+                    db.add(TemplateVersionFile(
+                        template_version_id=version.id,
+                        file_name=name,
+                        file_type=FileType.SHELL_SCRIPT,
+                        file_path=f"scripts/{name}",
+                        content=content,
+                        is_primary=False
+                    ))
+                    files_in_version += 1
+
             db.commit()
             files_created += 1
-            logger.info(f"✅ Created 3 files for version: {version.id} (template: {template.name})")
+            logger.info(f"✅ Created {files_in_version} files for version: {version.id} (template: {template.name})")
             
         except Exception as e:
             logger.error(f"❌ Failed to create files for version {version.id}: {e}", exc_info=True)

--- a/src/models/deployment_log.py
+++ b/src/models/deployment_log.py
@@ -27,6 +27,13 @@ class DeploymentLogEventType(str, Enum):
     FAILED = "failed"
     DEPLOYMENT_DELETION_REQUESTED = "deployment_deletion_requested"
     DEPLOYMENT_DELETED = "deployment_deleted"
+    # Ansible
+    SSH_WAIT = "ssh_wait"
+    ANSIBLE_STARTED = "ansible_started"
+    ANSIBLE_TASK = "ansible_task"
+    ANSIBLE_OK = "ansible_ok"
+    ANSIBLE_FAILED = "ansible_failed"
+    ANSIBLE_COMPLETED = "ansible_completed"
 
 
 class DeploymentLog(Base):

--- a/src/models/template_version_file.py
+++ b/src/models/template_version_file.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from uuid import uuid4
 
-from sqlalchemy import String, DateTime, Text, ForeignKey, Enum as SQLEnum, Integer
+from sqlalchemy import String, DateTime, Text, ForeignKey, Enum as SQLEnum, Integer, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.core.database import Base
@@ -29,6 +29,9 @@ class TemplateVersionFile(Base):
     """
     
     __tablename__ = "template_version_files"
+    __table_args__ = (
+        UniqueConstraint('template_version_id', 'file_path', name='uq_template_version_file_path'),
+    )
     
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
     template_version_id: Mapped[str] = mapped_column(String(36), ForeignKey("template_versions.id"), nullable=False)

--- a/src/repositories/template_version_file_repository.py
+++ b/src/repositories/template_version_file_repository.py
@@ -140,6 +140,59 @@ class TemplateVersionFileRepository(BaseRepository[TemplateVersionFile]):
         self.db.refresh(file)
         return file
 
+    def get_by_file_path(
+        self,
+        template_version_id: str | UUID,
+        file_path: str
+    ) -> Optional[TemplateVersionFile]:
+        """Get a file by its path within a template version."""
+        return self.db.query(self.model).filter(
+            self.model.template_version_id == str(template_version_id),
+            self.model.file_path == file_path
+        ).first()
+
+    def upsert(
+        self,
+        template_version_id: str,
+        file_name: str,
+        file_type: FileType,
+        file_path: str,
+        content: Optional[str],
+        file_size: Optional[int],
+        description: Optional[str],
+        is_primary: bool,
+        order: int,
+    ) -> tuple[TemplateVersionFile, bool]:
+        """Create or update a file by (template_version_id, file_path).
+
+        Returns:
+            (file, created) — created=True if new, False if updated
+        """
+        existing = self.get_by_file_path(template_version_id, file_path)
+        if existing:
+            existing.file_name = file_name
+            existing.file_type = file_type
+            existing.content = content
+            existing.file_size = file_size
+            existing.description = description
+            existing.order = order
+            self.db.commit()
+            self.db.refresh(existing)
+            return existing, False
+        else:
+            file = self.create(
+                template_version_id=template_version_id,
+                file_name=file_name,
+                file_type=file_type,
+                file_path=file_path,
+                content=content,
+                file_size=file_size,
+                description=description,
+                is_primary=is_primary,
+                order=order,
+            )
+            return file, True
+
     def delete_by_version_id(
         self,
         template_version_id: str | UUID

--- a/src/schemas/deployment.py
+++ b/src/schemas/deployment.py
@@ -40,19 +40,19 @@ class DeploymentCreate(BaseModel):
     name: str = Field(..., description="Deployment name for identification", max_length=255)
     template_version_id: str = Field(..., description="Template version ID to deploy")
     course_id: str = Field(..., description="Keycloak group ID for the course")
-    
-    # Heat template parameters (OpenStack)
-    heat_parameters: dict[str, Any] = Field(
-        ...,
-        description="Heat template parameters (image, flavor, network, ssh_cidr, etc.)"
+
+    # All template parameters — backend separates Heat vs Ansible automatically
+    parameters: dict[str, Any] = Field(
+        default_factory=dict,
+        description="All template parameters from app.yaml (Heat + Ansible). Backend splits them automatically."
     )
-    
+
     # Stack assignments (for user_json generation)
     stack_assignments: list[StackAssignment] = Field(
         ...,
         description="Stack assignments with groups and students"
     )
-    
+
     # Teacher info (for admin_credentials generation)
     teacher: TeacherInfo = Field(
         ...,

--- a/src/schemas/template_parameters.py
+++ b/src/schemas/template_parameters.py
@@ -12,7 +12,7 @@ class TemplateParameterSchema(BaseModel):
     type: str = Field(..., description="Parameter type (string, int, number, boolean)")
     required: bool = Field(..., description="Whether this parameter is required")
     default: Any = Field(None, description="Default value if not required")
-    description: str = Field(..., description="Human-readable description for UI")
+    description: str | None = Field(None, description="Human-readable description for UI")
     label: str | None = Field(None, description="Display label for the parameter in UI")
     step: str | None = Field(None, description="Step/group name for organizing parameters in UI")
     enum: list[Any] | None = Field(None, description="List of allowed values for this parameter")

--- a/src/services/ansible_keypair_service.py
+++ b/src/services/ansible_keypair_service.py
@@ -1,0 +1,97 @@
+"""Service to ensure the DoziLab Ansible keypair exists in an OpenStack project."""
+import logging
+from cryptography.hazmat.primitives.serialization import (
+    load_ssh_private_key,
+    Encoding,
+    PublicFormat,
+)
+
+import openstack
+
+from src.models.openstack_project import OpenstackProject
+from src.core.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+KEYPAIR_NAME = "dozilab-ansible-key"
+
+
+def _derive_public_key(private_key_content: str) -> str:
+    """Derive the OpenSSH public key string from a private key."""
+    private_key = load_ssh_private_key(
+        private_key_content.encode(),
+        password=None,
+    )
+    pub_bytes = private_key.public_key().public_bytes(
+        encoding=Encoding.OpenSSH,
+        format=PublicFormat.OpenSSH,
+    )
+    return pub_bytes.decode()
+
+
+class AnsibleKeypairService:
+    """Ensures the shared Ansible keypair exists in an OpenStack project.
+
+    Called once when a new OpenstackProject is created or updated.
+    If the keypair already exists, it is left untouched.
+    If it is missing, it is created from the Backend's SSH key.
+    """
+
+    @staticmethod
+    def ensure_keypair(openstack_project: OpenstackProject) -> None:
+        """Register the Ansible public key in the given OpenStack project if missing.
+
+        Args:
+            openstack_project: The project to check/update.
+
+        Raises:
+            RuntimeError: If ANSIBLE_SSH_KEY_PATH is not configured.
+        """
+        settings = get_settings()
+        private_key_content = settings.ansible_ssh_private_key
+
+        if not private_key_content:
+            raise RuntimeError(
+                "ANSIBLE_SSH_KEY_PATH is not configured — cannot register Ansible keypair."
+            )
+
+        try:
+            conn = openstack.connect(
+                auth_url=openstack_project.auth_url,
+                project_name=openstack_project.openstack_project_name,
+                project_id=openstack_project.openstack_project_id,
+                username=openstack_project.username,
+                password=openstack_project.password,
+                user_domain_name=openstack_project.user_domain_name,
+                project_domain_name=openstack_project.user_domain_name,
+                region_name=openstack_project.region_name,
+            )
+
+            # Check if keypair already exists
+            existing = conn.compute.find_keypair(KEYPAIR_NAME)
+            if existing:
+                logger.info(
+                    f"Ansible keypair '{KEYPAIR_NAME}' already exists in project "
+                    f"{openstack_project.openstack_project_name} — skipping."
+                )
+                return
+
+            # Derive public key from private key
+            public_key = _derive_public_key(private_key_content)
+
+            conn.compute.create_keypair(
+                name=KEYPAIR_NAME,
+                public_key=public_key,
+            )
+            logger.info(
+                f"Ansible keypair '{KEYPAIR_NAME}' registered in project "
+                f"{openstack_project.openstack_project_name}."
+            )
+
+        except Exception as e:
+            logger.error(
+                f"Failed to ensure Ansible keypair in project "
+                f"{openstack_project.openstack_project_name}: {e}",
+                exc_info=True,
+            )
+            raise

--- a/src/services/ansible_service.py
+++ b/src/services/ansible_service.py
@@ -8,6 +8,8 @@ import time
 from pathlib import Path
 from typing import Generator
 
+from src.utils.log_sanitizer import sanitize_message
+
 from sqlalchemy.orm import Session
 
 from src.models.deployment_log import DeploymentLogEventType, DeploymentLogLevel
@@ -96,33 +98,44 @@ class AnsibleService:
             if scripts:
                 (tmp / "scripts").mkdir()
                 for name, content in scripts.items():
-                    (tmp / "scripts" / name).write_text(content)
+                    (tmp / "scripts" / name).write_text(content, encoding="utf-8")
 
             # Write files
             if files:
                 (tmp / "files").mkdir()
                 for name, content in files.items():
-                    (tmp / "files" / name).write_text(content)
+                    (tmp / "files" / name).write_text(content, encoding="utf-8")
 
             # Build a minimal playbook that copies the directories
-            copy_tasks = []
+            copy_tasks: list[dict] = [
+                {
+                    "name": "Secure /opt/dozilab root directory",
+                    "file": {
+                        "path": "/opt/dozilab",
+                        "state": "directory",
+                        "mode": "0700",
+                        "owner": "root",
+                        "group": "root",
+                    },
+                }
+            ]
             if scripts:
                 copy_tasks.append({
                     "name": "Create /opt/dozilab/scripts",
-                    "file": {"path": "/opt/dozilab/scripts", "state": "directory", "mode": "0755"},
+                    "file": {"path": "/opt/dozilab/scripts", "state": "directory", "mode": "0700", "owner": "root", "group": "root"},
                 })
                 copy_tasks.append({
                     "name": "Copy scripts",
-                    "copy": {"src": str(tmp / "scripts") + "/", "dest": "/opt/dozilab/scripts/", "mode": "0755"},
+                    "copy": {"src": str(tmp / "scripts") + "/", "dest": "/opt/dozilab/scripts/", "mode": "0700", "owner": "root", "group": "root"},
                 })
             if files:
                 copy_tasks.append({
                     "name": "Create /opt/dozilab/files",
-                    "file": {"path": "/opt/dozilab/files", "state": "directory", "mode": "0755"},
+                    "file": {"path": "/opt/dozilab/files", "state": "directory", "mode": "0700", "owner": "root", "group": "root"},
                 })
                 copy_tasks.append({
                     "name": "Copy files",
-                    "copy": {"src": str(tmp / "files") + "/", "dest": "/opt/dozilab/files/"},
+                    "copy": {"src": str(tmp / "files") + "/", "dest": "/opt/dozilab/files/", "owner": "root", "group": "root"},
                 })
 
             import yaml as _yaml
@@ -134,14 +147,14 @@ class AnsibleService:
                 "tasks": copy_tasks,
             }])
             playbook_path = tmp / "copy_assets.yml"
-            playbook_path.write_text(playbook_content)
+            playbook_path.write_text(playbook_content, encoding="utf-8")
 
             self._log(
                 DeploymentLogEventType.ANSIBLE_STARTED,
                 f"Copying {len(scripts)} scripts and {len(files)} files to VM",
             )
             for line in self._run_playbook(str(playbook_path), extra_vars={}):
-                pass  # output already logged inside _run_playbook
+                pass
 
     def run_playbooks(
         self,
@@ -162,7 +175,7 @@ class AnsibleService:
             for playbook_name, content in playbooks:
                 playbook_path = tmp / playbook_name
                 playbook_path.parent.mkdir(parents=True, exist_ok=True)
-                playbook_path.write_text(content)
+                playbook_path.write_text(content, encoding="utf-8")
 
                 self._log(
                     DeploymentLogEventType.ANSIBLE_STARTED,
@@ -235,7 +248,7 @@ class AnsibleService:
             )
 
             for raw_line in process.stdout:
-                line = raw_line.rstrip()
+                line = sanitize_message(raw_line.rstrip())
                 if not line:
                     continue
 

--- a/src/services/ansible_service.py
+++ b/src/services/ansible_service.py
@@ -247,6 +247,7 @@ class AnsibleService:
                 bufsize=1,
             )
 
+            assert process.stdout is not None
             for raw_line in process.stdout:
                 line = sanitize_message(raw_line.rstrip())
                 if not line:

--- a/src/services/ansible_service.py
+++ b/src/services/ansible_service.py
@@ -1,0 +1,290 @@
+"""Ansible service — runs playbooks on a remote VM and streams output to DeploymentLog."""
+import json
+import logging
+import socket
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import Generator
+
+from sqlalchemy.orm import Session
+
+from src.models.deployment_log import DeploymentLogEventType, DeploymentLogLevel
+from src.services.deployment_log_service import DeploymentLogService
+
+logger = logging.getLogger(__name__)
+
+# How long to wait for SSH before giving up (seconds)
+SSH_TIMEOUT = 600
+SSH_RETRY_INTERVAL = 10
+
+
+class AnsibleService:
+    """Runs Ansible playbooks on a remote VM.
+
+    Workflow per stack:
+      1. wait_for_ssh()      — polls port 22 until reachable
+      2. copy_files()        — copies scripts/ and files/ to /opt/dozilab/
+      3. run_playbooks()     — executes each playbook in order, streams stdout
+                               line-by-line into DeploymentLog
+    """
+
+    def __init__(
+        self,
+        db: Session,
+        deployment_id: str,
+        floating_ip: str,
+        ssh_private_key: str,
+        ssh_user: str = "ubuntu",
+    ):
+        self.db = db
+        self.deployment_id = deployment_id
+        self.floating_ip = floating_ip
+        self.ssh_private_key = ssh_private_key
+        self.ssh_user = ssh_user
+        self.log_service = DeploymentLogService(db)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def wait_for_ssh(self, timeout: int = SSH_TIMEOUT) -> None:
+        """Block until port 22 is reachable or timeout expires.
+
+        Raises:
+            TimeoutError: If the VM is not reachable within timeout seconds.
+        """
+        self._log(
+            DeploymentLogEventType.SSH_WAIT,
+            f"Waiting for SSH on {self.floating_ip} (timeout {timeout}s)",
+        )
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                with socket.create_connection((self.floating_ip, 22), timeout=5):
+                    self._log(
+                        DeploymentLogEventType.SSH_WAIT,
+                        f"SSH reachable on {self.floating_ip}",
+                    )
+                    return
+            except OSError:
+                time.sleep(SSH_RETRY_INTERVAL)
+
+        raise TimeoutError(
+            f"VM {self.floating_ip} not reachable via SSH after {timeout}s"
+        )
+
+    def copy_files(
+        self,
+        scripts: dict[str, str],
+        files: dict[str, str],
+    ) -> None:
+        """Copy template scripts/ and files/ to /opt/dozilab/ on the VM.
+
+        Args:
+            scripts: {filename: content} from the scripts/ folder
+            files:   {filename: content} from the files/ folder
+        """
+        if not scripts and not files:
+            return
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+
+            # Write scripts
+            if scripts:
+                (tmp / "scripts").mkdir()
+                for name, content in scripts.items():
+                    (tmp / "scripts" / name).write_text(content)
+
+            # Write files
+            if files:
+                (tmp / "files").mkdir()
+                for name, content in files.items():
+                    (tmp / "files" / name).write_text(content)
+
+            # Build a minimal playbook that copies the directories
+            copy_tasks = []
+            if scripts:
+                copy_tasks.append({
+                    "name": "Create /opt/dozilab/scripts",
+                    "file": {"path": "/opt/dozilab/scripts", "state": "directory", "mode": "0755"},
+                })
+                copy_tasks.append({
+                    "name": "Copy scripts",
+                    "copy": {"src": str(tmp / "scripts") + "/", "dest": "/opt/dozilab/scripts/", "mode": "0755"},
+                })
+            if files:
+                copy_tasks.append({
+                    "name": "Create /opt/dozilab/files",
+                    "file": {"path": "/opt/dozilab/files", "state": "directory", "mode": "0755"},
+                })
+                copy_tasks.append({
+                    "name": "Copy files",
+                    "copy": {"src": str(tmp / "files") + "/", "dest": "/opt/dozilab/files/"},
+                })
+
+            import yaml as _yaml
+            playbook_content = _yaml.dump([{
+                "name": "DoziLab — copy template assets",
+                "hosts": "all",
+                "remote_user": self.ssh_user,
+                "become": True,
+                "tasks": copy_tasks,
+            }])
+            playbook_path = tmp / "copy_assets.yml"
+            playbook_path.write_text(playbook_content)
+
+            self._log(
+                DeploymentLogEventType.ANSIBLE_STARTED,
+                f"Copying {len(scripts)} scripts and {len(files)} files to VM",
+            )
+            for line in self._run_playbook(str(playbook_path), extra_vars={}):
+                pass  # output already logged inside _run_playbook
+
+    def run_playbooks(
+        self,
+        playbooks: list[tuple[str, str]],
+        extra_vars: dict,
+    ) -> None:
+        """Run a list of playbooks in order.
+
+        Args:
+            playbooks: List of (name, content) tuples sorted by filename.
+            extra_vars: Variables passed to every playbook via --extra-vars.
+
+        Raises:
+            RuntimeError: If any playbook exits with non-zero return code.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            for playbook_name, content in playbooks:
+                playbook_path = tmp / playbook_name
+                playbook_path.parent.mkdir(parents=True, exist_ok=True)
+                playbook_path.write_text(content)
+
+                self._log(
+                    DeploymentLogEventType.ANSIBLE_STARTED,
+                    f"Running playbook: {playbook_name}",
+                    details={"playbook": playbook_name},
+                )
+
+                failed = False
+                for line in self._run_playbook(str(playbook_path), extra_vars):
+                    if "FAILED" in line or "fatal:" in line.lower():
+                        failed = True
+
+                if failed:
+                    self._log(
+                        DeploymentLogEventType.ANSIBLE_FAILED,
+                        f"Playbook {playbook_name} reported failures",
+                        level=DeploymentLogLevel.ERROR,
+                        details={"playbook": playbook_name},
+                    )
+                    raise RuntimeError(f"Ansible playbook {playbook_name} failed")
+
+                self._log(
+                    DeploymentLogEventType.ANSIBLE_COMPLETED,
+                    f"Playbook {playbook_name} completed successfully",
+                    details={"playbook": playbook_name},
+                )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _run_playbook(
+        self,
+        playbook_path: str,
+        extra_vars: dict,
+    ) -> Generator[str, None, None]:
+        """Execute ansible-playbook and yield each output line.
+
+        Lines are also written to DeploymentLog in real time.
+        """
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".pem", delete=False, prefix="dozilab_ssh_"
+        ) as key_file:
+            key_file.write(self.ssh_private_key)
+            key_path = key_file.name
+
+        try:
+            Path(key_path).chmod(0o600)
+
+            inventory = f"{self.floating_ip},"
+            cmd = [
+                "ansible-playbook",
+                playbook_path,
+                "-i", inventory,
+                "--private-key", key_path,
+                "--user", self.ssh_user,
+                "--ssh-extra-args", "-o StrictHostKeyChecking=no -o ConnectTimeout=10",
+            ]
+            if extra_vars:
+                cmd += ["--extra-vars", json.dumps(extra_vars)]
+
+            logger.debug(f"Running: {' '.join(cmd[:4])} ...")
+
+            process = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+            )
+
+            for raw_line in process.stdout:
+                line = raw_line.rstrip()
+                if not line:
+                    continue
+
+                event_type, level = self._classify_line(line)
+                self._log(event_type, line, level=level)
+                yield line
+
+            process.wait()
+            if process.returncode != 0:
+                raise RuntimeError(
+                    f"ansible-playbook exited with code {process.returncode}"
+                )
+        finally:
+            Path(key_path).unlink(missing_ok=True)
+
+    @staticmethod
+    def _classify_line(line: str) -> tuple[DeploymentLogEventType, DeploymentLogLevel]:
+        """Map an ansible-playbook output line to a log event type and level."""
+        upper = line.upper()
+        if "TASK [" in upper:
+            return DeploymentLogEventType.ANSIBLE_TASK, DeploymentLogLevel.INFO
+        if upper.startswith("OK:") or " OK:" in upper:
+            return DeploymentLogEventType.ANSIBLE_OK, DeploymentLogLevel.INFO
+        # PLAY RECAP line: only flag as failed if failed=N where N > 0
+        if "FAILED=" in upper:
+            import re
+            m = re.search(r"failed=(\d+)", line, re.IGNORECASE)
+            if m and int(m.group(1)) > 0:
+                return DeploymentLogEventType.ANSIBLE_FAILED, DeploymentLogLevel.ERROR
+            return DeploymentLogEventType.ANSIBLE_TASK, DeploymentLogLevel.INFO
+        if "FATAL" in upper or upper.startswith("FAILED"):
+            return DeploymentLogEventType.ANSIBLE_FAILED, DeploymentLogLevel.ERROR
+        if "[ERROR]" in upper:
+            return DeploymentLogEventType.ANSIBLE_FAILED, DeploymentLogLevel.ERROR
+        if "WARNING" in upper:
+            return DeploymentLogEventType.ANSIBLE_TASK, DeploymentLogLevel.WARNING
+        return DeploymentLogEventType.ANSIBLE_TASK, DeploymentLogLevel.INFO
+
+    def _log(
+        self,
+        event_type: DeploymentLogEventType,
+        message: str,
+        level: DeploymentLogLevel = DeploymentLogLevel.INFO,
+        details: dict | None = None,
+    ) -> None:
+        self.log_service.log(
+            deployment_id=self.deployment_id,
+            event_type=event_type,
+            message=message,
+            level=level,
+            details=details,
+        )

--- a/src/services/credential_generator_service.py
+++ b/src/services/credential_generator_service.py
@@ -1,0 +1,192 @@
+"""Generates per-deployment credentials from the app.yaml credentials block."""
+import re
+import secrets
+import string
+from typing import Any
+
+from src.schemas.deployment import StackAssignment, TeacherInfo
+
+
+_SPECIAL = "!@#$%^&*"
+_ALPHABET = string.ascii_letters + string.digits + _SPECIAL
+
+
+def _generate_password(length: int = 16) -> str:
+    """Generate a secure password that satisfies common complexity rules."""
+    while True:
+        pw = "".join(secrets.choice(_ALPHABET) for _ in range(length))
+        if (
+            any(c.isupper() for c in pw)
+            and any(c.islower() for c in pw)
+            and any(c.isdigit() for c in pw)
+            and any(c in _SPECIAL for c in pw)
+        ):
+            return pw
+
+
+def _sanitize_username(name: str) -> str:
+    """Convert any string to a valid Unix username (max 32 chars)."""
+    username = name.lower().replace(" ", "-").replace(".", "-")
+    username = re.sub(r"[^a-z0-9\-_]", "", username)
+    if username and username[0].isdigit():
+        username = "u" + username
+    return (username or "user")[:32]
+
+
+def _resolve_field(template: str, context: dict[str, Any]) -> str:
+    """Replace {{ key }} placeholders with values from context."""
+    def replacer(m: re.Match) -> str:
+        key = m.group(1).strip()
+        # Support group_index:02d format
+        if ":" in key:
+            key, fmt = key.split(":", 1)
+            val = context.get(key, "")
+            try:
+                return format(int(val), fmt)
+            except (ValueError, TypeError):
+                return str(val)
+        return str(context.get(key, m.group(0)))
+
+    return re.sub(r"\{\{\s*([^}]+)\s*\}\}", replacer, str(template))
+
+
+def _build_credential_entry(
+    spec: dict[str, Any],
+    context: dict[str, Any],
+) -> dict[str, Any]:
+    """Build a single credential dict by resolving all field values."""
+    result = {}
+    for field, value in spec.items():
+        if value == "generate":
+            result[field] = _generate_password()
+        else:
+            result[field] = _resolve_field(str(value), context)
+    return result
+
+
+class CredentialGeneratorService:
+    """Generates Ansible extra-vars from the credentials block in app.yaml.
+
+    Replaces the old if/else template-name logic in template_user_management_service.py.
+    The credentials block is read directly from app.yaml so every template controls
+    exactly which credentials the backend generates.
+
+    Usage:
+        creds = CredentialGeneratorService.generate(
+            credentials_spec=manifest["credentials"],
+            stack_assignment=stack_assignment,
+            teacher=teacher,
+        )
+        # creds["students"]  → list, one entry per group
+        # creds["teacher"]   → dict
+    """
+
+    @staticmethod
+    def generate(
+        credentials_spec: dict[str, list],
+        stack_assignment: StackAssignment,
+        teacher: TeacherInfo,
+    ) -> dict[str, Any]:
+        """Generate all credentials for one stack.
+
+        Args:
+            credentials_spec: The parsed credentials block from app.yaml.
+                              {"per_student": [...], "teacher": [...]}
+            stack_assignment:  The stack's groups and students.
+            teacher:           Teacher info from Keycloak.
+
+        Returns:
+            {
+              "students": [
+                {
+                  "username": "gruppe01",
+                  "email": "...",
+                  "group_name": "Gruppe 1",
+                  "group_index": 1,
+                  "linux":    {"username": "gruppe01", "password": "..."},
+                  "postgres": {"db_user": "grp01", "db_name": "db_g01", "password": "..."},
+                  ...
+                },
+                ...
+              ],
+              "teacher": {
+                "username": "prof-berg",
+                "email": "...",
+                "linux": {"username": "prof-berg", "password": "..."},  # always added
+                "postgres": {"db_user": "teacher", "password": "..."},
+                ...
+              }
+            }
+        """
+        per_student_specs: list[dict] = credentials_spec.get("per_student") or []
+        teacher_specs: list[dict] = credentials_spec.get("teacher") or []
+
+        # --- Teacher ---
+        teacher_username = _sanitize_username(teacher.username)
+        teacher_ctx = {
+            "username": teacher_username,
+            "email": teacher.email,
+            "first_name": teacher.first_name,
+            "last_name": teacher.last_name,
+        }
+
+        teacher_creds: dict[str, Any] = {
+            "username": teacher_username,
+            "email": teacher.email,
+            # linux is always generated for the teacher so Ansible can connect
+            "linux": {
+                "username": teacher_username,
+                "password": _generate_password(),
+            },
+        }
+        for spec_item in teacher_specs:
+            for cred_type, fields in spec_item.items():
+                if cred_type == "linux":
+                    # Merge — don't overwrite the auto-generated linux entry
+                    extra = _build_credential_entry(fields, teacher_ctx)
+                    teacher_creds["linux"].update(extra)
+                else:
+                    teacher_creds[cred_type] = _build_credential_entry(fields, teacher_ctx)
+
+        # --- Students (one entry per group) ---
+        students: list[dict[str, Any]] = []
+        for group in stack_assignment.groups:
+            # Use group name as the shared Linux username for the group
+            group_username = _sanitize_username(group.group_name)
+            # Use first student's email as group email (or generate a fallback)
+            group_email = group.students[0].email if group.students else f"{group_username}@dozilab.local"
+
+            student_ctx = {
+                "username": group_username,
+                "email": group_email,
+                "group_name": group.group_name,
+                "group_index": group.group_index,
+            }
+
+            entry: dict[str, Any] = {
+                "username": group_username,
+                "email": group_email,
+                "group_name": group.group_name,
+                "group_index": group.group_index,
+                "students": [
+                    {
+                        "id": s.id,
+                        "username": s.username,
+                        "email": s.email,
+                        "first_name": s.first_name,
+                        "last_name": s.last_name,
+                    }
+                    for s in group.students
+                ],
+            }
+
+            for spec_item in per_student_specs:
+                for cred_type, fields in spec_item.items():
+                    entry[cred_type] = _build_credential_entry(fields, student_ctx)
+
+            students.append(entry)
+
+        return {
+            "students": students,
+            "teacher": teacher_creds,
+        }

--- a/src/services/deployment_credential_service.py
+++ b/src/services/deployment_credential_service.py
@@ -86,7 +86,7 @@ class DeploymentCredentialService:
 
             for cred in application.get("credentials") or []:
                 entries.append({
-                    "access_type": AccessType.WEB_URL if is_pgadmin else AccessType.DATABASE,
+                    "access_type": AccessType.DATABASE,
                     "username": cred.get("email") or cred.get("db_user") or cred.get("username"),
                     "password": cred.get("password"),
                     "connection_url": pgadmin_url if is_pgadmin else None,
@@ -96,7 +96,7 @@ class DeploymentCredentialService:
             app_admin = application.get("admin_credentials")
             if app_admin:
                 entries.append({
-                    "access_type": AccessType.WEB_URL if is_pgadmin else AccessType.DATABASE,
+                    "access_type": AccessType.DATABASE,
                     "username": app_admin.get("email") or app_admin.get("db_user") or app_admin.get("username"),
                     "password": app_admin.get("password"),
                     "connection_url": pgadmin_url if is_pgadmin else None,

--- a/src/services/deployment_credential_service.py
+++ b/src/services/deployment_credential_service.py
@@ -1,10 +1,4 @@
-"""Persist deployment credentials produced by the per-stack ``user_json``.
-
-After a Heat stack is created, this service writes one ``DeploymentInstance``
-row per stack and one ``DeploymentInstanceAccess`` row per credential entry
-(group account, teacher admin, postgres user, pgAdmin user, ...). Passwords
-are auto-encrypted by the ``EncryptedString`` type decorator on the model.
-"""
+"""Persist deployment credentials produced by the per-stack ``user_json``."""
 from __future__ import annotations
 
 from typing import Any
@@ -15,7 +9,6 @@ from src.models.deployment_instance_access import AccessType, DeploymentInstance
 
 
 class DeploymentCredentialService:
-    """Write the credentials embedded in a stack's ``user_json`` to the database."""
 
     def __init__(self, db: Session):
         self.db = db
@@ -26,18 +19,9 @@ class DeploymentCredentialService:
         stack_name: str,
         openstack_stack_id: str,
         user_json: dict[str, Any],
+        floating_ip: str = "",
+        heat_outputs: dict[str, Any] | None = None,
     ) -> DeploymentInstance:
-        """Persist credentials for one Heat stack.
-
-        Creates a single ``DeploymentInstance`` for the stack and attaches one
-        ``DeploymentInstanceAccess`` row per credential entry found in
-        ``user_json``. Both the Ubuntu shape (credentials nested under
-        ``instance``) and the Postgres shape (credentials inside
-        ``applications[*]``) are supported.
-
-        The instance status is set to ``RUNNING`` because this is called only
-        after the Heat stack creation API returned successfully.
-        """
         instance = DeploymentInstance(
             deployment_id=deployment_id,
             vm_name=stack_name,
@@ -45,15 +29,17 @@ class DeploymentCredentialService:
             status=DeploymentInstanceStatus.RUNNING,
         )
         self.db.add(instance)
-        self.db.flush()  # populate instance.id for FK use below
+        self.db.flush()
 
-        for entry in self._extract_access_entries(user_json):
+        for entry in self._extract_access_entries(user_json, floating_ip, heat_outputs or {}):
             self.db.add(
                 DeploymentInstanceAccess(
                     deployment_instance_id=instance.id,
                     access_type=entry["access_type"],
                     username=entry.get("username"),
                     password=entry.get("password"),
+                    connection_url=entry.get("connection_url"),
+                    port=entry.get("port"),
                 )
             )
 
@@ -61,43 +47,60 @@ class DeploymentCredentialService:
         return instance
 
     @staticmethod
-    def _extract_access_entries(user_json: dict[str, Any]) -> list[dict[str, Any]]:
-        """Flatten a ``user_json`` payload into a list of access-row payloads.
-
-        Returns dicts shaped like ``{access_type, username, password}``. Username
-        for Postgres entries falls back to ``db_user`` since that's the field
-        the postgres template uses; pgAdmin entries use ``email``.
-        """
+    def _extract_access_entries(
+        user_json: dict[str, Any],
+        floating_ip: str = "",
+        heat_outputs: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
         entries: list[dict[str, Any]] = []
+        heat_outputs = heat_outputs or {}
 
+        # SSH credentials (Ubuntu/Ansible templates)
         instance = user_json.get("instance") or {}
         for cred in instance.get("credentials") or []:
+            username = cred.get("username")
             entries.append({
                 "access_type": AccessType.SSH,
-                "username": cred.get("username"),
+                "username": username,
                 "password": cred.get("password"),
+                "connection_url": f"ssh {username}@{floating_ip}" if username and floating_ip else None,
+                "port": 22,
             })
         admin = instance.get("admin_credentials")
         if admin:
+            username = admin.get("username")
             entries.append({
                 "access_type": AccessType.SSH,
-                "username": admin.get("username"),
+                "username": username,
                 "password": admin.get("password"),
+                "connection_url": f"ssh {username}@{floating_ip}" if username and floating_ip else None,
+                "port": 22,
             })
 
+        # App credentials (Postgres / pgAdmin templates)
+        pgadmin_url = heat_outputs.get("pgadmin_url")
+
         for application in user_json.get("applications") or []:
+            app_name = (application.get("name") or "").lower()
+            is_pgadmin = "pgadmin" in app_name
+
             for cred in application.get("credentials") or []:
                 entries.append({
-                    "access_type": AccessType.DATABASE,
-                    "username": cred.get("db_user") or cred.get("email") or cred.get("username"),
+                    "access_type": AccessType.WEB_URL if is_pgadmin else AccessType.DATABASE,
+                    "username": cred.get("email") or cred.get("db_user") or cred.get("username"),
                     "password": cred.get("password"),
+                    "connection_url": pgadmin_url if is_pgadmin else None,
+                    "port": 80 if is_pgadmin else None,
                 })
+
             app_admin = application.get("admin_credentials")
             if app_admin:
                 entries.append({
-                    "access_type": AccessType.DATABASE,
-                    "username": app_admin.get("db_user") or app_admin.get("email") or app_admin.get("username"),
+                    "access_type": AccessType.WEB_URL if is_pgadmin else AccessType.DATABASE,
+                    "username": app_admin.get("email") or app_admin.get("db_user") or app_admin.get("username"),
                     "password": app_admin.get("password"),
+                    "connection_url": pgadmin_url if is_pgadmin else None,
+                    "port": 80 if is_pgadmin else None,
                 })
 
         return [e for e in entries if e.get("password")]

--- a/src/services/deployment_log_service.py
+++ b/src/services/deployment_log_service.py
@@ -4,16 +4,16 @@ from sqlalchemy.orm import Session
 
 from src.repositories.deployment_log_repository import DeploymentLogRepository
 from src.models.deployment_log import DeploymentLog, DeploymentLogLevel, DeploymentLogEventType
+from src.utils.log_sanitizer import sanitize_message, sanitize_details
 
 
 class DeploymentLogService:
     """Service for deployment log business logic."""
-    
+
     def __init__(self, db: Session):
-        """Initialize DeploymentLogService with database session."""
         self.db = db
         self.log_repo = DeploymentLogRepository(db)
-    
+
     def log(
         self,
         deployment_id: str,
@@ -23,37 +23,18 @@ class DeploymentLogService:
         details: dict | None = None,
         request_id: str | None = None
     ) -> DeploymentLog:
-        """Create a deployment log entry.
-        
-        Args:
-            deployment_id: ID of the deployment
-            event_type: Type of event
-            message: Log message
-            level: Log level (default: INFO)
-            details: Additional details as dictionary
-            request_id: Request correlation ID
-            
-        Returns:
-            Created DeploymentLog instance
-        """
-        details_json = json.dumps(details) if details else None
-        
+        clean_message = sanitize_message(message)
+        clean_details = sanitize_details(details) if details else None
+        details_json = json.dumps(clean_details) if clean_details else None
+
         return self.log_repo.create(
             deployment_id=deployment_id,
             level=level,
             event_type=event_type,
-            message=message,
+            message=clean_message,
             details_json=details_json,
             request_id=request_id
         )
-    
+
     def get_deployment_logs(self, deployment_id: str) -> list[DeploymentLog]:
-        """Get all logs for a deployment.
-        
-        Args:
-            deployment_id: ID of the deployment
-            
-        Returns:
-            List of deployment logs ordered by time
-        """
         return self.log_repo.get_by_deployment_id(deployment_id)

--- a/src/services/deployment_service.py
+++ b/src/services/deployment_service.py
@@ -60,28 +60,32 @@ class DeploymentService:
                 skip_access_check=True
             )
             template_params_map = {p.name: p for p in template_params_resp.parameters}
-            required_params = [p.name for p in template_params_resp.parameters if p.required]
         except NotFoundException:
             raise
         except Exception as e:
             raise BadRequestException(f"Failed to read template parameters: {e}")
 
-        provided = deployment_data.heat_parameters or {}
-        
-        # Check for missing required parameters (excluding user_json and admin_credentials which we generate)
+        provided = deployment_data.parameters or {}
+
+        # Backend always injects these — never required from the caller
+        backend_managed = {"user_json", "admin_credentials", "key_name"}
+
+        # Validate all required parameters from app.yaml are provided
+        required_params = [
+            p.name for p in template_params_resp.parameters
+            if p.required and p.name not in backend_managed
+        ]
         if required_params:
-            missing = [p for p in required_params if p not in provided and p not in ["user_json", "admin_credentials"] and provided.get(p) is None]
+            missing = [p for p in required_params if p not in provided]
             if missing:
                 raise BadRequestException(f"Missing required template parameters: {', '.join(missing)}")
-        
+
         # Type validation for provided parameters
         type_errors = []
         for param_name, param_value in provided.items():
             if param_name not in template_params_map:
                 continue
-            
             expected_type = template_params_map[param_name].type.lower()
-            
             if expected_type == "boolean":
                 if not isinstance(param_value, bool):
                     type_errors.append(f"{param_name}: expected boolean, got {type(param_value).__name__}")
@@ -91,7 +95,6 @@ class DeploymentService:
             elif expected_type == "string":
                 if not isinstance(param_value, str):
                     type_errors.append(f"{param_name}: expected string, got {type(param_value).__name__}")
-        
         if type_errors:
             raise BadRequestException(f"Type validation errors: {'; '.join(type_errors)}")
 
@@ -125,10 +128,9 @@ class DeploymentService:
             self.db.flush()  # Get the ID without committing
         
         # Store complete deployment info as JSON
-        # Note: user_json will be generated per-stack during deployment task
         deployment_parameters = json.dumps({
             "template_name": template.name,
-            "heat_parameters": provided,
+            "parameters": provided,
             "stack_assignments": [sa.model_dump() for sa in deployment_data.stack_assignments],
             "teacher": deployment_data.teacher.model_dump()
         })
@@ -155,7 +157,7 @@ class DeploymentService:
                 "keycloak_group_id": deployment_data.course_id,
                 "stack_count": len(deployment_data.stack_assignments),
                 "total_groups": sum(len(sa.groups) for sa in deployment_data.stack_assignments),
-                "has_heat_parameters": bool(deployment_data.heat_parameters)
+                "has_parameters": bool(deployment_data.parameters)
             },
             request_id=request_id
         )

--- a/src/services/openstack_heat_service.py
+++ b/src/services/openstack_heat_service.py
@@ -113,15 +113,33 @@ class HeatStackService:
             
             # Create stack
             stack = conn.orchestration.create_stack(preview=False, **stack_params)
-            
             logger.info(f"Heat stack created successfully: {stack.id}")
-            
+
+            # Wait until CREATE_COMPLETE — SDK polls every 5s, timeout 30min
+            logger.info(f"Waiting for stack {stack.id} to reach CREATE_COMPLETE...")
+            stack = conn.orchestration.wait_for_status(
+                stack,
+                status="CREATE_COMPLETE",
+                failures=["CREATE_FAILED"],
+                interval=5,
+                wait=1800,
+            )
+            logger.info(f"Stack {stack.id} reached status: {stack.status}")
+
+            # Read outputs (floating_ip, server_id, etc.)
+            outputs = {}
+            if stack.outputs:
+                for output in stack.outputs:
+                    outputs[output["output_key"]] = output["output_value"]
+
             return {
                 'stack_id': stack.id,
                 'stack_name': stack.name,
                 'status': stack.status,
                 'status_reason': stack.status_reason,
                 'creation_time': str(stack.created_at) if stack.created_at else None,
+                'floating_ip': outputs.get('floating_ip'),
+                'outputs': outputs,
             }
             
         except HttpException as e:

--- a/src/services/openstack_project_service.py
+++ b/src/services/openstack_project_service.py
@@ -165,6 +165,17 @@ class OpenstackProjectService:
                     "openstack_project_id": credentials.openstack_project_id,
                 }
             )
+
+            # Register Ansible keypair in the new project
+            try:
+                from src.services.ansible_keypair_service import AnsibleKeypairService
+                AnsibleKeypairService.ensure_keypair(project)
+            except Exception as keypair_error:
+                logger.warning(
+                    f"Could not register Ansible keypair in project {credentials.openstack_project_id}: {keypair_error}. "
+                    "Deployment will fail if Ansible is used. Check ANSIBLE_SSH_KEY_PATH."
+                )
+
             return project
         except Exception as e:
             # _handle_integrity_error always raises an exception, never returns
@@ -262,6 +273,16 @@ class OpenstackProjectService:
                 "openstack_project_id": credentials.openstack_project_id,
             }
         )
+
+        # Re-check keypair in case the project changed
+        try:
+            from src.services.ansible_keypair_service import AnsibleKeypairService
+            AnsibleKeypairService.ensure_keypair(project)
+        except Exception as keypair_error:
+            logger.warning(
+                f"Could not register Ansible keypair after credentials update: {keypair_error}"
+            )
+
         return project
     
     def get_credentials(

--- a/src/services/template_version_file_service.py
+++ b/src/services/template_version_file_service.py
@@ -6,7 +6,7 @@ import logging
 
 from sqlalchemy.orm import Session
 
-from src.models.template_version_file import TemplateVersionFile
+from src.models.template_version_file import TemplateVersionFile, FileType
 from src.models.template import Template, TemplateVisibility, TemplateApprovalStatus
 from src.repositories.template_version_file_repository import TemplateVersionFileRepository
 from src.repositories.template_version_repository import TemplateVersionRepository
@@ -127,7 +127,7 @@ class TemplateVersionFileService:
         file, _ = self.file_repo.upsert(
             template_version_id=file_data.template_version_id,
             file_name=file_data.file_name,
-            file_type=file_data.file_type,
+            file_type=FileType(file_data.file_type),
             file_path=file_data.file_path,
             content=file_data.content,
             file_size=file_data.file_size,

--- a/src/services/template_version_file_service.py
+++ b/src/services/template_version_file_service.py
@@ -108,26 +108,23 @@ class TemplateVersionFileService:
         self,
         file_data: TemplateVersionFileCreate
     ) -> TemplateVersionFile:
-        """Create a new template version file.
-        
-        Args:
-            file_data: File creation data
-            
-        Returns:
-            Created file
-            
+        """Create or update a template version file (upsert by file_path).
+
+        If a file with the same (template_version_id, file_path) already exists
+        it is updated instead of creating a duplicate.
+
         Raises:
             BadRequestException: If trying to set multiple primary files
         """
         # Check if setting as primary and another primary file exists
         if file_data.is_primary:
             existing_primary = self.file_repo.get_primary_file(file_data.template_version_id)
-            if existing_primary:
+            if existing_primary and existing_primary.file_path != file_data.file_path:
                 raise BadRequestException(
                     f"Template version {file_data.template_version_id} already has a primary file: {existing_primary.file_name}"
                 )
-        
-        file = self.file_repo.create(
+
+        file, _ = self.file_repo.upsert(
             template_version_id=file_data.template_version_id,
             file_name=file_data.file_name,
             file_type=file_data.file_type,
@@ -136,7 +133,7 @@ class TemplateVersionFileService:
             file_size=file_data.file_size,
             description=file_data.description,
             is_primary=file_data.is_primary,
-            order=file_data.order
+            order=file_data.order,
         )
         return file
 

--- a/src/services/template_version_service.py
+++ b/src/services/template_version_service.py
@@ -436,22 +436,24 @@ class TemplateVersionService:
         
         # Try to find and parse app.yaml
         parameters = []
-        
+        user_files = []
+        allow_user_files = False
+
         try:
-            # Get app manifest file
             files = self.file_repo.get_by_version_id(version_id, include_content=True)
             app_manifest_file = None
-            
+
             for file in files:
                 if file.file_type == FileType.APP_MANIFEST or file.file_name.lower() == "app.yaml":
                     app_manifest_file = file
                     break
-            
+
             if app_manifest_file and app_manifest_file.content:
-                # Parse the app.yaml content and extract only parameters
                 parsed_manifest = AppManifestParser.parse(app_manifest_file.content)
                 parameters = parsed_manifest.get("parameters", [])
-                
+                user_files = parsed_manifest.get("user_files", [])
+                allow_user_files = parsed_manifest.get("app", {}).get("allow_user_files", False)
+
                 logger.info(
                     f"Loaded {len(parameters)} parameters for version {version_id}"
                 )
@@ -459,11 +461,12 @@ class TemplateVersionService:
             logger.warning(
                 f"Failed to parse app manifest for version {version_id}: {e}"
             )
-        
-        # Build result dictionary with only parameters
+
         result_dict = {
             "version": version,
-            "parameters": parameters
+            "parameters": parameters,
+            "user_files": user_files,
+            "allow_user_files": allow_user_files,
         }
         
         if file_count is not None:

--- a/src/tasks/deploy_tasks.py
+++ b/src/tasks/deploy_tasks.py
@@ -62,7 +62,6 @@ def deploy_stack(self, deployment_id: str) -> dict:
 
         try:
             deployment_params = json.loads(deployment.deployment_parameters)
-            template_name = deployment_params.get("template_name", "unknown")
             all_parameters = deployment_params.get("parameters", {})
             stack_assignments_raw = deployment_params.get("stack_assignments", [])
             teacher_info = deployment_params.get("teacher", {})
@@ -103,7 +102,7 @@ def deploy_stack(self, deployment_id: str) -> dict:
 
         # Parse app.yaml for credentials spec and playbook list
         app_yaml_file = next((f for f in files if f.file_name == "app.yaml"), None)
-        credentials_spec = {"per_student": [], "teacher": []}
+        credentials_spec: dict[str, list] = {"per_student": [], "teacher": []}
         playbooks: list[tuple[str, str]] = []
         scripts: dict[str, str] = {}
         template_files: dict[str, str] = {}

--- a/src/tasks/deploy_tasks.py
+++ b/src/tasks/deploy_tasks.py
@@ -163,6 +163,7 @@ def deploy_stack(self, deployment_id: str) -> dict:
         failed_stacks = []
 
         for idx, stack_assignment_data in enumerate(stack_assignments_raw, start=1):
+            stack_id = None  # set after Heat succeeds
             try:
                 stack_assignment = StackAssignment(**stack_assignment_data)
 
@@ -173,24 +174,7 @@ def deploy_stack(self, deployment_id: str) -> dict:
                     teacher=teacher,
                 )
 
-                # Build Heat extra parameter (user_json) — keep backwards compat
-                import base64
-                from src.services.template_user_management_service import TemplateUserManagementService
-                min_pw = int(base_heat_parameters.get("pw_min_length", 12))
-                user_json_data = TemplateUserManagementService.generate_user_json_for_stack(
-                    template_name=template_name,
-                    course_label=deployment.name,
-                    stack_assignment=stack_assignment,
-                    teacher=teacher,
-                    min_password_length=min_pw,
-                )
-                user_json_b64 = base64.b64encode(
-                    json.dumps(user_json_data, ensure_ascii=False).encode()
-                ).decode("ascii")
-
                 stack_params = {**base_heat_parameters}
-                if "user_json" in heat_defined_params:
-                    stack_params["user_json"] = user_json_b64
                 stack_params["key_name"] = get_settings().ansible_ssh_key_name
                 stack_name = f"{deployment.name}-s{idx}-{deployment_id[:4]}"
                 stack_name = stack_name.replace(" ", "-").replace("_", "-").lower()[:64]
@@ -230,11 +214,30 @@ def deploy_stack(self, deployment_id: str) -> dict:
                 )
 
                 try:
+                    # Build user_json from `generated` so DB passwords match what Ansible sets
+                    credentials_for_db = {
+                        "instance": {
+                            "credentials": [
+                                {
+                                    "username": s["linux"]["username"],
+                                    "password": s["linux"]["password"],
+                                }
+                                for s in generated.get("students", [])
+                                if s.get("linux", {}).get("password")
+                            ],
+                            "admin_credentials": {
+                                "username": generated["teacher"]["linux"]["username"],
+                                "password": generated["teacher"]["linux"]["password"],
+                            } if generated.get("teacher", {}).get("linux", {}).get("password") else None,
+                        },
+                    }
                     DeploymentCredentialService(db).persist_credentials_for_stack(
                         deployment_id=deployment_id,
                         stack_name=stack_name,
                         openstack_stack_id=stack_id,
-                        user_json=user_json_data,
+                        user_json=credentials_for_db,
+                        floating_ip=stack_result.get("floating_ip") or "",
+                        heat_outputs=stack_result.get("outputs") or {},
                     )
                 except Exception as cred_error:
                     logger.error(f"Failed to persist credentials for stack {idx}: {cred_error}", exc_info=True)
@@ -272,9 +275,9 @@ def deploy_stack(self, deployment_id: str) -> dict:
                             "course_label": deployment.name,
                             "stack_label": stack_name,
                             "ssh_allow_users": [
-                                s["username"]
+                                s["linux"]["username"]
                                 for s in generated.get("students", [])
-                                if "linux" in s
+                                if s.get("linux", {}).get("password")
                             ],
                         }
                         ansible.run_playbooks(playbooks=playbooks, extra_vars=extra_vars)
@@ -290,7 +293,7 @@ def deploy_stack(self, deployment_id: str) -> dict:
                 logger.error(error_msg, exc_info=True)
                 log_service.log(
                     deployment_id=deployment_id,
-                    event_type=DeploymentLogEventType.FAILED,
+                    event_type=DeploymentLogEventType.ANSIBLE_FAILED if stack_id else DeploymentLogEventType.FAILED,
                     message=error_msg,
                     level=DeploymentLogLevel.ERROR,
                     details={"error": str(stack_error), "stack_index": idx},
@@ -313,8 +316,9 @@ def deploy_stack(self, deployment_id: str) -> dict:
             repo.update_status(deployment_id, DeploymentStatus.FAILED)
             return {"status": "failed", "error": f"All {len(failed_stacks)} stacks failed", "failed_stacks": failed_stacks}
         elif failed_stacks:
-            repo.update_status(deployment_id, DeploymentStatus.RUNNING)
-            return {"status": "partial", "created_stacks": len(created_stack_ids), "failed_stacks": failed_stacks}
+            # Some stacks failed (e.g. Ansible error) — mark as FAILED even if Heat succeeded
+            repo.update_status(deployment_id, DeploymentStatus.FAILED)
+            return {"status": "failed", "created_stacks": len(created_stack_ids), "failed_stacks": failed_stacks}
         else:
             repo.update_status(deployment_id, DeploymentStatus.RUNNING)
             return {"status": "success", "stack_count": len(created_stack_ids), "stack_ids": created_stack_ids}
@@ -471,6 +475,26 @@ def delete_deployment(self, deployment_id: str) -> dict:
             logger.info(f"Deleted {logs_deleted} log entries for deployment {deployment_id}")
         except Exception as e:
             logger.warning(f"Failed to delete logs for deployment {deployment_id}: {e}")
+
+        # Delete deployment_instances (FK prevents deleting deployment record otherwise)
+        try:
+            from src.models.deployment_instance import DeploymentInstance
+            from src.models.deployment_instance_access import DeploymentInstanceAccess
+            instances = db.query(DeploymentInstance).filter(
+                DeploymentInstance.deployment_id == deployment_id
+            ).all()
+            for inst in instances:
+                db.query(DeploymentInstanceAccess).filter(
+                    DeploymentInstanceAccess.deployment_instance_id == inst.id
+                ).delete(synchronize_session=False)
+            db.query(DeploymentInstance).filter(
+                DeploymentInstance.deployment_id == deployment_id
+            ).delete(synchronize_session=False)
+            db.commit()
+            logger.info(f"Deleted {len(instances)} deployment instance(s) for {deployment_id}")
+        except Exception as e:
+            logger.warning(f"Failed to delete deployment instances for {deployment_id}: {e}")
+            db.rollback()
         
         # Finally delete DB record
         try:

--- a/src/tasks/deploy_tasks.py
+++ b/src/tasks/deploy_tasks.py
@@ -2,6 +2,7 @@
 import json
 import logging
 from uuid import UUID
+
 from src.celery_app import celery_app
 from src.core.database import SessionLocal
 from src.models.deployment import DeploymentStatus
@@ -14,225 +15,167 @@ from src.services.template_version_file_service import TemplateVersionFileServic
 from src.services.deployment_log_service import DeploymentLogService
 from src.services.deployment_credential_service import DeploymentCredentialService
 from src.services.openstack_heat_service import HeatStackService
+from src.services.ansible_service import AnsibleService
+from src.services.credential_generator_service import CredentialGeneratorService
+from src.utils.app_manifest_parser import AppManifestParser
+from src.core.config import get_settings
 
 logger = logging.getLogger(__name__)
 
 
 @celery_app.task(bind=True)
 def deploy_stack(self, deployment_id: str) -> dict:
-    """Deploy Heat stacks asynchronously for a deployment.
-    
-    Orchestrates OpenStack Heat stack creation for a deployment.
-    Creates ONE Heat stack per stack_assignment with its own user_json.
-    Updates deployment status throughout the process.
-    
-    Args:
-        deployment_id: ID of the deployment to process
-        
-    Returns:
-        Deployment result with status and task information
+    """Deploy Heat stacks and run Ansible playbooks for a deployment.
+
+    Flow per stack_assignment:
+      1. Create Heat stack
+      2. Wait for SSH
+      3. Copy scripts/ and files/ to VM
+      4. Run playbooks/ in order with generated credentials as extra-vars
     """
     task_id = self.request.id
     logger.info(f"Starting deployment task for deployment_id={deployment_id}, task_id={task_id}")
-    
+
     db = SessionLocal()
     try:
         repo = DeploymentRepository(db)
         log_service = DeploymentLogService(db)
         file_service = TemplateVersionFileService(db)
-        
+
         deployment = repo.get_by_id(deployment_id)
-        
         if not deployment:
             logger.error(f"Deployment not found: {deployment_id}")
             return {"status": "failed", "error": "Deployment not found"}
-        
-        # Log: Deployment started
+
         log_service.log(
             deployment_id=deployment_id,
             event_type=DeploymentLogEventType.DEPLOYMENT_STARTED,
             message=f"Deployment task started (task_id: {task_id})",
             level=DeploymentLogLevel.INFO,
-            details={
-                "task_id": task_id,
-                "template_version_id": deployment.template_version_id,
-                "course_id": deployment.course_id,
-                "keycloak_group_id": deployment.course_id
-            }
+            details={"task_id": task_id, "template_version_id": deployment.template_version_id},
         )
-        
-        # Update status to CREATING
         repo.update_status(deployment_id, DeploymentStatus.CREATING)
-        logger.info(f"Deployment {deployment_id} status updated to CREATING")
-        
-        # Parse deployment_parameters to get stack_assignments, teacher, and template name
+
+        # --- Parse deployment parameters ---
         if not deployment.deployment_parameters:
-            error_msg = "No deployment_parameters found in deployment"
-            logger.error(error_msg)
-            log_service.log(
-                deployment_id=deployment_id,
-                event_type=DeploymentLogEventType.FAILED,
-                message=error_msg,
-                level=DeploymentLogLevel.ERROR
-            )
-            repo.update_status(deployment_id, DeploymentStatus.FAILED)
-            return {"status": "failed", "error": error_msg}
-        
+            return _fail(repo, log_service, deployment_id, "No deployment_parameters found")
+
         try:
             deployment_params = json.loads(deployment.deployment_parameters)
             template_name = deployment_params.get("template_name", "unknown")
-            base_heat_parameters = deployment_params.get("heat_parameters", {})
-            stack_assignments = deployment_params.get("stack_assignments", [])
+            all_parameters = deployment_params.get("parameters", {})
+            stack_assignments_raw = deployment_params.get("stack_assignments", [])
             teacher_info = deployment_params.get("teacher", {})
-            
-            if not stack_assignments:
-                error_msg = "No stack_assignments found in deployment_parameters"
-                logger.error(error_msg)
-                log_service.log(
-                    deployment_id=deployment_id,
-                    event_type=DeploymentLogEventType.FAILED,
-                    message=error_msg,
-                    level=DeploymentLogLevel.ERROR
-                )
-                repo.update_status(deployment_id, DeploymentStatus.FAILED)
-                return {"status": "failed", "error": error_msg}
-            
-            logger.info(f"Found {len(stack_assignments)} stack assignments to deploy")
-            
         except json.JSONDecodeError as e:
-            error_msg = f"Invalid deployment_parameters JSON: {e}"
-            logger.error(error_msg)
-            log_service.log(
-                deployment_id=deployment_id,
-                event_type=DeploymentLogEventType.FAILED,
-                message=error_msg,
-                level=DeploymentLogLevel.ERROR
-            )
-            repo.update_status(deployment_id, DeploymentStatus.FAILED)
-            return {"status": "failed", "error": error_msg}
-        
-        # Fetch template version files ONCE (used for all stacks)
-        logger.info(f"Fetching template files for version {deployment.template_version_id}")
-        log_service.log(
-            deployment_id=deployment_id,
-            event_type=DeploymentLogEventType.DEPLOYMENT_STARTED,
-            message=f"Fetching template files for version {deployment.template_version_id}",
-            level=DeploymentLogLevel.INFO
-        )
-        
+            return _fail(repo, log_service, deployment_id, f"Invalid deployment_parameters JSON: {e}")
+
+        if not stack_assignments_raw:
+            return _fail(repo, log_service, deployment_id, "No stack_assignments found")
+
+        # --- Load template files from DB ---
         files = file_service.get_version_files(
-            deployment.template_version_id,
-            include_content=True,
-            skip_access_check=True
+            deployment.template_version_id, include_content=True, skip_access_check=True
         )
-        
         if not files:
-            error_msg = f"No files found for template version {deployment.template_version_id}"
-            logger.error(error_msg)
-            log_service.log(
-                deployment_id=deployment_id,
-                event_type=DeploymentLogEventType.FAILED,
-                message=error_msg,
-                level=DeploymentLogLevel.ERROR
-            )
-            repo.update_status(deployment_id, DeploymentStatus.FAILED)
-            return {"status": "failed", "error": error_msg}
-        
-        # Find primary Heat template
+            return _fail(repo, log_service, deployment_id, f"No files found for template version {deployment.template_version_id}")
+
         heat_file = next((f for f in files if f.is_primary), None)
         if not heat_file or not heat_file.content:
-            error_msg = "No primary Heat template found or template has no content"
-            logger.error(error_msg)
-            log_service.log(
-                deployment_id=deployment_id,
-                event_type=DeploymentLogEventType.FAILED,
-                message=error_msg,
-                level=DeploymentLogLevel.ERROR,
-                details={"available_files": [f.file_name for f in files]}
-            )
-            repo.update_status(deployment_id, DeploymentStatus.FAILED)
-            return {"status": "failed", "error": error_msg}
-        
-        logger.info(f"Found Heat template: {heat_file.file_name} ({len(heat_file.content)} bytes)")
-        
-        # Get lecturer OpenStack project
+            return _fail(repo, log_service, deployment_id, "No primary Heat template found")
+
+        # Split parameters: Heat gets only what heat/main.yaml defines, Ansible gets the rest
+        import yaml as _yaml
+        try:
+            heat_template_parsed = _yaml.safe_load(heat_file.content)
+            heat_defined_params = set(heat_template_parsed.get("parameters", {}).keys())
+        except Exception:
+            heat_defined_params = set()
+
+        backend_managed = {"user_json", "key_name"}
+        base_heat_parameters = {
+            k: v for k, v in all_parameters.items()
+            if k in heat_defined_params and k not in backend_managed
+        }
+        ansible_parameters = {
+            k: v for k, v in all_parameters.items()
+            if k not in heat_defined_params
+        }
+
+        # Parse app.yaml for credentials spec and playbook list
+        app_yaml_file = next((f for f in files if f.file_name == "app.yaml"), None)
+        credentials_spec = {"per_student": [], "teacher": []}
+        playbooks: list[tuple[str, str]] = []
+        scripts: dict[str, str] = {}
+        template_files: dict[str, str] = {}
+
+        if app_yaml_file and app_yaml_file.content:
+            manifest = AppManifestParser.parse(app_yaml_file.content)
+            credentials_spec = manifest.get("credentials", credentials_spec)
+
+        # Load _common playbooks first (sorted by filename → 00_, 01_, ...)
+        from pathlib import Path
+        common_playbooks_dir = Path(__file__).parent.parent / "_common" / "playbooks"
+        if common_playbooks_dir.exists():
+            for common_file in sorted(common_playbooks_dir.glob("*.yml")):
+                playbooks.append((f"_common/{common_file.name}", common_file.read_text()))
+
+        # Then template-specific playbooks
+        for f in sorted(files, key=lambda x: (x.order, x.file_name)):
+            if f.file_type == FileType.ANSIBLE_PLAYBOOK and f.content:
+                playbooks.append((f.file_name, f.content))
+            elif f.file_type == FileType.SHELL_SCRIPT and f.content:
+                scripts[f.file_name] = f.content
+            elif f.file_type == FileType.CONFIG_FILE and f.content:
+                template_files[f.file_name] = f.content
+
+        # --- Get OpenStack credentials ---
         teacher_keycloak_id = teacher_info.get("id")
         if not teacher_keycloak_id:
-            error_msg = "No teacher information found in deployment parameters"
-            logger.error(error_msg)
-            log_service.log(
-                deployment_id=deployment_id,
-                event_type=DeploymentLogEventType.FAILED,
-                message=error_msg,
-                level=DeploymentLogLevel.ERROR
-            )
-            repo.update_status(deployment_id, DeploymentStatus.FAILED)
-            return {"status": "failed", "error": error_msg}
-        
-        # Map Keycloak ID to local user ID
+            return _fail(repo, log_service, deployment_id, "No teacher information found")
+
         from src.models.user import User
         lecturer_user = db.query(User).filter(User.external_id == teacher_keycloak_id).first()
-        
         if not lecturer_user:
-            error_msg = f"No user found for Keycloak ID {teacher_keycloak_id}"
-            logger.error(error_msg)
-            log_service.log(
-                deployment_id=deployment_id,
-                event_type=DeploymentLogEventType.FAILED,
-                message=error_msg,
-                level=DeploymentLogLevel.ERROR
-            )
-            repo.update_status(deployment_id, DeploymentStatus.FAILED)
-            return {"status": "failed", "error": error_msg}
-        
-        lecturer_id = lecturer_user.id
-        
-        # Get lecturer's OpenStack project
+            return _fail(repo, log_service, deployment_id, f"No user found for Keycloak ID {teacher_keycloak_id}")
+
         openstack_repo = OpenstackProjectRepository(db)
-        openstack_projects = openstack_repo.get_by_owner(lecturer_id)
+        openstack_projects = openstack_repo.get_by_owner(lecturer_user.id)
         if not openstack_projects:
-            error_msg = f"No OpenStack project found for lecturer {lecturer_id}"
-            logger.error(error_msg)
-            log_service.log(
-                deployment_id=deployment_id,
-                event_type=DeploymentLogEventType.FAILED,
-                message=error_msg,
-                level=DeploymentLogLevel.ERROR,
-                details={"lecturer_id": lecturer_id}
-            )
-            repo.update_status(deployment_id, DeploymentStatus.FAILED)
-            return {"status": "failed", "error": error_msg}
-        
+            return _fail(repo, log_service, deployment_id, f"No OpenStack project found for lecturer {lecturer_user.id}")
+
         openstack_project = openstack_projects[0]
-        logger.info(f"Using OpenStack project {openstack_project.openstack_project_name} for lecturer {lecturer_id}")
-        
-        # Initialize Heat service ONCE
         heat_service = HeatStackService(openstack_project)
-        
-        # Prepare cloud-init files dictionary (same for all stacks)
+
+        # SSH private key from settings (shared backend key, not per-project)
+        ssh_private_key = get_settings().ansible_ssh_private_key or ""
+
+        # cloud-init files dict for Heat
         files_dict = {}
-        for template_file in files:
-            if template_file.file_type == FileType.CLOUD_INIT and template_file.content:
-                files_dict['../cloud-init/user-data.yaml'] = template_file.content
-                logger.info("Including cloud-init file in stack files")
-        
-        # Create ONE Heat stack per stack_assignment
+        for f in files:
+            if f.file_type == FileType.CLOUD_INIT and f.content:
+                files_dict["../cloud-init/user-data.yaml"] = f.content
+
+        # Reconstruct Pydantic objects
+        from src.schemas.deployment import StackAssignment, TeacherInfo
+        teacher = TeacherInfo(**teacher_info)
+
         created_stack_ids = []
         failed_stacks = []
-        
-        from src.services.template_user_management_service import TemplateUserManagementService
-        from src.schemas.deployment import StackAssignment, TeacherInfo
-        
-        for idx, stack_assignment_data in enumerate(stack_assignments, start=1):
+
+        for idx, stack_assignment_data in enumerate(stack_assignments_raw, start=1):
             try:
-                # Reconstruct Pydantic objects from JSON
                 stack_assignment = StackAssignment(**stack_assignment_data)
-                teacher = TeacherInfo(**teacher_info)
-                
-                # Generate user_json for THIS specific stack
-                # Pass pw_min_length from heat_parameters so generated passwords
-                # satisfy the per-deployment pwquality policy that cloud-init enforces
-                # via PAM (chpasswd would otherwise reject overly short passwords).
+
+                # --- Generate credentials from app.yaml spec ---
+                generated = CredentialGeneratorService.generate(
+                    credentials_spec=credentials_spec,
+                    stack_assignment=stack_assignment,
+                    teacher=teacher,
+                )
+
+                # Build Heat extra parameter (user_json) — keep backwards compat
+                import base64
+                from src.services.template_user_management_service import TemplateUserManagementService
                 min_pw = int(base_heat_parameters.get("pw_min_length", 12))
                 user_json_data = TemplateUserManagementService.generate_user_json_for_stack(
                     template_name=template_name,
@@ -241,70 +184,49 @@ def deploy_stack(self, deployment_id: str) -> dict:
                     teacher=teacher,
                     min_password_length=min_pw,
                 )
+                user_json_b64 = base64.b64encode(
+                    json.dumps(user_json_data, ensure_ascii=False).encode()
+                ).decode("ascii")
 
-                # Base64-encode JSON to avoid YAML parsing issues when inserted via str_replace
-                # Cloud-init will decode it back to JSON
-                import base64
-                user_json_string = json.dumps(user_json_data, ensure_ascii=False)
-                user_json_b64 = base64.b64encode(user_json_string.encode('utf-8')).decode('ascii')
-                logger.debug(f"Generated user_json for stack {idx}: {len(user_json_string)} chars, {len(user_json_b64)} chars base64")
-                
-                # Merge base parameters with stack-specific user_json (base64-encoded)
-                stack_params = {
-                    **base_heat_parameters,
-                    "user_json": user_json_b64
-                }
-                
-                # Generate unique stack name
+                stack_params = {**base_heat_parameters}
+                if "user_json" in heat_defined_params:
+                    stack_params["user_json"] = user_json_b64
+                stack_params["key_name"] = get_settings().ansible_ssh_key_name
                 stack_name = f"{deployment.name}-s{idx}-{deployment_id[:4]}"
                 stack_name = stack_name.replace(" ", "-").replace("_", "-").lower()[:64]
-                
                 tags = {
                     "deployment_id": deployment_id,
                     "course_id": deployment.course_id,
                     "template_version_id": deployment.template_version_id,
-                    "stack_index": str(idx)
+                    "stack_index": str(idx),
                 }
-                
-                logger.info(f"Creating Heat stack {idx}/{len(stack_assignments)}: {stack_name}")
+
                 log_service.log(
                     deployment_id=deployment_id,
                     event_type=DeploymentLogEventType.DEPLOYMENT_STARTED,
-                    message=f"Creating Heat stack {idx}/{len(stack_assignments)}: {stack_name}",
+                    message=f"Creating Heat stack {idx}/{len(stack_assignments_raw)}: {stack_name}",
                     level=DeploymentLogLevel.INFO,
-                    details={
-                        "stack_index": idx,
-                        "stack_name": stack_name,
-                        "groups_count": len(stack_assignment.groups),
-                        "parameters": list(stack_params.keys())
-                    }
+                    details={"stack_index": idx, "stack_name": stack_name},
                 )
-                
-                # Create stack via OpenStack Heat API
+
+                # --- 1. Create Heat stack ---
                 stack_result = heat_service.create_stack(
                     stack_name=stack_name,
                     template=heat_file.content,
                     parameters=stack_params,
-                    files=files_dict if files_dict else None,
+                    files=files_dict or None,
                     tags=tags,
-                    timeout_mins=60
+                    timeout_mins=60,
                 )
-                
-                stack_id = stack_result['stack_id']
+                stack_id = stack_result["stack_id"]
                 created_stack_ids.append(stack_id)
-                logger.info(f"Heat stack {idx} created successfully: {stack_id}")
-                
+
                 log_service.log(
                     deployment_id=deployment_id,
                     event_type=DeploymentLogEventType.STACK_CREATE,
                     message=f"Heat stack {idx} created: {stack_name}",
                     level=DeploymentLogLevel.INFO,
-                    details={
-                        "stack_id": stack_id,
-                        "stack_name": stack_name,
-                        "stack_index": idx,
-                        "status": stack_result['status'],
-                    }
+                    details={"stack_id": stack_id, "stack_name": stack_name, "stack_index": idx},
                 )
 
                 try:
@@ -315,9 +237,6 @@ def deploy_stack(self, deployment_id: str) -> dict:
                         user_json=user_json_data,
                     )
                 except Exception as cred_error:
-                    # Best-effort: a failure to record credentials must not roll back the
-                    # stack itself. Surface the error in the deployment log so the lecturer
-                    # knows credentials need to be retrieved another way.
                     logger.error(f"Failed to persist credentials for stack {idx}: {cred_error}", exc_info=True)
                     log_service.log(
                         deployment_id=deployment_id,
@@ -326,174 +245,82 @@ def deploy_stack(self, deployment_id: str) -> dict:
                         level=DeploymentLogLevel.ERROR,
                         details={"stack_index": idx, "error": str(cred_error)}
                     )
-                
+
+                # --- 2+3+4. Ansible (only if playbooks exist and SSH key available) ---
+                if playbooks and ssh_private_key:
+                    floating_ip = stack_result.get("floating_ip", "")
+                    if not floating_ip:
+                        log_service.log(
+                            deployment_id=deployment_id,
+                            event_type=DeploymentLogEventType.ANSIBLE_FAILED,
+                            message=f"No floating_ip in stack result for stack {idx} — skipping Ansible",
+                            level=DeploymentLogLevel.WARNING,
+                        )
+                    else:
+                        ansible = AnsibleService(
+                            db=db,
+                            deployment_id=deployment_id,
+                            floating_ip=floating_ip,
+                            ssh_private_key=ssh_private_key,
+                        )
+                        ansible.wait_for_ssh()
+                        ansible.copy_files(scripts=scripts, files=template_files)
+
+                        extra_vars = {
+                            **generated,
+                            **ansible_parameters,
+                            "course_label": deployment.name,
+                            "stack_label": stack_name,
+                            "ssh_allow_users": [
+                                s["username"]
+                                for s in generated.get("students", [])
+                                if "linux" in s
+                            ],
+                        }
+                        ansible.run_playbooks(playbooks=playbooks, extra_vars=extra_vars)
+                elif playbooks and not ssh_private_key:
+                    log_service.log(
+                        deployment_id=deployment_id,
+                        event_type=DeploymentLogEventType.ANSIBLE_FAILED,
+                        message="Playbooks defined but no SSH private key configured — skipping Ansible",
+                        level=DeploymentLogLevel.WARNING,
+                    )
             except Exception as stack_error:
-                error_msg = f"Failed to create Heat stack {idx}: {str(stack_error)}"
+                error_msg = f"Failed to deploy stack {idx}: {str(stack_error)}"
                 logger.error(error_msg, exc_info=True)
                 log_service.log(
                     deployment_id=deployment_id,
                     event_type=DeploymentLogEventType.FAILED,
                     message=error_msg,
                     level=DeploymentLogLevel.ERROR,
-                    details={"error": str(stack_error), "stack_index": idx}
+                    details={"error": str(stack_error), "stack_index": idx},
                 )
                 failed_stacks.append({"index": idx, "error": str(stack_error)})
-        
-        # Store all stack IDs as JSON array
+
+        # --- Store results ---
         if created_stack_ids:
             deployment.openstack_stack_id = json.dumps(created_stack_ids)
             db.commit()
-            logger.info(f"Stored {len(created_stack_ids)} stack IDs: {created_stack_ids}")
             log_service.log(
                 deployment_id=deployment_id,
                 event_type=DeploymentLogEventType.VM_READY,
-                message=f"Created {len(created_stack_ids)}/{len(stack_assignments)} Heat stacks",
+                message=f"Created {len(created_stack_ids)}/{len(stack_assignments_raw)} stacks",
                 level=DeploymentLogLevel.INFO,
-                details={
-                    "stack_ids": created_stack_ids,
-                    "total_stacks": len(stack_assignments),
-                    "failed_stacks": len(failed_stacks)
-                }
+                details={"stack_ids": created_stack_ids, "failed_stacks": len(failed_stacks)},
             )
-        
-        # Update deployment status based on results
+
         if failed_stacks and not created_stack_ids:
-            # All stacks failed
             repo.update_status(deployment_id, DeploymentStatus.FAILED)
-            return {
-                "status": "failed",
-                "error": f"All {len(failed_stacks)} stacks failed",
-                "failed_stacks": failed_stacks
-            }
+            return {"status": "failed", "error": f"All {len(failed_stacks)} stacks failed", "failed_stacks": failed_stacks}
         elif failed_stacks:
-            # Partial failure
-            logger.warning(f"Partial deployment success: {len(created_stack_ids)} succeeded, {len(failed_stacks)} failed")
             repo.update_status(deployment_id, DeploymentStatus.RUNNING)
-            return {
-                "status": "partial",
-                "created_stacks": len(created_stack_ids),
-                "failed_stacks": failed_stacks
-            }
+            return {"status": "partial", "created_stacks": len(created_stack_ids), "failed_stacks": failed_stacks}
         else:
-            # All stacks succeeded
             repo.update_status(deployment_id, DeploymentStatus.RUNNING)
-            logger.info(f"All {len(created_stack_ids)} stacks created successfully")
-            return {
-                "status": "success",
-                "stack_count": len(created_stack_ids),
-                "stack_ids": created_stack_ids
-            }
-        
-        try:
-            heat_service = HeatStackService(openstack_project)
-            
-            # Generate stack name based on deployment
-            stack_name = f"deployment-{deployment_id[:8]}-{deployment.course_id[:8]}"
-            
-            # Add deployment metadata as tags
-            tags = {
-                "deployment_id": deployment_id,
-                "course_id": deployment.course_id,
-                "template_version_id": deployment.template_version_id,
-            }
-            
-            logger.info(f"Creating Heat stack: {stack_name}")
-            
-            # Prepare files dictionary for get_file references in template
-            # Heat expects relative paths as used in get_file
-            files_dict = {}
-            for template_file in files:
-                if template_file.file_type == FileType.CLOUD_INIT and template_file.content:
-                    # Use path as referenced in template (e.g., ../cloud-init/user-data.yaml)
-                    files_dict['../cloud-init/user-data.yaml'] = template_file.content
-                    logger.info("Including cloud-init file in stack files")
-            
-            # Create stack via OpenStack Heat API
-            stack_result = heat_service.create_stack(
-                stack_name=stack_name,
-                template=heat_file.content,
-                parameters=stack_params,
-                files=files_dict if files_dict else None,
-                tags=tags,
-                timeout_mins=60
-            )
-            
-            stack_id = stack_result['stack_id']
-            logger.info(f"Heat stack created successfully: {stack_id}")
-            
-            log_service.log(
-                deployment_id=deployment_id,
-                event_type=DeploymentLogEventType.STACK_CREATE,
-                message=f"Heat stack created: {stack_name}",
-                level=DeploymentLogLevel.INFO,
-                details={
-                    "stack_id": stack_id,
-                    "stack_index": idx,
-                    "status": stack_result['status'],
-                }
-            )
-                
-        except Exception as stack_error:
-            error_msg = f"Failed to create Heat stack {idx}: {str(stack_error)}"
-            logger.error(error_msg, exc_info=True)
-            log_service.log(
-                deployment_id=deployment_id,
-                event_type=DeploymentLogEventType.FAILED,
-                message=error_msg,
-                level=DeploymentLogLevel.ERROR,
-                details={"error": str(stack_error), "stack_index": idx}
-            )
-            failed_stacks.append({"index": idx, "error": str(stack_error)})
-        
-        # Store all stack IDs as JSON array
-        if created_stack_ids:
-            deployment.openstack_stack_id = json.dumps(created_stack_ids)
-            db.commit()
-            logger.info(f"Stored {len(created_stack_ids)} stack IDs: {created_stack_ids}")
-            log_service.log(
-                deployment_id=deployment_id,
-                event_type=DeploymentLogEventType.VM_READY,
-                message=f"Created {len(created_stack_ids)}/{len(stack_assignments)} Heat stacks",
-                level=DeploymentLogLevel.INFO,
-                details={
-                    "stack_ids": created_stack_ids,
-                    "total_stacks": len(stack_assignments),
-                    "failed_stacks": len(failed_stacks)
-                }
-            )
-        
-        # Update deployment status based on results
-        if failed_stacks and not created_stack_ids:
-            # All stacks failed
-            repo.update_status(deployment_id, DeploymentStatus.FAILED)
-            return {
-                "status": "failed",
-                "error": f"All {len(failed_stacks)} stacks failed",
-                "failed_stacks": failed_stacks
-            }
-        elif failed_stacks:
-            # Partial failure
-            logger.warning(f"Partial deployment success: {len(created_stack_ids)} succeeded, {len(failed_stacks)} failed")
-            repo.update_status(deployment_id, DeploymentStatus.RUNNING)
-            return {
-                "status": "partial",
-                "created_stacks": len(created_stack_ids),
-                "failed_stacks": failed_stacks
-            }
-        else:
-            # All stacks succeeded
-            repo.update_status(deployment_id, DeploymentStatus.RUNNING)
-            logger.info(f"All {len(created_stack_ids)} stacks created successfully")
-            return {
-                "status": "success",
-                "stack_count": len(created_stack_ids),
-                "stack_ids": created_stack_ids
-            }
-    
+            return {"status": "success", "stack_count": len(created_stack_ids), "stack_ids": created_stack_ids}
+
     except Exception as e:
         logger.exception(f"Failed to deploy stacks for deployment {deployment_id}: {e}")
-        
-        # Log the failure
         try:
             log_service = DeploymentLogService(db)
             log_service.log(
@@ -501,29 +328,34 @@ def deploy_stack(self, deployment_id: str) -> dict:
                 event_type=DeploymentLogEventType.FAILED,
                 message=f"Deployment failed: {str(e)}",
                 level=DeploymentLogLevel.ERROR,
-                details={
-                    "error": str(e),
-                    "error_type": type(e).__name__
-                }
+                details={"error": str(e), "error_type": type(e).__name__},
             )
         except Exception as log_error:
             logger.error(f"Failed to log deployment error: {log_error}")
-        
-        # Update status to FAILED
-        if db:
-            try:
-                repo = DeploymentRepository(db)
-                repo.update_status(deployment_id, DeploymentStatus.FAILED)
-            except Exception as status_error:
-                logger.error(f"Failed to update deployment status: {status_error}")
-        
-        return {
-            "status": "failed",
-            "deployment_id": deployment_id,
-            "error": str(e)
-        }
+        try:
+            repo = DeploymentRepository(db)
+            repo.update_status(deployment_id, DeploymentStatus.FAILED)
+        except Exception:
+            pass
+        return {"status": "failed", "deployment_id": deployment_id, "error": str(e)}
     finally:
         db.close()
+
+
+def _fail(repo, log_service, deployment_id: str, error_msg: str) -> dict:
+    """Log error, set status to FAILED and return failure dict."""
+    logger.error(error_msg)
+    log_service.log(
+        deployment_id=deployment_id,
+        event_type=DeploymentLogEventType.FAILED,
+        message=error_msg,
+        level=DeploymentLogLevel.ERROR,
+    )
+    repo.update_status(deployment_id, DeploymentStatus.FAILED)
+    return {"status": "failed", "error": error_msg}
+
+
+
 
 
 @celery_app.task(bind=True)

--- a/src/utils/app_manifest_parser.py
+++ b/src/utils/app_manifest_parser.py
@@ -5,7 +5,7 @@ from typing import Optional, Any
 
 class AppManifestParameter:
     """Represents a parameter from app.yaml."""
-    
+
     def __init__(
         self,
         name: str,
@@ -29,9 +29,8 @@ class AppManifestParameter:
         self.step = step
         self.enum = enum
         self.hidden = hidden
-    
+
     def to_dict(self) -> dict:
-        """Convert parameter to dictionary."""
         result = {
             "name": self.name,
             "type": self.type,
@@ -39,60 +38,41 @@ class AppManifestParameter:
             "required": self.required,
             "secret": self.secret,
             "label": self.label,
-            "description": self.description
+            "description": self.description,
         }
-        
-        # Add optional fields only if they are set
         if self.step is not None:
             result["step"] = self.step
         if self.enum is not None:
             result["enum"] = self.enum
         if self.hidden:
             result["hidden"] = self.hidden
-        
         return result
 
 
 class AppManifestParser:
     """Parser for app.yaml manifest files."""
-    
+
     @staticmethod
     def parse(content: str) -> dict:
-        """Parse app.yaml content and extract metadata.
-        
-        Args:
-            content: Raw YAML content of app.yaml
-            
-        Returns:
-            Dictionary containing parsed app metadata including parameters
-            
-        Raises:
-            yaml.YAMLError: If YAML parsing fails
-            ValueError: If required fields are missing
+        """Parse app.yaml and return all sections.
+
+        Returns a dict with keys:
+          app, parameters, outputs, credentials, user_files
         """
         try:
             data = yaml.safe_load(content)
-            
             if not data:
                 raise ValueError("Empty YAML content")
-            
-            # Extract app metadata
+
             app_info = data.get("app", {})
-            
-            # Extract parameters
+
+            # Parameters
             parameters = []
-            params_list = data.get("parameters", [])
-            
-            for param in params_list:
-                if not isinstance(param, dict):
+            for param in data.get("parameters", []):
+                if not isinstance(param, dict) or not param.get("name"):
                     continue
-                    
-                name = param.get("name")
-                if not name:
-                    continue
-                
-                parameter = AppManifestParameter(
-                    name=name,
+                parameters.append(AppManifestParameter(
+                    name=param["name"],
                     type=param.get("type", "string"),
                     default=param.get("default"),
                     required=param.get("required", False),
@@ -101,59 +81,68 @@ class AppManifestParser:
                     description=param.get("description"),
                     step=param.get("step"),
                     enum=param.get("enum"),
-                    hidden=param.get("hidden", False)
-                )
-                parameters.append(parameter.to_dict())
-            
-            # Extract outputs
+                    hidden=param.get("hidden", False),
+                ).to_dict())
+
+            # Outputs
             outputs = []
-            outputs_list = data.get("outputs", [])
-            
-            for output in outputs_list:
-                if not isinstance(output, dict):
+            for output in data.get("outputs", []):
+                if not isinstance(output, dict) or not output.get("name"):
                     continue
-                    
-                name = output.get("name")
-                if not name:
-                    continue
-                
                 outputs.append({
-                    "name": name,
+                    "name": output["name"],
+                    "label": output.get("label"),
                     "from_heat_output": output.get("from_heat_output"),
-                    "description": output.get("description")
+                    "description": output.get("description"),
                 })
-            
-            # Extract artifacts
-            artifacts = data.get("artifacts", {})
-            
+
+            # Credentials
+            credentials_raw = data.get("credentials") or {}
+            credentials = {
+                "per_student": credentials_raw.get("per_student") or [],
+                "teacher": credentials_raw.get("teacher") or [],
+            }
+
+            # User files
+            user_files = data.get("user_files") or []
+
             return {
                 "app": {
                     "name": app_info.get("name"),
                     "label": app_info.get("label"),
                     "version": app_info.get("version"),
                     "description": app_info.get("description"),
-                    "owner_team": app_info.get("owner_team")
+                    "owner_team": app_info.get("owner_team"),
+                    "allow_user_files": app_info.get("allow_user_files", False),
                 },
-                "artifacts": artifacts,
                 "parameters": parameters,
-                "outputs": outputs
+                "outputs": outputs,
+                "credentials": credentials,
+                "user_files": user_files,
             }
-            
-        except yaml.YAMLError as e:
-            raise ValueError(f"Failed to parse YAML: {e}")
-    
+
+        except Exception as e:
+            raise ValueError(f"Failed to parse app.yaml: {e}")
+
     @staticmethod
     def extract_parameters(content: str) -> list[dict]:
-        """Extract only parameters from app.yaml content.
-        
-        Args:
-            content: Raw YAML content of app.yaml
-            
-        Returns:
-            List of parameter dictionaries
-        """
         try:
-            parsed = AppManifestParser.parse(content)
-            return parsed.get("parameters", [])
+            return AppManifestParser.parse(content).get("parameters", [])
+        except Exception:
+            return []
+
+    @staticmethod
+    def extract_credentials(content: str) -> dict:
+        """Return the credentials block or empty structure on failure."""
+        try:
+            return AppManifestParser.parse(content).get("credentials", {"per_student": [], "teacher": []})
+        except Exception:
+            return {"per_student": [], "teacher": []}
+
+    @staticmethod
+    def extract_user_files(content: str) -> list[dict]:
+        """Return the user_files list or empty list on failure."""
+        try:
+            return AppManifestParser.parse(content).get("user_files", [])
         except Exception:
             return []

--- a/src/utils/log_sanitizer.py
+++ b/src/utils/log_sanitizer.py
@@ -1,0 +1,54 @@
+"""Sanitize log messages before storing them in the database.
+
+Removes passwords and other sensitive fields from Ansible output and
+arbitrary log strings so they never appear in the deployment log UI.
+"""
+import re
+from typing import Any
+
+# Keys whose values should be redacted everywhere (case-insensitive)
+_SENSITIVE_KEYS = {
+    "password", "passwd", "pass", "secret", "token",
+    "private_key", "ssh_key", "key", "credential",
+}
+
+# Regex patterns that match common sensitive inline patterns
+_PATTERNS = [
+    # 'password': 'abc123' or "password": "abc123"
+    re.compile(
+        r"""(['"]?(?:password|passwd|secret|token|private_key)['"]?\s*[:=]\s*)['"]?[^\s'"}{,\]]+['"]?""",
+        re.IGNORECASE,
+    ),
+    # password_hash('sha512') output — long hash strings
+    re.compile(r"\\\$[0-9a-z]+\\\$.{20,}", re.IGNORECASE),
+    re.compile(r"\$[0-9a-z]+\$[^'\"\s]{20,}", re.IGNORECASE),
+]
+
+
+def sanitize_message(message: str) -> str:
+    """Replace sensitive values in a log message string."""
+    if not message:
+        return message
+    result = message
+    for pattern in _PATTERNS:
+        result = pattern.sub(lambda m: m.group(1) + "***" if m.lastindex else "***", result)
+    return result
+
+
+def sanitize_details(details: Any) -> Any:
+    """Recursively redact sensitive keys in a dict/list structure."""
+    if isinstance(details, dict):
+        return {
+            k: "***" if _is_sensitive_key(k) else sanitize_details(v)
+            for k, v in details.items()
+        }
+    if isinstance(details, list):
+        return [sanitize_details(item) for item in details]
+    if isinstance(details, str):
+        return sanitize_message(details)
+    return details
+
+
+def _is_sensitive_key(key: str) -> bool:
+    lower = key.lower()
+    return any(s in lower for s in _SENSITIVE_KEYS)


### PR DESCRIPTION
## Linked Issue
Closes #<IssueNummer>

## Description
This PR integrates the Ansible deployment pipeline and fixes several critical issues discovered during local testing.

**Critical bug fix: DB credentials now match VM credentials**
`TemplateUserManagementService` was generating a separate set of random passwords independently from `CredentialGeneratorService`. Ansible used passwords from `CredentialGeneratorService`, while the DB stored passwords from `TemplateUserManagementService` — making all stored credentials wrong. Fixed by deriving `credentials_for_db` directly from `generated`.

**SSE log streaming**
New endpoint `GET /deployments/{id}/logs/stream` pushes log entries as Server-Sent Events (one JSON object per `data:` frame). Supports `?since_id=` to resume without duplicates. Stream closes automatically when deployment reaches a terminal status.

**Security hardening**
- `/opt/dozilab` on the VM is now created as `root:root 0700` (was world-readable `0755`)
- All Ansible stdout lines are run through `log_sanitizer` before being written to DeploymentLog
- New `src/utils/log_sanitizer.py` redacts `password`, `secret`, `token`, `key` fields in both message strings and details dicts — applied centrally in `DeploymentLogService.log()`
- `user_files` and `allow_user_files` are now returned by the template version API

**Refactoring**
- Removed dead code: `TemplateUserManagementService` block + `user_json_data` / `user_json_b64` in `deploy_tasks.py`
- `ssh_allow_users` and `credentials_for_db` now use identical filter logic (`linux.username` / `linux.password`)
- `ansible_service.py`: consistent `encoding="utf-8"` on all `write_text()` calls
- Seed data reduced to Ansible Multi-User Ubuntu only; `no_log: true` added to all student loops in playbook

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (no functional changes)

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have added/updated unit tests
- [x] I have updated the documentation (if applicable)
- [x] I have verified my changes locally