### PR TITLE
fix: merge alembic heads to resolve multiple head revisions error

### DIFF
--- a/alembic/versions/merge_heads_2026_06.py
+++ b/alembic/versions/merge_heads_2026_06.py
@@ -1,0 +1,22 @@
+"""merge heads: encrypt_dia_secrets and b3f9c1d2e4a5
+
+Revision ID: merge_heads_2026_06
+Revises: encrypt_dia_secrets, b3f9c1d2e4a5
+Create Date: 2026-06-09
+
+"""
+from typing import Sequence, Union
+from alembic import op
+
+revision: str = 'merge_heads_2026_06'
+down_revision: Union[str, Sequence[str], None] = ('encrypt_dia_secrets', 'b3f9c1d2e4a5')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Linked Issue
Closes #<IssueNummer>

## Description
Merges encrypt_dia_secrets and b3f9c1d2e4a5 into a single head so that `alembic upgrade head` works without ambiguity.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have added/updated unit tests
- [ ] I have updated the documentation (if applicable)
- [ ] I have verified my changes locally

## Screenshots / Logs (Optional)