### PR TITLE
fix: disable SSL verification for self-signed Keycloak certificate

### DIFF
--- a/src/core/auth.py
+++ b/src/core/auth.py
@@ -28,7 +28,10 @@ def get_keycloak_public_keys() -> dict[str, Any]:
     certs_url = f"{settings.keycloak_realm_url}/protocol/openid-connect/certs"
     
     try:
-        response = httpx.get(certs_url, timeout=10.0)
+        # SSL verification is disabled because Keycloak uses a self-signed certificate.
+        # Acceptable in a controlled university environment where the Keycloak server is
+        # trusted. Replace with a CA-signed certificate for production use.
+        response = httpx.get(certs_url, timeout=10.0, verify=False)
         response.raise_for_status()
         return response.json()
     except httpx.HTTPError as e:


### PR DESCRIPTION
The backend fetches Keycloak public keys over HTTPS but the Keycloak server uses a self-signed certificate. Python rejects this by default. Disabled SSL verification with a comment explaining why.