### PR TITLE
ci: restrict main merges to staging branch only

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -8,6 +8,19 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-source-branch:
+    name: Only staging can merge into main
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
+    steps:
+      - name: Check source branch
+        run: |
+          if [ "${{ github.head_ref }}" != "staging" ]; then
+            echo "PRs to main are only allowed from 'staging' branch!"
+            echo "Current branch: ${{ github.head_ref }}"
+            exit 1
+          fi
+
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Purpose

Bring the new `check-source-branch` job into `staging` so that future `staging → main` PRs already include the check.

## What changes?

This is a cherry-pick of the CI commit that was merged into `main` (PR #140). It adds a single new job `check-source-branch` that fails any PR targeting `main` whose source branch is not `staging`.

Diff: 1 file changed, 13 insertions(+).

## Why a cherry-pick instead of a regular sync?

A direct `main → staging` sync would also bring in the squash-commit from the previous release, which produces a misleading huge diff (the actual code is already on staging). Cherry-picking only the missing CI commit keeps the diff minimal and accurate.