### PR TITLE
feat(courses): scope embedded deployments by owner + active OpenStack project

### DIFF
--- a/bruno/Courses/Get Course.bru
+++ b/bruno/Courses/Get Course.bru
@@ -5,9 +5,13 @@ meta {
 }
 
 get {
-  url: {{base_url}}/api/v1/courses/{{course_id}}
+  url: {{base_url}}/api/v1/courses/{{course_id}}?openstack_project_id={{openstack_project_local_id}}
   body: none
   auth: bearer
+}
+
+params:query {
+  openstack_project_id: {{openstack_project_local_id}}
 }
 
 auth:bearer {
@@ -16,14 +20,22 @@ auth:bearer {
 
 docs {
   # Get Course
-  
-  Retrieves a single course by ID.
-  
-  **Required Role:** Authenticated user
-  
+
+  Retrieves a single course by ID. The embedded `deployments` collection
+  follows the same scoping rules as `List Courses`.
+
+  **Required Role:** Authenticated user (lecturer or admin)
+
+  **Query Parameters:**
+  - `openstack_project_id`: Local DB id of the active OpenStack project.
+    Required for non-admins (400 if missing); ignored for admins unless set.
+
   **Response:**
-  - Complete course details including metadata and timestamps
-  
+  - Complete course details including metadata and timestamps. The
+    `deployments` array is filtered to (project = arg) AND (teacher.id = caller)
+    for non-admins.
+
   **Variables used:**
   - `course_id`: Set automatically after creating a course
+  - `openstack_project_local_id`: Set after creating an OpenStack project
 }

--- a/bruno/Courses/List Courses.bru
+++ b/bruno/Courses/List Courses.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{base_url}}/api/v1/courses?page=1&page_size=10
+  url: {{base_url}}/api/v1/courses?page=1&page_size=10&openstack_project_id={{openstack_project_local_id}}
   body: none
   auth: bearer
 }
@@ -13,9 +13,8 @@ get {
 params:query {
   page: 1
   page_size: 10
-  ~semester: WS2024
-  ~search: 
-  ~lecturer_id: 
+  openstack_project_id: {{openstack_project_local_id}}
+  ~search:
 }
 
 auth:bearer {
@@ -24,18 +23,23 @@ auth:bearer {
 
 docs {
   # List Courses
-  
-  Lists all courses with optional filters and pagination.
-  
-  **Required Role:** Authenticated user
-  
+
+  Lists all courses with optional filters and pagination. The embedded
+  `deployments` collection is scoped to the calling user and the active
+  OpenStack project.
+
+  **Required Role:** Authenticated user (lecturer or admin)
+
   **Query Parameters:**
   - `page`: Page number (default: 1)
   - `page_size`: Items per page (default: 10)
-  - `semester`: Filter by semester (e.g., WS2024, SS2025)
-  - `search`: Search in course name
-  - `lecturer_id`: Filter by lecturer ID
-  
+  - `search`: Search in course name or Keycloak course ID
+  - `openstack_project_id`: Local DB id of the active OpenStack project.
+    Required for non-admins (400 if missing); ignored for admins unless set.
+    Restricts each course's embedded `deployments` to (project = arg) AND
+    (teacher.id = caller).
+
   **Response:**
-  - Paginated list of courses with total count
+  - Paginated list of courses with total count. Each course's
+    `deployments` array obeys the scoping above.
 }

--- a/src/api/courses.py
+++ b/src/api/courses.py
@@ -2,11 +2,10 @@
 from typing import Optional
 from uuid import UUID
 
-from fastapi import APIRouter, status, Query, Depends
+from fastapi import APIRouter, status, Query, Depends, HTTPException
 
 from src.core.response_builder import ResponseBuilder
-from src.core.dependencies import DBSession, RequestID, Pagination, CurrentUser
-from src.core.auth import require_roles
+from src.core.dependencies import DBSession, RequestID, Pagination, CurrentUser, require_roles
 from src.core.exceptions import NotFoundException
 from src.schemas.course import CourseCreate, CourseUpdate, CourseResponse, CourseGroupCreate, CourseGroupResponse, CourseMemberResponse, GroupMemberAdd
 from src.services.course_service import CourseService
@@ -14,6 +13,8 @@ from src.models.user import UserRole
 from src.models.course_group import CourseGroup
 from src.models.course_member import CourseMember
 from src.models.group_member import GroupMember
+from src.repositories.openstack_project_repository import OpenstackProjectRepository
+from src.api.deployments import get_deployment_owner_id
 from sqlalchemy.orm import joinedload
 
 
@@ -24,6 +25,68 @@ router = APIRouter(
 )
 
 
+def _authorize_courses_scope(
+    current_user: dict,
+    openstack_project_id: Optional[UUID],
+    db,
+) -> bool:
+    """Validate the OpenStack-project scoping for course-list/detail reads.
+
+    Mirrors the auth block in ``list_deployments``: non-admins MUST pass an
+    ``openstack_project_id`` and that project must belong to them. Returns
+    ``is_admin`` so the caller can decide whether to apply the embedded
+    Owner-filter.
+    """
+    user_roles = current_user.get("roles", [])
+    is_admin = "admin" in [r.lower() for r in user_roles]
+    if is_admin:
+        return True
+
+    if openstack_project_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="openstack_project_id query parameter is required",
+        )
+
+    openstack_repo = OpenstackProjectRepository(db)
+    proj = openstack_repo.get_by_id(str(openstack_project_id))
+    if not proj or proj.owner_user_id != current_user["user_id"]:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="OpenStack project does not belong to user",
+        )
+    return False
+
+
+def _filter_deployments_by_owner(courses, current_user_id: str, db) -> None:
+    """In-place restrict each course's embedded deployments to the caller.
+
+    The repository already filtered the eager-loaded list by
+    ``openstack_project_id``; this strips out any deployment whose
+    ``deployment_parameters.teacher.id`` does not resolve to the calling user.
+    Owner-resolution lives in ``deployment_parameters`` JSON, not on a column,
+    so this stays in Python (same trade-off as PR #137).
+
+    Unlike the per-deployment endpoints (which use ``get_deployment_owner_id``
+    to *authorize* access and want to surface a 500 on a missing teacher
+    record), here we are *filtering* a list. A single deployment with a stale
+    or unresolvable teacher.id (e.g. user deleted from the local DB but row
+    still here) must not fail the whole listing — we drop it instead, which is
+    also the safer default for a leak fix.
+    """
+    for course in courses:
+        kept = []
+        for d in course.deployments:
+            try:
+                owner_id = get_deployment_owner_id(d, db)
+            except HTTPException:
+                # Owner not resolvable — drop the row (safer than leaking it).
+                continue
+            if owner_id == current_user_id:
+                kept.append(d)
+        course.deployments = kept
+
+
 @router.get("", response_model=None)
 async def list_courses(
     pagination: Pagination,
@@ -31,27 +94,46 @@ async def list_courses(
     request_id: RequestID,
     current_user: CurrentUser,
     search: Optional[str] = Query(None, description="Search in course name or Keycloak course ID"),
+    openstack_project_id: UUID | None = Query(
+        None,
+        description=(
+            "OpenStack project (local DB id) whose deployments to embed in each course. "
+            "Required for non-admin users; ignored for admins unless provided."
+        ),
+    ),
 ):
     """List all courses with optional filters and pagination.
-    
+
     Supports filtering by:
     - Search term (searches course name or keycloak_course_id)
-    
+
+    Authorization & visibility:
+    - Admins see all courses. If ``openstack_project_id`` is passed, the
+      embedded deployments are restricted to that project; otherwise all.
+    - Non-admins (lecturers) MUST pass ``openstack_project_id`` and only see
+      deployments that they own (teacher.id == them) within that project
+      embedded under each course.
+
     Returns paginated results with total count.
     """
+    is_admin = _authorize_courses_scope(current_user, openstack_project_id, db)
+
     service = CourseService(db)
-    
     courses, total = service.list_courses(
         skip=(pagination.page - 1) * pagination.page_size,
         limit=pagination.page_size,
         search=search,
+        openstack_project_id=str(openstack_project_id) if openstack_project_id else None,
     )
-    
+
+    if not is_admin:
+        _filter_deployments_by_owner(courses, current_user["user_id"], db)
+
     course_responses = [
         CourseResponse.model_validate(course).model_dump(mode="json")
         for course in courses
     ]
-    
+
     return ResponseBuilder.paginated(
         data=course_responses,
         page=pagination.page,
@@ -67,16 +149,33 @@ async def get_course(
     db: DBSession,
     request_id: RequestID,
     current_user: CurrentUser,
+    openstack_project_id: UUID | None = Query(
+        None,
+        description=(
+            "OpenStack project (local DB id) whose deployments to embed. "
+            "Required for non-admin users; ignored for admins unless provided."
+        ),
+    ),
 ):
     """Get a single course by ID.
-    
-    Returns complete course details including metadata and timestamps.
+
+    Returns complete course details including metadata and timestamps. The
+    embedded ``deployments`` collection follows the same scoping rules as
+    ``GET /courses``.
     """
+    is_admin = _authorize_courses_scope(current_user, openstack_project_id, db)
+
     service = CourseService(db)
-    course = service.get_course(str(course_id))
-    
+    course = service.get_course(
+        str(course_id),
+        openstack_project_id=str(openstack_project_id) if openstack_project_id else None,
+    )
+
+    if not is_admin:
+        _filter_deployments_by_owner([course], current_user["user_id"], db)
+
     course_response = CourseResponse.model_validate(course)
-    
+
     return ResponseBuilder.success(
         data=course_response.model_dump(mode="json"),
         message="Course retrieved successfully",

--- a/src/repositories/course_repository.py
+++ b/src/repositories/course_repository.py
@@ -1,9 +1,10 @@
 """Course repository for database operations."""
 from typing import Optional
 
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import Session, selectinload
 
 from src.models.course import Course
+from src.models.deployment import Deployment
 from src.repositories.base_repository import BaseRepository
 
 
@@ -12,7 +13,7 @@ class CourseRepository(BaseRepository[Course]):
 
     def __init__(self, db: Session):
         """Initialize CourseRepository with database session.
-        
+
         Args:
             db: SQLAlchemy database session
         """
@@ -31,19 +32,41 @@ class CourseRepository(BaseRepository[Course]):
             )
         return query
 
+    def _deployments_loader(self, openstack_project_id: Optional[str]):
+        """Build the eager-load option for ``Course.deployments``.
+
+        When ``openstack_project_id`` is set, only deployments belonging to that
+        OpenStack project are eager-loaded into ``course.deployments``. We use
+        ``selectinload`` (not ``joinedload``) so the embedded list is filtered
+        cleanly via a separate ``WHERE deployment.course_id IN (...) AND
+        deployment.openstack_project_id = ?`` query, instead of mixing courses
+        and deployments into one row-set that ``and_()`` filters can't dedup.
+        """
+        if openstack_project_id is None:
+            return selectinload(self.model.deployments)
+        return selectinload(
+            self.model.deployments.and_(
+                Deployment.openstack_project_id == str(openstack_project_id)
+            )
+        )
+
     def get_all_filtered(
         self,
         skip: int = 0,
         limit: int = 100,
         search: Optional[str] = None,
+        openstack_project_id: Optional[str] = None,
     ) -> tuple[list[Course], int]:
         """Get all courses with filters and pagination.
-        
+
         Args:
             skip: Number of records to skip (offset)
             limit: Maximum number of records to return
             search: Search term for course name or keycloak_course_id
-            
+            openstack_project_id: If set, only deployments belonging to this
+                OpenStack project (local DB id) are eager-loaded into
+                ``course.deployments``. Courses themselves are not filtered.
+
         Returns:
             Tuple of (list of courses, total count)
         """
@@ -51,16 +74,38 @@ class CourseRepository(BaseRepository[Course]):
             self.db.query(self.model),
             search
         )
-        
+
         total = base_query.count()
-        
+
         courses = (
             base_query
-            .options(joinedload(self.model.deployments))
+            .options(self._deployments_loader(openstack_project_id))
             .order_by(self.model.created_at.desc())
             .offset(skip)
             .limit(limit)
             .all()
         )
-        
+
         return courses, total
+
+    def get_by_id_with_deployments(
+        self,
+        course_id: str,
+        openstack_project_id: Optional[str] = None,
+    ) -> Optional[Course]:
+        """Fetch a course by id with its deployments eager-loaded.
+
+        Args:
+            course_id: Course primary key.
+            openstack_project_id: Same semantics as ``get_all_filtered`` —
+                filters the embedded ``deployments`` collection only.
+
+        Returns:
+            The Course (with filtered deployments) or ``None`` if not found.
+        """
+        return (
+            self.db.query(self.model)
+            .options(self._deployments_loader(openstack_project_id))
+            .filter(self.model.id == str(course_id))
+            .first()
+        )

--- a/src/services/course_service.py
+++ b/src/services/course_service.py
@@ -40,19 +40,32 @@ class CourseService:
         )
         return course
 
-    def get_course(self, course_id: str | UUID) -> Course:
+    def get_course(
+        self,
+        course_id: str | UUID,
+        openstack_project_id: Optional[str] = None,
+    ) -> Course:
         """Get a course by ID.
-        
+
         Args:
             course_id: Course ID
-            
+            openstack_project_id: If set, the embedded ``deployments`` collection
+                is restricted to that OpenStack project. ``None`` returns all
+                deployments (admin path / call sites that don't care).
+
         Returns:
             Course instance
-            
+
         Raises:
             NotFoundException: If course not found
         """
-        course = self.course_repo.get_by_id(course_id)
+        if openstack_project_id is not None:
+            course = self.course_repo.get_by_id_with_deployments(
+                str(course_id),
+                openstack_project_id=openstack_project_id,
+            )
+        else:
+            course = self.course_repo.get_by_id(course_id)
         if not course:
             raise NotFoundException(f"Course with ID {course_id} not found")
         return course
@@ -62,14 +75,18 @@ class CourseService:
         skip: int = 0,
         limit: int = 100,
         search: Optional[str] = None,
+        openstack_project_id: Optional[str] = None,
     ) -> tuple[list[Course], int]:
         """List courses with filters and pagination.
-        
+
         Args:
             skip: Number of records to skip
             limit: Maximum number of records to return
             search: Search term for course name or keycloak_course_id
-            
+            openstack_project_id: If set, restricts the embedded ``deployments``
+                collection to that OpenStack project. Courses themselves are
+                always returned.
+
         Returns:
             Tuple of (list of courses, total count)
         """
@@ -77,6 +94,7 @@ class CourseService:
             skip=skip,
             limit=limit,
             search=search,
+            openstack_project_id=openstack_project_id,
         )
 
     def update_course(

--- a/tests/api/test_course_routes.py
+++ b/tests/api/test_course_routes.py
@@ -1,0 +1,313 @@
+"""Tests for course listing endpoint with OpenStack-project scoping.
+
+These tests guard the second deployment-leak fix (the first one lived in
+``/api/v1/deployments`` and is covered by ``test_deployment_routes.py``):
+``GET /api/v1/courses`` eager-loads ``course.deployments`` and used to do so
+with no owner/project filter. The contract here mirrors ``list_deployments``:
+
+- Non-admin without ``openstack_project_id``  → 400
+- Non-admin with someone else's project       → 403
+- Non-admin with their own project            → embedded deployments are filtered
+  to (project == arg) AND (teacher.id == caller)
+- Admin                                       → no scoping enforced
+"""
+from unittest.mock import patch, MagicMock
+import pytest
+from uuid import uuid4
+from datetime import datetime
+from fastapi.testclient import TestClient
+
+from src.main import app
+from src.core.dependencies import get_current_user, get_db
+from src.models.user import UserRole
+from src.models.course import Course
+from src.models.deployment import Deployment, DeploymentStatus
+
+
+TEST_OS_PROJECT_ID = "11111111-1111-1111-1111-111111111111"
+
+
+def _patched_openstack_repo(owner_user_id: int = 1):
+    """Make ``OpenstackProjectRepository.get_by_id`` return a project owned by
+    ``owner_user_id`` so the courses-API auth helper (which lives in
+    ``src.api.courses``) accepts ``TEST_OS_PROJECT_ID``."""
+    proj = MagicMock()
+    proj.id = TEST_OS_PROJECT_ID
+    proj.owner_user_id = owner_user_id
+    repo = MagicMock()
+    repo.get_by_id.return_value = proj
+    return patch("src.api.courses.OpenstackProjectRepository", return_value=repo)
+
+
+def mock_lecturer_user():
+    return {
+        "sub": "lecturer-123",
+        "email": "lecturer@example.com",
+        "name": "Test Lecturer",
+        "preferred_username": "lecturer",
+        "roles": [UserRole.LECTURER.value],
+        "user_id": 1,
+    }
+
+
+def mock_admin_user():
+    return {
+        "sub": "admin-123",
+        "email": "admin@example.com",
+        "name": "Test Admin",
+        "preferred_username": "admin",
+        "roles": [UserRole.ADMIN.value],
+        "user_id": 2,
+    }
+
+
+client = TestClient(app)
+
+
+def _make_deployment(*, did: str, teacher_keycloak: str | None) -> Deployment:
+    """Build a Deployment mock with the minimal attrs the response schema needs.
+
+    ``teacher_keycloak`` is the value embedded into ``deployment_parameters``
+    JSON; ``get_deployment_owner_id`` walks the JSON to resolve it back to a
+    local user_id via the User-table lookup we mock below.
+    """
+    d = MagicMock(spec=Deployment)
+    d.id = did
+    d.name = f"Deployment {did}"
+    d.template_version_id = str(uuid4())
+    d.status = DeploymentStatus.RUNNING
+    d.created_at = datetime(2024, 11, 27, 10, 0, 0)
+    d.openstack_project_id = TEST_OS_PROJECT_ID
+    if teacher_keycloak is None:
+        d.deployment_parameters = None
+    else:
+        d.deployment_parameters = (
+            '{"teacher": {"id": "' + teacher_keycloak + '"}}'
+        )
+    return d
+
+
+@pytest.fixture
+def mock_course_with_mixed_deployments():
+    """One course with two deployments: one owned by the lecturer, one by
+    someone else. The repository's project-filter is mocked separately, so this
+    fixture only exercises the API-layer owner filter."""
+    own = _make_deployment(did="deploy-own", teacher_keycloak="lecturer-123")
+    foreign = _make_deployment(did="deploy-foreign", teacher_keycloak="other-456")
+
+    course = MagicMock(spec=Course)
+    course.id = str(uuid4())
+    course.name = "CS101"
+    course.keycloak_course_id = "kc-course-1"
+    course.created_at = datetime(2024, 11, 27, 10, 0, 0)
+    course.updated_at = datetime(2024, 11, 27, 10, 0, 0)
+    # Both deployments are eager-loaded by the (mocked) repo. The endpoint will
+    # strip ``deploy-foreign`` after owner-resolution because its teacher.id
+    # doesn't map to user_id=1.
+    course.deployments = [own, foreign]
+    return course
+
+
+def _install_db_with_courses(courses: list, owner_lookup_user_id: int | None = 1):
+    """Configure ``app.dependency_overrides`` so the route gets a DB whose
+    ``CourseRepository`` returns ``courses`` and whose User-lookup (used by
+    ``get_deployment_owner_id``) only resolves ``"lecturer-123"`` to user_id=1.
+
+    Returns the mock_db so callers can introspect it if needed.
+    """
+    mock_db = MagicMock()
+
+    # Course-list query: a chain that ends in ``.all()`` — used by
+    # CourseRepository.get_all_filtered.
+    course_query = MagicMock()
+    course_query.filter.return_value = course_query
+    course_query.order_by.return_value = course_query
+    course_query.count.return_value = len(courses)
+    course_query.offset.return_value = course_query
+    course_query.limit.return_value = course_query
+    course_query.options.return_value = course_query
+    course_query.all.return_value = courses
+    # CourseRepository.get_by_id_with_deployments ends in ``.first()`` — return
+    # the first course so the route's get_course path works too.
+    course_query.first.return_value = courses[0] if courses else None
+
+    # User-lookup query: ``db.query(User).filter(User.external_id == kc).first()``.
+    # We need different return values per kc-id so the owner-filter actually
+    # discriminates. Using a side_effect on filter() that captures the kc-id
+    # via the SQLAlchemy expression's right-hand side is brittle — instead we
+    # build a MagicMock whose .first() returns a user with id=1 when the most
+    # recent filter() arg encodes "lecturer-123", else None.
+    def make_user_query():
+        user_query = MagicMock()
+        captured = {"kc": None}
+
+        def filter_side_effect(*args, **kwargs):
+            # SQLAlchemy passes a BinaryExpression like (User.external_id == "kc-id").
+            # Pull the literal off the expression's right-hand side; fall back to
+            # str() for the rare case it's pre-bound.
+            if args:
+                expr = args[0]
+                rhs = getattr(expr, "right", None)
+                if rhs is not None:
+                    captured["kc"] = getattr(rhs, "value", str(rhs))
+                else:
+                    captured["kc"] = str(expr)
+            return user_query
+
+        user_query.filter.side_effect = filter_side_effect
+
+        def first_side_effect():
+            if captured["kc"] == "lecturer-123" and owner_lookup_user_id is not None:
+                u = MagicMock()
+                u.id = owner_lookup_user_id
+                return u
+            return None
+
+        user_query.first.side_effect = first_side_effect
+        return user_query
+
+    # Two model classes are queried via db.query(): Course and User. Dispatch
+    # by what was passed in.
+    def query_side_effect(model):
+        # CourseRepository passes the Course class; get_deployment_owner_id passes
+        # the User class. Distinguish by name to avoid importing the model just
+        # to do an isinstance check.
+        if getattr(model, "__name__", "") == "User":
+            return make_user_query()
+        return course_query
+
+    mock_db.query.side_effect = query_side_effect
+
+    app.dependency_overrides[get_current_user] = mock_lecturer_user
+    app.dependency_overrides[get_db] = lambda: mock_db
+    return mock_db
+
+
+# ── 400: non-admin without openstack_project_id ───────────────────────────────
+
+
+def test_list_courses_lecturer_without_project_id_returns_400():
+    """The same contract as ``list_deployments``: a lecturer must always scope
+    by project. Without it, the embedded deployments would leak again."""
+    _install_db_with_courses([])
+    response = client.get("/api/v1/courses")
+    assert response.status_code == 400
+    assert "openstack_project_id" in response.json()["detail"]
+    app.dependency_overrides.clear()
+
+
+# ── 403: non-admin with someone else's project ────────────────────────────────
+
+
+def test_list_courses_lecturer_with_foreign_project_returns_403():
+    """If the project doesn't belong to the caller, we reject before reading
+    any course rows. ``owner_user_id=99`` ≠ ``user_id=1`` triggers it."""
+    _install_db_with_courses([])
+    response = client.get(
+        f"/api/v1/courses?openstack_project_id={TEST_OS_PROJECT_ID}"
+    )
+    # No openstack-repo patch ⇒ default fallback would be a real DB call. Patch
+    # explicitly to return a project NOT owned by the caller.
+    with _patched_openstack_repo(owner_user_id=99):
+        response = client.get(
+            f"/api/v1/courses?openstack_project_id={TEST_OS_PROJECT_ID}"
+        )
+    assert response.status_code == 403
+    assert "does not belong" in response.json()["detail"]
+    app.dependency_overrides.clear()
+
+
+# ── 200: lecturer with own project ⇒ owner-filter strips foreign deployments ──
+
+
+def test_list_courses_lecturer_filters_embedded_deployments(
+    mock_course_with_mixed_deployments,
+):
+    """Both project-filter (in repo) and owner-filter (in API) must apply.
+    Repo is mocked to return the course unchanged with both deployments; the
+    API layer should drop the foreign one."""
+    _install_db_with_courses([mock_course_with_mixed_deployments])
+
+    with _patched_openstack_repo():
+        response = client.get(
+            f"/api/v1/courses?openstack_project_id={TEST_OS_PROJECT_ID}"
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert len(data["data"]) == 1
+    course = data["data"][0]
+    deployment_ids = [d["id"] for d in course["deployments"]]
+    assert deployment_ids == ["deploy-own"], (
+        f"Owner-filter leaked: expected only ['deploy-own'], got {deployment_ids}"
+    )
+    app.dependency_overrides.clear()
+
+
+# ── 200: admin without project_id ⇒ no scoping ────────────────────────────────
+
+
+def test_list_courses_admin_without_project_id_sees_all_deployments(
+    mock_course_with_mixed_deployments,
+):
+    """Admins keep their unrestricted view — the same exception we made in
+    ``list_deployments``. They can pass ``openstack_project_id`` if they want
+    to scope, but unset means no filter."""
+    mock_db = MagicMock()
+    mock_query = MagicMock()
+    mock_query.filter.return_value = mock_query
+    mock_query.order_by.return_value = mock_query
+    mock_query.count.return_value = 1
+    mock_query.offset.return_value = mock_query
+    mock_query.limit.return_value = mock_query
+    mock_query.options.return_value = mock_query
+    mock_query.all.return_value = [mock_course_with_mixed_deployments]
+    mock_db.query.return_value = mock_query
+
+    app.dependency_overrides[get_current_user] = mock_admin_user
+    app.dependency_overrides[get_db] = lambda: mock_db
+
+    response = client.get("/api/v1/courses")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["data"]) == 1
+    deployment_ids = [d["id"] for d in data["data"][0]["deployments"]]
+    # Admin path: NEITHER filter ran, both deployments embedded as-is.
+    assert sorted(deployment_ids) == ["deploy-foreign", "deploy-own"]
+    app.dependency_overrides.clear()
+
+
+# ── get_course mirrors the same contract ──────────────────────────────────────
+
+
+def test_get_course_lecturer_filters_embedded_deployments(
+    mock_course_with_mixed_deployments,
+):
+    """``GET /api/v1/courses/{id}`` shares the auth helper and owner-filter
+    with ``list_courses``; verify the same outcome on the single-course path."""
+    course = mock_course_with_mixed_deployments
+    _install_db_with_courses([course])
+
+    with _patched_openstack_repo():
+        response = client.get(
+            f"/api/v1/courses/{course.id}?openstack_project_id={TEST_OS_PROJECT_ID}"
+        )
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    deployment_ids = [d["id"] for d in data["deployments"]]
+    assert deployment_ids == ["deploy-own"]
+    app.dependency_overrides.clear()
+
+
+def test_get_course_lecturer_without_project_id_returns_400(
+    mock_course_with_mixed_deployments,
+):
+    """Single-course endpoint enforces the same query-param contract."""
+    course = mock_course_with_mixed_deployments
+    _install_db_with_courses([course])
+    response = client.get(f"/api/v1/courses/{course.id}")
+    assert response.status_code == 400
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## Why

PR #137 plugged the deployment leak via `/api/v1/deployments` — non-admins must now pass `?openstack_project_id=...` and only see deployments they own. But the same data also leaks through the **courses** API: `GET /api/v1/courses` eager-loaded `course.deployments` via `joinedload()` with no owner/project filter, and the frontend's Courses page renders that embedded list directly. Lecturer A opening `/courses` still saw Lecturer B's deployments under the same Keycloak group.

This PR closes that path using the same contract as #137.

## What

- `GET /api/v1/courses` and `GET /api/v1/courses/{id}` accept a new `openstack_project_id` query param.
  - For **non-admins**: required (400 without; 403 if the project belongs to someone else).
  - For **admins**: optional — behaviour matches today (no scoping enforced).
- `CourseRepository` switches `Course.deployments` eager-load from `joinedload` to `selectinload(...).and_(Deployment.openstack_project_id == arg)`. `selectinload` runs a separate IN-query, so the relationship can be filtered cleanly without `joinedload`'s row-mixing duplication.
- New `_filter_deployments_by_owner` in [`src/api/courses.py`](src/api/courses.py) strips deployments whose `teacher.id` doesn't resolve to the caller. Owner-resolution lives in `deployment_parameters` JSON, not on a column — same trade-off as #137. Unlike the per-deployment endpoints, an unresolvable `teacher.id` here drops the row instead of 500-ing the whole listing (listing semantics shouldn't die because of one stale row, and drop-on-fail is the safer leak default).

### Drive-by fix

`src/api/courses.py` was the only router importing `require_roles` from `src.core.auth` (which expects `realm_access.roles`); every other router uses `src.core.dependencies` (flat `roles`). Switched to match — this is what made the new tests originally trip on 403 at the router-level dependency before they ever reached the endpoint.

## Verification

- 6 new tests in `tests/api/test_course_routes.py` cover the contract for both list and detail:
  1. Lecturer without `openstack_project_id` → 400
  2. Lecturer with someone else's project → 403
  3. Lecturer with their own project → embedded deployments filtered (project + owner)
  4. Admin without param → unrestricted view
  5. Same for `GET /courses/{id}` (3 + 1 above)
- Local: `pytest tests/` → **255 passed, 4 skipped, 0 failed** (249 prior + 6 new).
- Bruno: `List Courses` and `Get Course` updated to send `{{openstack_project_local_id}}` (the env var introduced in #137).

## Companion PR

Frontend changes that thread `activeProjectId` through `getMyCourses` follow in a separate PR against `staging`. Backend without frontend will start returning 400 on the Courses page until both are merged together.

## Out-of-scope (intentional)

- Course-Owner concept: `Course` still has no owner — every lecturer sees every course. Separate audit, not a deployment leak.
- `getMyCourses` despite its name doesn't filter by membership today. Separate audit.
- Co-lecturer view (co-owner sees co-lecturer deployments): explicitly not requested.
- Performance optimisation of the `get_deployment_owner_id` loop (one User-lookup per embedded deployment) — separate refactor if it ever becomes a bottleneck.