### PR TITLE
feat: migrate Dockerfile from pip to uv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,18 +9,21 @@ RUN apt-get update && apt-get install -y \
     openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
+# Install uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
 # Copy project files
-COPY pyproject.toml .
+COPY pyproject.toml uv.lock ./
 COPY alembic.ini .
 COPY alembic/ ./alembic/
 COPY src/ ./src/
 COPY tests/ ./tests/
 
-# Install Python dependencies (including dev extras for running tests inside container)
-RUN pip install --no-cache-dir ".[dev]"
+# Install Python dependencies
+RUN uv sync --frozen --extra dev
 
 # Expose port
 EXPOSE 8000
 
 # Default command (can be overridden in docker-compose)
-CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uv", "run", "uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Linked Issue
Closes #N/A

## Description
Migrates the Dockerfile from `pip` to `uv` for faster and reproducible dependency installation.
- Copies `uv` binary from the official `ghcr.io/astral-sh/uv` image
- Replaces `pip install --no-cache-dir ".[dev]"` with `uv sync --frozen --extra dev`
- Copies `uv.lock` into the image for reproducible builds
- Updates `CMD` to use `uv run uvicorn`

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have added/updated unit tests
- [x] I have updated the documentation (if applicable)
- [x] I have verified my changes locally

## Screenshots / Logs (Optional)
Build tested successfully locally with `docker build`.