### PR TITLE
ci: Nur staging-Branch darf in main gemergt werden

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -8,6 +8,19 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-source-branch:
+    name: Only staging can merge into main
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
+    steps:
+      - name: Check source branch
+        run: |
+          if [ "${{ github.head_ref }}" != "staging" ]; then
+            echo "PRs to main are only allowed from 'staging' branch!"
+            echo "Current branch: ${{ github.head_ref }}"
+            exit 1
+          fi
+
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Was ändert sich?

Neuer Job `check-source-branch`: Schlägt fehl, wenn ein PR auf `main` nicht vom `staging` Branch kommt.

## Warum?

Wir hatten den Vorfall, dass ein Feature direkt von einem Feature-Branch in `main` gemergt wurde, ohne vorher auf staging getestet zu werden. Dieser Check verhindert das.

## Nach dem Merge

In den GitHub Settings unter Branch Protection für `main` muss noch `Only staging can merge into main` als Required Status Check eingetragen werden, damit der Check tatsächlich blockierend wirkt.