### PR TITLE
fix: add venv to PATH so celery and uvicorn are accessible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,11 @@ COPY tests/ ./tests/
 # Install Python dependencies
 RUN uv sync --frozen --extra dev
 
+# Make uv-managed binaries available in PATH
+ENV PATH="/app/.venv/bin:$PATH"
+
 # Expose port
 EXPOSE 8000
 
 # Default command (can be overridden in docker-compose)
-CMD ["uv", "run", "uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Linked Issue
Closes #N/A

## Description
Adds `ENV PATH="/app/.venv/bin:$PATH"` to the Dockerfile so that `celery` and `uvicorn` are directly accessible without `uv run`. Without this, the `celery-worker` container failed to start with `executable file not found in $PATH`.

Also changes `CMD` from `uv run uvicorn` to `uvicorn` directly since the binary is now in PATH.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have added/updated unit tests
- [ ] I have updated the documentation (if applicable)
- [x] I have verified my changes locally

## Screenshots / Logs (Optional)
Tested locally — `which celery` and `which uvicorn` both resolve to `/app/.venv/bin/`.