### PR TITLE
Hardcoded-Fixes (B1, B1.5, B2, B6): flavors endpoint, instance flavor, owner names, deployment expiry

### DIFF
--- a/alembic/versions/ab7ece9fa8cc_add_flavor_to_deployment_instances.py
+++ b/alembic/versions/ab7ece9fa8cc_add_flavor_to_deployment_instances.py
@@ -1,0 +1,42 @@
+"""add flavor to deployment_instances
+
+Revision ID: ab7ece9fa8cc
+Revises: a4f2b91c30d1
+Create Date: 2026-06-20 17:32:49.391619
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'ab7ece9fa8cc'
+down_revision: Union[str, Sequence[str], None] = 'a4f2b91c30d1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    Adds a nullable ``flavor`` column to ``deployment_instances`` so the
+    OpenStack Nova flavor used for each instance (e.g. ``gp1.small``) is
+    persisted alongside the stack metadata. The frontend resolves this
+    flavor name against ``GET /api/v1/openstack/flavors`` to display real
+    vCPU/RAM/disk numbers, replacing the previous hardcoded multiplier.
+
+    Nullable + no backfill: existing rows predate this column and will
+    show as ``flavor=NULL``. New deployments populate the column from
+    the Heat-stack parameters at creation time.
+    """
+    op.add_column(
+        'deployment_instances',
+        sa.Column('flavor', sa.String(length=255), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('deployment_instances', 'flavor')

--- a/alembic/versions/d3f1b2c8a47e_add_display_fields_to_users.py
+++ b/alembic/versions/d3f1b2c8a47e_add_display_fields_to_users.py
@@ -1,0 +1,56 @@
+"""add display fields to users
+
+Revision ID: d3f1b2c8a47e
+Revises: ab7ece9fa8cc
+Create Date: 2026-06-20 18:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd3f1b2c8a47e'
+down_revision: Union[str, Sequence[str], None] = 'ab7ece9fa8cc'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    Adds three nullable display fields to ``users``: ``display_name``,
+    ``email``, ``username``. These are CACHED copies of Keycloak token
+    claims, refreshed on every login by ``UserSyncService``. They exist so
+    the API can show human-readable owner names (e.g. on Template-Approval
+    cards in AdminMonitoring) without round-tripping to the Keycloak Admin
+    API on every request.
+
+    Source of truth remains Keycloak — these columns are display-only and
+    may be stale until the user logs in again. Roles continue to be read
+    exclusively from the JWT, never from this table.
+
+    Nullable + no backfill: existing rows predate this column. Their fields
+    populate on the user's next login.
+    """
+    op.add_column(
+        'users',
+        sa.Column('display_name', sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        'users',
+        sa.Column('email', sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        'users',
+        sa.Column('username', sa.String(length=255), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('users', 'username')
+    op.drop_column('users', 'email')
+    op.drop_column('users', 'display_name')

--- a/alembic/versions/f7a92e3b8c41_add_expiry_fields_to_deployments.py
+++ b/alembic/versions/f7a92e3b8c41_add_expiry_fields_to_deployments.py
@@ -1,0 +1,62 @@
+"""add expiry fields to deployments
+
+Revision ID: f7a92e3b8c41
+Revises: d3f1b2c8a47e
+Create Date: 2026-06-20 19:30:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f7a92e3b8c41'
+down_revision: Union[str, Sequence[str], None] = 'd3f1b2c8a47e'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    Adds two nullable timestamps to ``deployments``:
+
+    - ``expires_at`` — when this deployment will be hard-deleted by the
+      ``expire_deployments_task`` Celery-Beat job (Heat-stack down + DB row
+      removed). NULL means "never expires" (legacy rows + admin-overridden
+      deployments).
+    - ``expiry_warning_at`` — when the frontend should start showing the
+      "läuft bald ab" banner / icon. Computed as
+      ``expires_at - min(14 days, runtime * 0.25)`` so that short-runtime
+      deployments do not warn for half their life.
+
+    Both are nullable + no backfill: existing rows keep both as NULL and
+    are therefore never expired by the beat job. New deployments populate
+    both at creation time from ``runtime_months`` (default 4).
+
+    Index on ``expires_at`` so the daily beat sweep
+    (``WHERE expires_at < NOW() AND status NOT IN ('deleted','deleting')``)
+    stays cheap as the table grows.
+    """
+    op.add_column(
+        'deployments',
+        sa.Column('expires_at', sa.DateTime(), nullable=True),
+    )
+    op.add_column(
+        'deployments',
+        sa.Column('expiry_warning_at', sa.DateTime(), nullable=True),
+    )
+    op.create_index(
+        'ix_deployments_expires_at',
+        'deployments',
+        ['expires_at'],
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index('ix_deployments_expires_at', table_name='deployments')
+    op.drop_column('deployments', 'expiry_warning_at')
+    op.drop_column('deployments', 'expires_at')

--- a/bruno/Courses/Get Course.bru
+++ b/bruno/Courses/Get Course.bru
@@ -5,9 +5,13 @@ meta {
 }
 
 get {
-  url: {{base_url}}/api/v1/courses/{{course_id}}
+  url: {{base_url}}/api/v1/courses/{{course_id}}?openstack_project_id={{openstack_project_local_id}}
   body: none
   auth: bearer
+}
+
+params:query {
+  openstack_project_id: {{openstack_project_local_id}}
 }
 
 auth:bearer {
@@ -16,14 +20,22 @@ auth:bearer {
 
 docs {
   # Get Course
-  
-  Retrieves a single course by ID.
-  
-  **Required Role:** Authenticated user
-  
+
+  Retrieves a single course by ID. The embedded `deployments` collection
+  follows the same scoping rules as `List Courses`.
+
+  **Required Role:** Authenticated user (lecturer or admin)
+
+  **Query Parameters:**
+  - `openstack_project_id`: Local DB id of the active OpenStack project.
+    Required for non-admins (400 if missing); ignored for admins unless set.
+
   **Response:**
-  - Complete course details including metadata and timestamps
-  
+  - Complete course details including metadata and timestamps. The
+    `deployments` array is filtered to (project = arg) AND (teacher.id = caller)
+    for non-admins.
+
   **Variables used:**
   - `course_id`: Set automatically after creating a course
+  - `openstack_project_local_id`: Set after creating an OpenStack project
 }

--- a/bruno/Courses/List Courses.bru
+++ b/bruno/Courses/List Courses.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{base_url}}/api/v1/courses?page=1&page_size=10
+  url: {{base_url}}/api/v1/courses?page=1&page_size=10&openstack_project_id={{openstack_project_local_id}}
   body: none
   auth: bearer
 }
@@ -13,9 +13,8 @@ get {
 params:query {
   page: 1
   page_size: 10
-  ~semester: WS2024
-  ~search: 
-  ~lecturer_id: 
+  openstack_project_id: {{openstack_project_local_id}}
+  ~search:
 }
 
 auth:bearer {
@@ -24,18 +23,23 @@ auth:bearer {
 
 docs {
   # List Courses
-  
-  Lists all courses with optional filters and pagination.
-  
-  **Required Role:** Authenticated user
-  
+
+  Lists all courses with optional filters and pagination. The embedded
+  `deployments` collection is scoped to the calling user and the active
+  OpenStack project.
+
+  **Required Role:** Authenticated user (lecturer or admin)
+
   **Query Parameters:**
   - `page`: Page number (default: 1)
   - `page_size`: Items per page (default: 10)
-  - `semester`: Filter by semester (e.g., WS2024, SS2025)
-  - `search`: Search in course name
-  - `lecturer_id`: Filter by lecturer ID
-  
+  - `search`: Search in course name or Keycloak course ID
+  - `openstack_project_id`: Local DB id of the active OpenStack project.
+    Required for non-admins (400 if missing); ignored for admins unless set.
+    Restricts each course's embedded `deployments` to (project = arg) AND
+    (teacher.id = caller).
+
   **Response:**
-  - Paginated list of courses with total count
+  - Paginated list of courses with total count. Each course's
+    `deployments` array obeys the scoping above.
 }

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -7,6 +7,7 @@ from src.api.openstack_projects import router as openstack_projects_router
 from src.api.template_version_files import router as template_version_files_router
 from src.api.courses import router as courses_router
 from src.api.quotas import router as quotas_router
+from src.api.openstack_flavors import router as openstack_flavors_router
 from src.api.github_app import router as github_app_router
 
 # Create main API router
@@ -19,6 +20,7 @@ api_router.include_router(openstack_projects_router)
 api_router.include_router(template_version_files_router)
 api_router.include_router(courses_router)
 api_router.include_router(quotas_router)
+api_router.include_router(openstack_flavors_router)
 api_router.include_router(github_app_router)
 
 __all__ = [

--- a/src/api/courses.py
+++ b/src/api/courses.py
@@ -2,11 +2,10 @@
 from typing import Optional
 from uuid import UUID
 
-from fastapi import APIRouter, status, Query, Depends
+from fastapi import APIRouter, status, Query, Depends, HTTPException
 
 from src.core.response_builder import ResponseBuilder
-from src.core.dependencies import DBSession, RequestID, Pagination, CurrentUser
-from src.core.auth import require_roles
+from src.core.dependencies import DBSession, RequestID, Pagination, CurrentUser, require_roles
 from src.core.exceptions import NotFoundException
 from src.schemas.course import CourseCreate, CourseUpdate, CourseResponse, CourseGroupCreate, CourseGroupResponse, CourseMemberResponse, GroupMemberAdd
 from src.services.course_service import CourseService
@@ -14,6 +13,8 @@ from src.models.user import UserRole
 from src.models.course_group import CourseGroup
 from src.models.course_member import CourseMember
 from src.models.group_member import GroupMember
+from src.repositories.openstack_project_repository import OpenstackProjectRepository
+from src.api.deployments import get_deployment_owner_id
 from sqlalchemy.orm import joinedload
 
 
@@ -24,6 +25,68 @@ router = APIRouter(
 )
 
 
+def _authorize_courses_scope(
+    current_user: dict,
+    openstack_project_id: Optional[UUID],
+    db,
+) -> bool:
+    """Validate the OpenStack-project scoping for course-list/detail reads.
+
+    Mirrors the auth block in ``list_deployments``: non-admins MUST pass an
+    ``openstack_project_id`` and that project must belong to them. Returns
+    ``is_admin`` so the caller can decide whether to apply the embedded
+    Owner-filter.
+    """
+    user_roles = current_user.get("roles", [])
+    is_admin = "admin" in [r.lower() for r in user_roles]
+    if is_admin:
+        return True
+
+    if openstack_project_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="openstack_project_id query parameter is required",
+        )
+
+    openstack_repo = OpenstackProjectRepository(db)
+    proj = openstack_repo.get_by_id(str(openstack_project_id))
+    if not proj or proj.owner_user_id != current_user["user_id"]:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="OpenStack project does not belong to user",
+        )
+    return False
+
+
+def _filter_deployments_by_owner(courses, current_user_id: str, db) -> None:
+    """In-place restrict each course's embedded deployments to the caller.
+
+    The repository already filtered the eager-loaded list by
+    ``openstack_project_id``; this strips out any deployment whose
+    ``deployment_parameters.teacher.id`` does not resolve to the calling user.
+    Owner-resolution lives in ``deployment_parameters`` JSON, not on a column,
+    so this stays in Python (same trade-off as PR #137).
+
+    Unlike the per-deployment endpoints (which use ``get_deployment_owner_id``
+    to *authorize* access and want to surface a 500 on a missing teacher
+    record), here we are *filtering* a list. A single deployment with a stale
+    or unresolvable teacher.id (e.g. user deleted from the local DB but row
+    still here) must not fail the whole listing — we drop it instead, which is
+    also the safer default for a leak fix.
+    """
+    for course in courses:
+        kept = []
+        for d in course.deployments:
+            try:
+                owner_id = get_deployment_owner_id(d, db)
+            except HTTPException:
+                # Owner not resolvable — drop the row (safer than leaking it).
+                continue
+            if owner_id == current_user_id:
+                kept.append(d)
+        course.deployments = kept
+
+
 @router.get("", response_model=None)
 async def list_courses(
     pagination: Pagination,
@@ -31,27 +94,46 @@ async def list_courses(
     request_id: RequestID,
     current_user: CurrentUser,
     search: Optional[str] = Query(None, description="Search in course name or Keycloak course ID"),
+    openstack_project_id: UUID | None = Query(
+        None,
+        description=(
+            "OpenStack project (local DB id) whose deployments to embed in each course. "
+            "Required for non-admin users; ignored for admins unless provided."
+        ),
+    ),
 ):
     """List all courses with optional filters and pagination.
-    
+
     Supports filtering by:
     - Search term (searches course name or keycloak_course_id)
-    
+
+    Authorization & visibility:
+    - Admins see all courses. If ``openstack_project_id`` is passed, the
+      embedded deployments are restricted to that project; otherwise all.
+    - Non-admins (lecturers) MUST pass ``openstack_project_id`` and only see
+      deployments that they own (teacher.id == them) within that project
+      embedded under each course.
+
     Returns paginated results with total count.
     """
+    is_admin = _authorize_courses_scope(current_user, openstack_project_id, db)
+
     service = CourseService(db)
-    
     courses, total = service.list_courses(
         skip=(pagination.page - 1) * pagination.page_size,
         limit=pagination.page_size,
         search=search,
+        openstack_project_id=str(openstack_project_id) if openstack_project_id else None,
     )
-    
+
+    if not is_admin:
+        _filter_deployments_by_owner(courses, current_user["user_id"], db)
+
     course_responses = [
         CourseResponse.model_validate(course).model_dump(mode="json")
         for course in courses
     ]
-    
+
     return ResponseBuilder.paginated(
         data=course_responses,
         page=pagination.page,
@@ -67,16 +149,33 @@ async def get_course(
     db: DBSession,
     request_id: RequestID,
     current_user: CurrentUser,
+    openstack_project_id: UUID | None = Query(
+        None,
+        description=(
+            "OpenStack project (local DB id) whose deployments to embed. "
+            "Required for non-admin users; ignored for admins unless provided."
+        ),
+    ),
 ):
     """Get a single course by ID.
-    
-    Returns complete course details including metadata and timestamps.
+
+    Returns complete course details including metadata and timestamps. The
+    embedded ``deployments`` collection follows the same scoping rules as
+    ``GET /courses``.
     """
+    is_admin = _authorize_courses_scope(current_user, openstack_project_id, db)
+
     service = CourseService(db)
-    course = service.get_course(str(course_id))
-    
+    course = service.get_course(
+        str(course_id),
+        openstack_project_id=str(openstack_project_id) if openstack_project_id else None,
+    )
+
+    if not is_admin:
+        _filter_deployments_by_owner([course], current_user["user_id"], db)
+
     course_response = CourseResponse.model_validate(course)
-    
+
     return ResponseBuilder.success(
         data=course_response.model_dump(mode="json"),
         message="Course retrieved successfully",

--- a/src/api/deployments.py
+++ b/src/api/deployments.py
@@ -380,6 +380,7 @@ async def get_deployment(
             "openstack_instance_id": instance.openstack_server_id,
             "status": instance.status.value if instance.status else None,
             "ip_address": instance.ip_address,
+            "flavor": instance.flavor,
             "access_urls": [
                 {
                     "id": str(access.id),

--- a/src/api/deployments.py
+++ b/src/api/deployments.py
@@ -11,7 +11,7 @@ from src.core.response_builder import ResponseBuilder
 from src.core.dependencies import RequestID, Pagination, CurrentUser, require_roles
 from src.repositories.deployment_repository import DeploymentRepository
 from src.repositories.openstack_project_repository import OpenstackProjectRepository
-from src.schemas.deployment import DeploymentResponse, DeploymentCreate
+from src.schemas.deployment import DeploymentResponse, DeploymentCreate, DeploymentExtend
 from src.services.deployment_service import DeploymentService
 from src.services.deployment_log_service import DeploymentLogService
 from src.services.openstack_heat_service import HeatStackService
@@ -760,6 +760,63 @@ async def restart_deployment(
         message="Restart requested; operation is in progress",
         request_id=request_id,
         status_code=status.HTTP_202_ACCEPTED,
+    )
+
+
+@router.patch(
+    "/{deployment_id}/extend",
+    summary="Extend a deployment's lifetime",
+    responses={
+        200: {"description": "Lifetime extended; new expires_at returned"},
+        400: {"description": "Deployment is already deleted or runtime_months invalid"},
+        403: {"description": "Forbidden - not owner or insufficient role"},
+        404: {"description": "Deployment not found"},
+    },
+)
+async def extend_deployment(
+    deployment_id: str,
+    payload: DeploymentExtend,
+    db: DBSession,
+    request_id: RequestID,
+    user: CurrentUser,
+    openstack_project_id: UUID | None = Query(
+        None,
+        description="OpenStack project (local DB id) the deployment must belong to. Required for non-admin users.",
+    ),
+):
+    """Push the deployment's ``expires_at`` out by ``runtime_months`` months.
+
+    Anchored on ``max(now, current_expires_at)``: if the deployment is still
+    valid, the new window stacks on top of its existing end date; if it has
+    already expired (but not yet been swept by the daily beat job), the
+    extension counts from now. Companion ``expiry_warning_at`` is recomputed
+    so the UI banner timing matches the new lifetime.
+
+    **Authorization:** Owner (lecturer) or Admin only.
+    """
+    deployment_repo = DeploymentRepository(db)
+    deployment = deployment_repo.get_by_id(deployment_id)
+
+    if not deployment:
+        raise NotFoundException(f"Deployment with ID {deployment_id} not found")
+
+    authorize_deployment_access(deployment, user, openstack_project_id, db)
+
+    service = DeploymentService(db)
+    updated = service.extend_deployment(
+        deployment_id=deployment_id,
+        runtime_months=payload.runtime_months,
+    )
+
+    return ResponseBuilder.success(
+        data={
+            "deployment_id": str(updated.id),
+            "expires_at": updated.expires_at.isoformat() if updated.expires_at else None,
+            "expiry_warning_at": updated.expiry_warning_at.isoformat() if updated.expiry_warning_at else None,
+            "runtime_months_added": payload.runtime_months,
+        },
+        message=f"Deployment lifetime extended by {payload.runtime_months} months",
+        request_id=request_id,
     )
 
 

--- a/src/api/openstack_flavors.py
+++ b/src/api/openstack_flavors.py
@@ -1,0 +1,123 @@
+"""OpenStack flavors API endpoint.
+
+Exposes the available Nova flavors (compute size offerings) for an
+OpenStack project. Used by the frontend to resolve flavor *names*
+(e.g. ``gp1.small``) into actual vCPU / RAM / disk numbers, instead
+of the previously hardcoded ``*2 / *4 / *20`` multipliers in
+``DeploymentDetailsPage.tsx`` and ``AdminMonitoring.tsx``.
+
+Auth & project scoping mirror the ``/quotas`` endpoint:
+- Lecturers may only read flavors for their own project.
+- Admins may pass ``project_id`` or ``lecturer_id`` to read any project.
+"""
+import logging
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query
+
+from src.core.dependencies import CurrentUser, DBSession, RequestID, require_roles
+from src.core.exceptions import ForbiddenException, NotFoundException
+from src.core.response_builder import ResponseBuilder
+from src.models.user import UserRole
+from src.repositories.openstack_project_repository import OpenstackProjectRepository
+from src.schemas.openstack_resources import FlavorsResponse
+from src.services.openstack_resource_service import OpenstackResourceService
+
+logger = logging.getLogger(__name__)
+
+
+router = APIRouter(
+    prefix="/openstack",
+    tags=["openstack"],
+    dependencies=[Depends(require_roles(UserRole.ADMIN, UserRole.LECTURER))],
+)
+
+
+@router.get(
+    "/flavors",
+    response_model=FlavorsResponse,
+)
+async def get_flavors(
+    db: DBSession,
+    request_id: RequestID,
+    user: CurrentUser,
+    lecturer_id: UUID | None = Query(
+        None,
+        description=(
+            "Lecturer user ID (admin only). Each lecturer has exactly one project. "
+            "If specified, returns flavors visible to that lecturer's project."
+        ),
+    ),
+    project_id: UUID | None = Query(
+        None,
+        description=(
+            "Project ID (optional, defaults to user's own project). "
+            "Admins can specify any project ID."
+        ),
+    ),
+):
+    """Get the list of available Nova flavors for an OpenStack project.
+
+    Returns one entry per flavor with ``id``, ``name``, ``vcpus``,
+    ``ram_mb``, ``disk_gb``, ``ephemeral_gb`` and ``is_public``.
+
+    Access Control:
+    - LECTURER: only their own project
+    - ADMIN: any project (via ``project_id`` or ``lecturer_id``)
+    """
+    user_id = user.get("user_id")
+    if not user_id:
+        raise ForbiddenException("User ID not found in authentication token")
+
+    user_roles = user.get("roles", [])
+    is_admin = UserRole.ADMIN.value in user_roles
+
+    target_user_id: str = user_id
+    project_id_str: str | None = None
+
+    # Priority: lecturer_id > project_id > caller's own project
+    if lecturer_id:
+        if not is_admin:
+            raise ForbiddenException("Only admins can specify lecturer_id")
+
+        target_user_id = str(lecturer_id)
+        project_repo = OpenstackProjectRepository(db)
+
+        if not project_repo.user_exists(target_user_id):
+            logger.warning(f"Lecturer not found: {lecturer_id}")
+            raise NotFoundException(f"Lecturer with ID {lecturer_id} does not exist")
+
+        lecturer_projects = project_repo.get_by_owner(target_user_id)
+        if not lecturer_projects:
+            logger.warning(f"No project found for lecturer: {lecturer_id}")
+            raise NotFoundException(
+                f"No OpenStack project found for lecturer with ID {lecturer_id}"
+            )
+
+        if len(lecturer_projects) > 1:
+            logger.warning(
+                f"Lecturer {lecturer_id} has {len(lecturer_projects)} projects (expected 1), using first one",
+                extra={"lecturer_id": str(lecturer_id), "project_count": len(lecturer_projects)},
+            )
+        project_id_str = str(lecturer_projects[0].id)
+    elif project_id:
+        project_id_str = str(project_id)
+        # Ownership check is delegated to the service via _get_project_for_user
+
+    resource_service = OpenstackResourceService(db)
+    flavors_data = resource_service.get_flavors(
+        user_id=target_user_id,
+        project_id=project_id_str,
+        allow_admin_access=is_admin,
+    )
+
+    # owner_user_id is only surfaced to admins (consistent with /quotas)
+    owner_user_id = flavors_data.get("owner_user_id") if is_admin else None
+
+    response_data = FlavorsResponse.from_service_dict(flavors_data, owner_user_id=owner_user_id)
+
+    return ResponseBuilder.success(
+        data=response_data,
+        message="Flavors retrieved successfully",
+        request_id=request_id,
+    )

--- a/src/celery_app.py
+++ b/src/celery_app.py
@@ -1,6 +1,7 @@
 """Celery application configuration."""
 import logging
 from celery import Celery
+from celery.schedules import crontab
 from celery.signals import setup_logging
 
 from src.core.config import get_settings
@@ -12,7 +13,11 @@ celery_app = Celery(
     "appstore",
     broker=settings.redis_url,
     backend=settings.redis_url,
-    include=["src.tasks.deploy_tasks", "src.tasks.sync_tasks"],
+    include=[
+        "src.tasks.deploy_tasks",
+        "src.tasks.sync_tasks",
+        "src.tasks.expiry_tasks",
+    ],
 )
 
 # Celery configuration
@@ -26,6 +31,18 @@ celery_app.conf.update(
     task_time_limit=30 * 60,  # 30 minutes
     worker_prefetch_multiplier=1,
 )
+
+# Periodic tasks. Run a daily sweep that hard-deletes deployments whose
+# ``expires_at`` lies in the past — see src/tasks/expiry_tasks.py for the
+# semantics. Scheduled at 03:17 UTC: off-the-hour to avoid colliding with
+# every other system's hourly cron, and during low-traffic hours so the
+# Heat-stack tear-downs don't fight peak-hour deployments.
+celery_app.conf.beat_schedule = {
+    "expire-deployments-daily": {
+        "task": "src.tasks.expiry_tasks.expire_deployments",
+        "schedule": crontab(hour=3, minute=17),
+    },
+}
 
 
 @setup_logging.connect

--- a/src/models/deployment.py
+++ b/src/models/deployment.py
@@ -42,6 +42,17 @@ class Deployment(Base):
     )
     openstack_stack_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     deployment_parameters: Mapped[Optional[str]] = mapped_column(String, nullable=True, comment="Heat parameters, stack_assignments, and teacher info as JSON")
+    expires_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime,
+        nullable=True,
+        index=True,
+        comment="When this deployment is hard-deleted by the daily expire_deployments_task; NULL = never expire",
+    )
+    expiry_warning_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime,
+        nullable=True,
+        comment="When the UI should start showing the 'expires soon' warning; computed at creation/extend",
+    )
     created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
     updated_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 

--- a/src/models/deployment_instance.py
+++ b/src/models/deployment_instance.py
@@ -29,6 +29,12 @@ class DeploymentInstance(Base):
     vm_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
     openstack_server_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
     ip_address: Mapped[str | None] = mapped_column(String(45), nullable=True)
+    # OpenStack Nova flavor name used for this instance (e.g. "gp1.small").
+    # Captured from the Heat-stack parameters at creation time so the frontend
+    # can resolve real vCPU/RAM/disk values via /api/v1/openstack/flavors,
+    # instead of using hardcoded multipliers. Nullable for legacy rows
+    # created before this column existed.
+    flavor: Mapped[str | None] = mapped_column(String(255), nullable=True)
     status: Mapped[DeploymentInstanceStatus] = mapped_column(
         SQLEnum(DeploymentInstanceStatus), 
         default=DeploymentInstanceStatus.CREATING

--- a/src/models/deployment_log.py
+++ b/src/models/deployment_log.py
@@ -27,6 +27,8 @@ class DeploymentLogEventType(str, Enum):
     FAILED = "failed"
     DEPLOYMENT_DELETION_REQUESTED = "deployment_deletion_requested"
     DEPLOYMENT_DELETED = "deployment_deleted"
+    DEPLOYMENT_LIFETIME_EXTENDED = "deployment_lifetime_extended"
+    DEPLOYMENT_EXPIRED = "deployment_expired"
     # Ansible
     SSH_WAIT = "ssh_wait"
     ANSIBLE_STARTED = "ansible_started"

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -28,27 +28,35 @@ class UserRole(str, Enum):
 
 
 class User(Base):
-    """Minimal user record for database relationships only.
-    
+    """Minimal user record for database relationships + cached display fields.
+
     DESIGN PRINCIPLE:
     =================
-    This table stores ONLY what's needed for foreign key relationships.
-    All user attributes (email, name, roles) come from Keycloak token.
-    
+    This table stores what's needed for foreign key relationships, plus a
+    small set of CACHED display fields (display_name, email, username) so
+    the API can render owner names without round-tripping to Keycloak on
+    every request.
+
+    Source of truth for everything user-related is still the Keycloak JWT
+    token. Roles in particular are NEVER read from this table — they come
+    exclusively from `realm_access.roles` on the token, on every request.
+    The cached fields below may be stale until the user logs in again.
+
     Why this table exists:
     - Enable foreign keys: courses.lecturer_id → users.id
     - Referential integrity in PostgreSQL
     - Audit trail: Track who created resources
-    
+    - Cached display fields for owner-name lookups (e.g. Template approval
+      cards), refreshed on every login
+
     What this table does NOT store:
-    - email (read from token)
-    - name (read from token)
     - roles (read from token - Keycloak is source of truth)
     - is_active (read from token)
-    
+
     User sync on login:
-    - First login → User created with external_id from token
-    - Subsequent logins → last_login_at updated
+    - First login → User created with external_id + display fields from token
+    - Subsequent logins → last_login_at updated; display fields refreshed
+      if the token claims differ
     """
     
     __tablename__ = "users"
@@ -63,13 +71,31 @@ class User(Base):
     
     # Keycloak user ID (token 'sub' claim) - links to Keycloak
     external_id: Mapped[str] = mapped_column(
-        String(255), 
-        nullable=False, 
+        String(255),
+        nullable=False,
         unique=True,
         index=True,
         comment="Keycloak user UUID (sub claim) - IMMUTABLE"
     )
-    
+
+    # Cached display fields, refreshed from the JWT on every login.
+    # Display-only — never used for authorization. Source of truth is Keycloak.
+    display_name: Mapped[str | None] = mapped_column(
+        String(255),
+        nullable=True,
+        comment="Cached full name from Keycloak token 'name' claim; nullable for legacy rows"
+    )
+    email: Mapped[str | None] = mapped_column(
+        String(255),
+        nullable=True,
+        comment="Cached email from Keycloak token; nullable for legacy rows"
+    )
+    username: Mapped[str | None] = mapped_column(
+        String(255),
+        nullable=True,
+        comment="Cached preferred_username from Keycloak token; nullable for legacy rows"
+    )
+
     # Audit: When was user first seen?
     created_at: Mapped[datetime] = mapped_column(
         DateTime, 

--- a/src/repositories/course_repository.py
+++ b/src/repositories/course_repository.py
@@ -1,9 +1,10 @@
 """Course repository for database operations."""
 from typing import Optional
 
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import Session, selectinload
 
 from src.models.course import Course
+from src.models.deployment import Deployment
 from src.repositories.base_repository import BaseRepository
 
 
@@ -12,7 +13,7 @@ class CourseRepository(BaseRepository[Course]):
 
     def __init__(self, db: Session):
         """Initialize CourseRepository with database session.
-        
+
         Args:
             db: SQLAlchemy database session
         """
@@ -31,19 +32,41 @@ class CourseRepository(BaseRepository[Course]):
             )
         return query
 
+    def _deployments_loader(self, openstack_project_id: Optional[str]):
+        """Build the eager-load option for ``Course.deployments``.
+
+        When ``openstack_project_id`` is set, only deployments belonging to that
+        OpenStack project are eager-loaded into ``course.deployments``. We use
+        ``selectinload`` (not ``joinedload``) so the embedded list is filtered
+        cleanly via a separate ``WHERE deployment.course_id IN (...) AND
+        deployment.openstack_project_id = ?`` query, instead of mixing courses
+        and deployments into one row-set that ``and_()`` filters can't dedup.
+        """
+        if openstack_project_id is None:
+            return selectinload(self.model.deployments)
+        return selectinload(
+            self.model.deployments.and_(
+                Deployment.openstack_project_id == str(openstack_project_id)
+            )
+        )
+
     def get_all_filtered(
         self,
         skip: int = 0,
         limit: int = 100,
         search: Optional[str] = None,
+        openstack_project_id: Optional[str] = None,
     ) -> tuple[list[Course], int]:
         """Get all courses with filters and pagination.
-        
+
         Args:
             skip: Number of records to skip (offset)
             limit: Maximum number of records to return
             search: Search term for course name or keycloak_course_id
-            
+            openstack_project_id: If set, only deployments belonging to this
+                OpenStack project (local DB id) are eager-loaded into
+                ``course.deployments``. Courses themselves are not filtered.
+
         Returns:
             Tuple of (list of courses, total count)
         """
@@ -51,16 +74,38 @@ class CourseRepository(BaseRepository[Course]):
             self.db.query(self.model),
             search
         )
-        
+
         total = base_query.count()
-        
+
         courses = (
             base_query
-            .options(joinedload(self.model.deployments))
+            .options(self._deployments_loader(openstack_project_id))
             .order_by(self.model.created_at.desc())
             .offset(skip)
             .limit(limit)
             .all()
         )
-        
+
         return courses, total
+
+    def get_by_id_with_deployments(
+        self,
+        course_id: str,
+        openstack_project_id: Optional[str] = None,
+    ) -> Optional[Course]:
+        """Fetch a course by id with its deployments eager-loaded.
+
+        Args:
+            course_id: Course primary key.
+            openstack_project_id: Same semantics as ``get_all_filtered`` —
+                filters the embedded ``deployments`` collection only.
+
+        Returns:
+            The Course (with filtered deployments) or ``None`` if not found.
+        """
+        return (
+            self.db.query(self.model)
+            .options(self._deployments_loader(openstack_project_id))
+            .filter(self.model.id == str(course_id))
+            .first()
+        )

--- a/src/repositories/template_repository.py
+++ b/src/repositories/template_repository.py
@@ -3,7 +3,7 @@ from typing import Optional
 from uuid import UUID
 
 from sqlalchemy import and_, exists, or_
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 from src.models.template import Template, TemplateVisibility
 from src.models.template_version import TemplateVersion, TemplateVersionApprovalStatus
@@ -16,6 +16,19 @@ class TemplateRepository(BaseRepository[Template]):
     def __init__(self, db: Session):
         """Initialize TemplateRepository with database session."""
         super().__init__(Template, db)
+
+    def get_by_id(self, id):
+        """Get a template by ID with the owner relationship eager-loaded.
+
+        Override of BaseRepository.get_by_id so consumers always have access
+        to ``template.owner.display_name`` without an extra round-trip.
+        """
+        return (
+            self.db.query(self.model)
+            .options(joinedload(self.model.owner))
+            .filter(self.model.id == str(id))
+            .first()
+        )
 
     @staticmethod
     def _has_approved_version_clause():
@@ -54,7 +67,7 @@ class TemplateRepository(BaseRepository[Template]):
         that have at least one APPROVED version. Pass ``None`` for admins / when
         the caller has already gated access elsewhere.
         """
-        query = self.db.query(self.model)
+        query = self.db.query(self.model).options(joinedload(self.model.owner))
 
         if visibility:
             query = query.filter(self.model.visibility == visibility)

--- a/src/schemas/deployment.py
+++ b/src/schemas/deployment.py
@@ -1,7 +1,13 @@
 """Deployment schemas for request/response validation."""
-from pydantic import BaseModel, Field, ConfigDict
+from pydantic import BaseModel, Field, ConfigDict, field_validator
 from datetime import datetime
 from typing import Optional, Any
+
+
+# Allowed lifetime presets matching the Wizard dropdown.
+# Keep this in sync with appstore-frontend/src/pages/DeploymentWizard.tsx.
+ALLOWED_RUNTIME_MONTHS = (1, 3, 4, 6, 12, 24)
+DEFAULT_RUNTIME_MONTHS = 4
 
 
 class StudentInfo(BaseModel):
@@ -66,6 +72,29 @@ class DeploymentCreate(BaseModel):
         ...,
         description="Teacher/lecturer information for admin access"
     )
+
+    # Lifetime: how many months until the deployment is hard-deleted by the
+    # daily expire_deployments_task. Must be one of ALLOWED_RUNTIME_MONTHS.
+    # Defaults to 4 months when omitted (matches Wizard default).
+    runtime_months: int = Field(
+        default=DEFAULT_RUNTIME_MONTHS,
+        description=(
+            f"Deployment lifetime in months. Must be one of "
+            f"{list(ALLOWED_RUNTIME_MONTHS)}. After this many months the "
+            f"deployment is hard-deleted (Heat-stack down + DB row removed) "
+            f"by the daily expire_deployments_task. Default: "
+            f"{DEFAULT_RUNTIME_MONTHS} months."
+        ),
+    )
+
+    @field_validator("runtime_months")
+    @classmethod
+    def _runtime_months_in_allowed_set(cls, v: int) -> int:
+        if v not in ALLOWED_RUNTIME_MONTHS:
+            raise ValueError(
+                f"runtime_months must be one of {list(ALLOWED_RUNTIME_MONTHS)}, got {v}"
+            )
+        return v
     
     model_config = ConfigDict(
         json_schema_extra={
@@ -122,9 +151,20 @@ class DeploymentResponse(BaseModel):
     status: str = Field(..., description="Current status")
     openstack_stack_id: Optional[str] = Field(None, description="OpenStack Heat stack ID")
     deployment_parameters: Optional[str] = Field(None, description="Heat template parameters as JSON string")
+    expires_at: Optional[datetime] = Field(
+        None,
+        description="Hard-delete timestamp (NULL = never expires).",
+    )
+    expiry_warning_at: Optional[datetime] = Field(
+        None,
+        description=(
+            "When the UI should start showing the expiry warning. Frontend "
+            "renders the banner/icon when now() > expiry_warning_at."
+        ),
+    )
     created_at: datetime = Field(..., description="Creation timestamp")
     updated_at: datetime = Field(..., description="Last update timestamp")
-    
+
     model_config = ConfigDict(
         from_attributes=True,
         json_schema_extra={
@@ -136,10 +176,43 @@ class DeploymentResponse(BaseModel):
                 "status": "queued",
                 "openstack_stack_id": None,
                 "deployment_parameters": '{"image": "Ubuntu 22.04", "flavor": "gp1.small"}',
+                "expires_at": "2026-10-27T10:00:00Z",
+                "expiry_warning_at": "2026-10-13T10:00:00Z",
                 "created_at": "2024-11-27T10:00:00Z",
                 "updated_at": "2024-11-27T10:00:00Z"
             }
         }
+    )
+
+
+class DeploymentExtend(BaseModel):
+    """Body for ``PATCH /deployments/{id}/extend``.
+
+    Pushes ``expires_at`` out by ``runtime_months``, anchored at
+    ``max(now, expires_at)`` so that an already-expired-but-not-yet-deleted
+    deployment is extended from now (not from the past), and a still-valid
+    deployment is extended from its existing end date.
+    """
+
+    runtime_months: int = Field(
+        default=DEFAULT_RUNTIME_MONTHS,
+        description=(
+            f"Months to add to the deployment lifetime. Must be one of "
+            f"{list(ALLOWED_RUNTIME_MONTHS)}."
+        ),
+    )
+
+    @field_validator("runtime_months")
+    @classmethod
+    def _runtime_months_in_allowed_set(cls, v: int) -> int:
+        if v not in ALLOWED_RUNTIME_MONTHS:
+            raise ValueError(
+                f"runtime_months must be one of {list(ALLOWED_RUNTIME_MONTHS)}, got {v}"
+            )
+        return v
+
+    model_config = ConfigDict(
+        json_schema_extra={"example": {"runtime_months": 4}}
     )
 
 

--- a/src/schemas/openstack_resources.py
+++ b/src/schemas/openstack_resources.py
@@ -1,6 +1,74 @@
 """OpenStack Resources schemas for quota and usage responses."""
 from pydantic import BaseModel, Field
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
+
+
+class FlavorDto(BaseModel):
+    """Schema for a single Nova flavor (compute size offering).
+
+    Mirrors the fields the frontend needs to resolve a flavor name
+    (e.g. ``gp1.small``) to actual vCPU / RAM / disk numbers, instead of
+    the previously hardcoded multipliers in ``DeploymentDetailsPage`` and
+    ``AdminMonitoring``.
+    """
+
+    id: str = Field(..., description="Nova flavor ID (UUID or numeric string)")
+    name: str = Field(..., description="Flavor name (e.g. 'gp1.small')")
+    vcpus: int = Field(..., description="Number of virtual CPUs")
+    ram_mb: int = Field(..., description="RAM in megabytes")
+    disk_gb: int = Field(..., description="Root disk size in gigabytes")
+    ephemeral_gb: int = Field(0, description="Ephemeral disk size in gigabytes")
+    is_public: bool = Field(True, description="Whether the flavor is publicly visible")
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "id": "1",
+                "name": "gp1.small",
+                "vcpus": 2,
+                "ram_mb": 4096,
+                "disk_gb": 20,
+                "ephemeral_gb": 0,
+                "is_public": True,
+            }
+        }
+    }
+
+
+class FlavorsResponse(BaseModel):
+    """Schema for the list-flavors endpoint response."""
+
+    project_id: str = Field(..., description="OpenStack project ID the flavors were fetched from")
+    project_name: str = Field(..., description="OpenStack project name")
+    owner_user_id: Optional[str] = Field(None, description="Owner user ID (only set for admin access)")
+    flavors: List[FlavorDto] = Field(default_factory=list, description="List of available flavors")
+    fetched_at: Optional[str] = Field(None, description="Timestamp when data was fetched (ISO format)")
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "project_id": "abc123def456",
+                "project_name": "my_project_ws2024",
+                "owner_user_id": None,
+                "flavors": [
+                    {"id": "1", "name": "gp1.small", "vcpus": 2, "ram_mb": 4096, "disk_gb": 20, "ephemeral_gb": 0, "is_public": True},
+                    {"id": "2", "name": "gp1.medium", "vcpus": 4, "ram_mb": 8192, "disk_gb": 40, "ephemeral_gb": 0, "is_public": True},
+                ],
+                "fetched_at": "2024-11-27T10:00:00Z",
+            }
+        }
+    }
+
+    @classmethod
+    def from_service_dict(cls, data: Dict[str, Any], owner_user_id: Optional[str] = None) -> "FlavorsResponse":
+        """Create FlavorsResponse from service dictionary."""
+        return cls(
+            project_id=data.get("project_id", ""),
+            project_name=data.get("project_name", ""),
+            owner_user_id=owner_user_id,
+            flavors=[FlavorDto(**f) for f in data.get("flavors", [])],
+            fetched_at=data.get("fetched_at"),
+        )
 
 
 class QuotaResource(BaseModel):

--- a/src/schemas/template.py
+++ b/src/schemas/template.py
@@ -1,7 +1,7 @@
 """Template schemas for request/response validation."""
-from pydantic import BaseModel, Field, ConfigDict
+from pydantic import BaseModel, Field, ConfigDict, computed_field
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
 from src.schemas.template_version import TemplateVersionResponse
 
 
@@ -65,6 +65,36 @@ class TemplateResponse(BaseModel):
     created_at: datetime = Field(..., description="Creation timestamp")
     updated_at: datetime = Field(..., description="Last update timestamp")
 
+    # The owning User ORM instance is held internally so we can derive the
+    # display fields below without re-querying. It is excluded from the
+    # serialized response — only `owner_name`, `owner_email`, and
+    # `owner_username` are exposed to clients.
+    owner: Any = Field(default=None, exclude=True, repr=False)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def owner_name(self) -> Optional[str]:
+        """Cached display name of the template owner.
+
+        Sourced from the Keycloak token's `name` claim and refreshed on every
+        login (see ``UserSyncService``). May be ``None`` for legacy users who
+        have not logged in since this column was introduced — clients should
+        fall back to ``owner_id`` in that case.
+        """
+        return getattr(self.owner, "display_name", None) if self.owner else None
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def owner_email(self) -> Optional[str]:
+        """Cached email of the template owner; ``None`` for legacy users."""
+        return getattr(self.owner, "email", None) if self.owner else None
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def owner_username(self) -> Optional[str]:
+        """Cached preferred_username of the owner; ``None`` for legacy users."""
+        return getattr(self.owner, "username", None) if self.owner else None
+
     model_config = ConfigDict(
         from_attributes=True,
         json_schema_extra={
@@ -73,6 +103,9 @@ class TemplateResponse(BaseModel):
                 "name": "Python Flask Template",
                 "description": "A template for Flask web applications",
                 "owner_id": "user-456",
+                "owner_name": "Prof. Dr. Bernd Berg",
+                "owner_email": "berg@dhbw.de",
+                "owner_username": "bberg",
                 "repo_url": "https://github.com/example/flask-template",
                 "icon_url": "mdi:flask",
                 "visibility": "public",

--- a/src/services/course_service.py
+++ b/src/services/course_service.py
@@ -40,19 +40,32 @@ class CourseService:
         )
         return course
 
-    def get_course(self, course_id: str | UUID) -> Course:
+    def get_course(
+        self,
+        course_id: str | UUID,
+        openstack_project_id: Optional[str] = None,
+    ) -> Course:
         """Get a course by ID.
-        
+
         Args:
             course_id: Course ID
-            
+            openstack_project_id: If set, the embedded ``deployments`` collection
+                is restricted to that OpenStack project. ``None`` returns all
+                deployments (admin path / call sites that don't care).
+
         Returns:
             Course instance
-            
+
         Raises:
             NotFoundException: If course not found
         """
-        course = self.course_repo.get_by_id(course_id)
+        if openstack_project_id is not None:
+            course = self.course_repo.get_by_id_with_deployments(
+                str(course_id),
+                openstack_project_id=openstack_project_id,
+            )
+        else:
+            course = self.course_repo.get_by_id(course_id)
         if not course:
             raise NotFoundException(f"Course with ID {course_id} not found")
         return course
@@ -62,14 +75,18 @@ class CourseService:
         skip: int = 0,
         limit: int = 100,
         search: Optional[str] = None,
+        openstack_project_id: Optional[str] = None,
     ) -> tuple[list[Course], int]:
         """List courses with filters and pagination.
-        
+
         Args:
             skip: Number of records to skip
             limit: Maximum number of records to return
             search: Search term for course name or keycloak_course_id
-            
+            openstack_project_id: If set, restricts the embedded ``deployments``
+                collection to that OpenStack project. Courses themselves are
+                always returned.
+
         Returns:
             Tuple of (list of courses, total count)
         """
@@ -77,6 +94,7 @@ class CourseService:
             skip=skip,
             limit=limit,
             search=search,
+            openstack_project_id=openstack_project_id,
         )
 
     def update_course(

--- a/src/services/deployment_credential_service.py
+++ b/src/services/deployment_credential_service.py
@@ -21,11 +21,13 @@ class DeploymentCredentialService:
         user_json: dict[str, Any],
         floating_ip: str = "",
         heat_outputs: dict[str, Any] | None = None,
+        flavor: str | None = None,
     ) -> DeploymentInstance:
         instance = DeploymentInstance(
             deployment_id=deployment_id,
             vm_name=stack_name,
             openstack_server_id=openstack_stack_id,
+            flavor=flavor,
             status=DeploymentInstanceStatus.RUNNING,
         )
         self.db.add(instance)

--- a/src/services/deployment_service.py
+++ b/src/services/deployment_service.py
@@ -16,6 +16,7 @@ from src.core.exceptions import NotFoundException
 from src.core.exceptions import BadRequestException
 from src.services.template_version_file_service import TemplateVersionFileService
 from src.tasks.deploy_tasks import deploy_stack
+from src.utils.deployment_expiry import compute_expiry, compute_extension, utcnow
 
 
 class DeploymentService:
@@ -162,6 +163,11 @@ class DeploymentService:
 
         # Create deployment record with initial status QUEUED
         # Use course.id (DB ID) instead of keycloak_course_id
+        # Compute expiry timestamps from runtime_months so the daily Beat
+        # sweep knows when to delete and the UI knows when to start warning.
+        now = utcnow()
+        expires_at, expiry_warning_at = compute_expiry(now, deployment_data.runtime_months)
+
         deployment = self.deployment_repo.create(
             name=deployment_data.name,
             template_version_id=deployment_data.template_version_id,
@@ -169,6 +175,8 @@ class DeploymentService:
             openstack_project_id=openstack_project.id,
             status=DeploymentStatus.QUEUED,
             deployment_parameters=deployment_parameters,
+            expires_at=expires_at,
+            expiry_warning_at=expiry_warning_at,
         )
         
         # Create initial log entry
@@ -183,14 +191,75 @@ class DeploymentService:
                 "keycloak_group_id": deployment_data.course_id,
                 "stack_count": len(deployment_data.stack_assignments),
                 "total_groups": sum(len(sa.groups) for sa in deployment_data.stack_assignments),
-                "has_parameters": bool(deployment_data.parameters)
+                "has_parameters": bool(deployment_data.parameters),
+                "runtime_months": deployment_data.runtime_months,
+                "expires_at": expires_at.isoformat(),
             },
             request_id=request_id
         )
         
         # Trigger async Celery task for Heat stack orchestration
         deploy_stack.delay(str(deployment.id))
-        
+
+        return deployment
+
+    def extend_deployment(self, deployment_id: str, runtime_months: int) -> Deployment:
+        """Push ``expires_at`` out by ``runtime_months`` months.
+
+        Anchored on ``max(now, current_expires_at)`` so that an
+        already-expired-but-not-yet-deleted deployment is extended from now
+        rather than from the stale past, while a still-valid deployment
+        stacks the new window on top of its existing end date.
+
+        The companion ``expiry_warning_at`` is recomputed from the new
+        runtime so the UI banner timing matches.
+
+        Args:
+            deployment_id: ID of the deployment to extend.
+            runtime_months: Months to add (validated by ``DeploymentExtend``).
+
+        Returns:
+            The updated deployment.
+
+        Raises:
+            NotFoundException: If no such deployment exists.
+            BadRequestException: If the deployment is in a terminal state
+                                 (DELETED) where extending makes no sense.
+        """
+        deployment = self.deployment_repo.get_by_id(deployment_id)
+        if not deployment:
+            raise NotFoundException(f"Deployment {deployment_id} not found")
+
+        if deployment.status == DeploymentStatus.DELETED:
+            raise BadRequestException(
+                "Deployment is already deleted and cannot be extended"
+            )
+
+        now = utcnow()
+        new_expires_at, new_warning_at = compute_extension(
+            now=now,
+            current_expires_at=deployment.expires_at,
+            runtime_months=runtime_months,
+        )
+
+        deployment.expires_at = new_expires_at
+        deployment.expiry_warning_at = new_warning_at
+        self.db.commit()
+        self.db.refresh(deployment)
+
+        # Audit trail — the lifecycle policy is operationally significant.
+        self.log_service.log(
+            deployment_id=str(deployment.id),
+            event_type=DeploymentLogEventType.DEPLOYMENT_LIFETIME_EXTENDED,
+            message=f"Deployment lifetime extended by {runtime_months} months",
+            level=DeploymentLogLevel.INFO,
+            details={
+                "runtime_months_added": runtime_months,
+                "expires_at": new_expires_at.isoformat(),
+                "expiry_warning_at": new_warning_at.isoformat(),
+            },
+        )
+
         return deployment
     
     def list_deployments(

--- a/src/services/openstack_resource_service.py
+++ b/src/services/openstack_resource_service.py
@@ -340,6 +340,87 @@ class OpenstackResourceService:
             logger.error(f"OpenStack SDK error retrieving quotas: {e}")
             raise BadRequestException(f"Failed to retrieve quotas: {str(e)}")
     
+    def get_flavors(
+        self,
+        user_id: str,
+        project_id: Optional[str] = None,
+        allow_admin_access: bool = False,
+    ) -> dict:
+        """Get available Nova flavors for a project.
+
+        Proxies ``conn.compute.flavors(details=True)`` so the frontend can
+        resolve flavor names (``gp1.small`` …) to actual vCPU / RAM / disk
+        numbers. Replaces the hardcoded ``*2 / *4 / *20`` multiplier used
+        in ``DeploymentDetailsPage.tsx`` / ``AdminMonitoring.tsx``.
+
+        Args:
+            user_id: User ID to look up the OpenStack project for
+            project_id: Optional specific project ID (defaults to user's first project)
+            allow_admin_access: Allow admin to access any user's project
+
+        Returns:
+            Dict with project metadata and a flat ``flavors`` list:
+            {
+                'project_id': str,
+                'project_name': str,
+                'owner_user_id': str,
+                'flavors': [
+                    {'id', 'name', 'vcpus', 'ram_mb', 'disk_gb', 'ephemeral_gb', 'is_public'},
+                    ...
+                ],
+                'fetched_at': str,
+            }
+
+        Raises:
+            NotFoundException: No project found for user
+            ForbiddenException: User does not own the requested project
+            BadRequestException: OpenStack connection or API call failed
+        """
+        project = self._get_project_for_user(user_id, project_id, allow_admin_access)
+
+        try:
+            conn = self._get_connection(project)
+
+            flavors_list = []
+            for f in conn.compute.flavors(details=True):
+                flavors_list.append({
+                    'id': str(f.id),
+                    'name': f.name,
+                    'vcpus': f.vcpus or 0,
+                    'ram_mb': f.ram or 0,
+                    'disk_gb': f.disk or 0,
+                    'ephemeral_gb': getattr(f, 'ephemeral', 0) or 0,
+                    'is_public': getattr(f, 'is_public', True),
+                })
+
+            # Sort by vcpus then ram so the frontend can render them in a sensible order
+            flavors_list.sort(key=lambda x: (x['vcpus'], x['ram_mb']))
+
+            result = {
+                'project_id': project.openstack_project_id,
+                'project_name': project.openstack_project_name,
+                'owner_user_id': project.owner_user_id,
+                'flavors': flavors_list,
+                'fetched_at': datetime.now(timezone.utc).isoformat(),
+            }
+
+            logger.info(
+                f"Retrieved {len(flavors_list)} flavors for user {user_id}",
+                extra={"user_id": user_id, "project_id": project.openstack_project_id, "flavor_count": len(flavors_list)},
+            )
+
+            return result
+
+        except BadRequestException:
+            # Re-raise BadRequestException from _get_connection
+            raise
+        except HttpException as e:
+            logger.error(f"OpenStack API error retrieving flavors: {e}")
+            raise BadRequestException(f"Failed to retrieve flavors: {str(e)}")
+        except SDKException as e:
+            logger.error(f"OpenStack SDK error retrieving flavors: {e}")
+            raise BadRequestException(f"Failed to retrieve flavors: {str(e)}")
+
     def check_availability(
         self,
         user_id: str,

--- a/src/services/user_sync_service.py
+++ b/src/services/user_sync_service.py
@@ -52,48 +52,70 @@ class UserSyncService:
     
     def sync_user_from_token(self, token_payload: dict) -> User:
         """Sync user from Keycloak token payload.
-        
-        Creates user on first login, updates last_login_at on subsequent logins.
-        Does NOT store email, name, or roles - those come from token.
-        
+
+        Creates user on first login, updates last_login_at on subsequent
+        logins, and refreshes the cached display fields (display_name, email,
+        username) whenever the token claims differ from what's stored. Roles
+        are NEVER stored — they remain on the token.
+
         Args:
             token_payload: Decoded JWT token from Keycloak with claims:
                 - sub: Keycloak user UUID (required)
-                
+                - name: Full display name (optional)
+                - email: User email (optional)
+                - preferred_username: Username (optional)
+
         Returns:
-            User record (created or updated with fresh last_login_at)
-            
+            User record (created or updated with fresh last_login_at and
+            display fields).
+
         Example token_payload:
             {
                 "sub": "abc-123-def",
                 "email": "lecturer@example.com",
                 "name": "Test Lecturer",
+                "preferred_username": "tlecturer",
                 "realm_access": {"roles": ["lecturer"]}
             }
         """
         external_id = token_payload.get("sub")
         if not external_id:
             raise ValueError("Token payload missing 'sub' claim (Keycloak user ID)")
-        
+
+        # Cached display fields from the token (None if claim is absent).
+        display_name = token_payload.get("name")
+        email = token_payload.get("email")
+        username = token_payload.get("preferred_username")
+
         # Check if user exists
         existing_user = self.user_repo.get_by_external_id(external_id)
-        
+
         if existing_user:
-            # Update last login timestamp
+            # Update last login timestamp; refresh display fields if they
+            # changed in Keycloak since the previous login.
             from datetime import datetime, timezone
             existing_user.last_login_at = datetime.now(timezone.utc)
+            if existing_user.display_name != display_name:
+                existing_user.display_name = display_name
+            if existing_user.email != email:
+                existing_user.email = email
+            if existing_user.username != username:
+                existing_user.username = username
             self.db.commit()
             self.db.refresh(existing_user)
-            
+
             logger.debug(f"User {external_id} login recorded")
             return existing_user
-        
+
         else:
-            # Create new user record (minimal - only ID mapping)
+            # Create new user record (ID mapping + cached display fields).
             new_user = self.user_repo.create(
                 external_id=external_id,
+                display_name=display_name,
+                email=email,
+                username=username,
             )
-            
+
             logger.info(
                 f"New user registered from Keycloak: {external_id}",
                 extra={
@@ -102,7 +124,7 @@ class UserSyncService:
                     "event": "user_created"
                 }
             )
-            
+
             return new_user
     
     def deactivate_user(self, external_id: str) -> None:

--- a/src/tasks/deploy_tasks.py
+++ b/src/tasks/deploy_tasks.py
@@ -240,6 +240,7 @@ def deploy_stack(self, deployment_id: str) -> dict:
                         user_json=credentials_for_db,
                         floating_ip=stack_result.get("floating_ip") or "",
                         heat_outputs=stack_result.get("outputs") or {},
+                        flavor=stack_params.get("flavor"),
                     )
                 except Exception as cred_error:
                     logger.error(f"Failed to persist credentials for stack {idx}: {cred_error}", exc_info=True)

--- a/src/tasks/expiry_tasks.py
+++ b/src/tasks/expiry_tasks.py
@@ -1,0 +1,115 @@
+"""Celery-Beat task that hard-deletes expired deployments.
+
+Scheduled in ``src/celery_app.py`` to run once per day. The task fetches
+all deployments whose ``expires_at`` lies in the past and that are not
+already terminal (DELETED) or mid-deletion (DELETING), then enqueues
+``delete_deployment`` for each one — same Heat-stack-down + DB-row-removal
+path used by the user-initiated DELETE endpoint, so there is no second
+deletion code path to maintain.
+
+Logs a ``DEPLOYMENT_EXPIRED`` audit entry per deployment before enqueuing
+the deletion so the lifecycle decision is auditable independently of the
+deletion's own logging. Idempotent: a deployment whose ``delete_deployment``
+task is still running gets caught on the next sweep by its DELETING status
+and skipped.
+"""
+from __future__ import annotations
+
+import logging
+
+from src.celery_app import celery_app
+from src.core.database import SessionLocal
+from src.models.deployment import Deployment, DeploymentStatus
+from src.models.deployment_log import DeploymentLogEventType, DeploymentLogLevel
+from src.services.deployment_log_service import DeploymentLogService
+from src.tasks.deploy_tasks import delete_deployment
+from src.utils.deployment_expiry import utcnow
+
+logger = logging.getLogger(__name__)
+
+# Statuses that block expiry from running. DELETED is already terminal,
+# DELETING means a deletion is in flight — second sweep would race the first.
+_TERMINAL_OR_TRANSITIONAL = (
+    DeploymentStatus.DELETED,
+    DeploymentStatus.DELETING,
+)
+
+
+@celery_app.task(bind=True, name="src.tasks.expiry_tasks.expire_deployments")
+def expire_deployments(self) -> dict:
+    """Find deployments past ``expires_at`` and enqueue their deletion.
+
+    Returns:
+        Summary dict ``{"total_expired": n, "enqueued": m, "skipped": k}``
+        for log/monitoring purposes.
+    """
+    task_id = self.request.id
+    now = utcnow()
+    logger.info(
+        "expire_deployments sweep starting",
+        extra={"task_id": task_id, "now": now.isoformat()},
+    )
+
+    db = SessionLocal()
+    enqueued = 0
+    skipped = 0
+    candidates: list[Deployment] = []
+    try:
+        # SQL pre-filter on the indexed expires_at column; status filter is
+        # cheap once the candidate set is small.
+        candidates = (
+            db.query(Deployment)
+            .filter(Deployment.expires_at.is_not(None))
+            .filter(Deployment.expires_at < now)
+            .filter(Deployment.status.notin_(_TERMINAL_OR_TRANSITIONAL))
+            .all()
+        )
+
+        log_service = DeploymentLogService(db)
+
+        for deployment in candidates:
+            deployment_id = str(deployment.id)
+            try:
+                log_service.log(
+                    deployment_id=deployment_id,
+                    event_type=DeploymentLogEventType.DEPLOYMENT_EXPIRED,
+                    message=(
+                        f"Deployment expired at {deployment.expires_at.isoformat()}; "
+                        f"enqueuing hard delete"
+                    ),
+                    level=DeploymentLogLevel.INFO,
+                    details={
+                        "expires_at": deployment.expires_at.isoformat(),
+                        "swept_at": now.isoformat(),
+                        "previous_status": deployment.status.value,
+                    },
+                )
+                # Hand off to the existing deletion pipeline — same path as the
+                # user-initiated DELETE endpoint.
+                delete_deployment.delay(deployment_id)
+                enqueued += 1
+            except Exception as e:
+                # One bad deployment must not poison the whole sweep.
+                logger.error(
+                    "Failed to enqueue expiry deletion for deployment",
+                    extra={
+                        "deployment_id": deployment_id,
+                        "error": str(e),
+                    },
+                    exc_info=True,
+                )
+                skipped += 1
+
+    finally:
+        db.close()
+
+    summary = {
+        "total_expired": len(candidates),
+        "enqueued": enqueued,
+        "skipped": skipped,
+    }
+    logger.info(
+        "expire_deployments sweep complete",
+        extra={"task_id": task_id, **summary},
+    )
+    return summary

--- a/src/tasks/expiry_tasks.py
+++ b/src/tasks/expiry_tasks.py
@@ -69,17 +69,21 @@ def expire_deployments(self) -> dict:
 
         for deployment in candidates:
             deployment_id = str(deployment.id)
+            # The SQL pre-filter guarantees expires_at is set; assert it for the
+            # type-checker so .isoformat() type-narrows cleanly.
+            assert deployment.expires_at is not None
+            expires_at_iso = deployment.expires_at.isoformat()
             try:
                 log_service.log(
                     deployment_id=deployment_id,
                     event_type=DeploymentLogEventType.DEPLOYMENT_EXPIRED,
                     message=(
-                        f"Deployment expired at {deployment.expires_at.isoformat()}; "
+                        f"Deployment expired at {expires_at_iso}; "
                         f"enqueuing hard delete"
                     ),
                     level=DeploymentLogLevel.INFO,
                     details={
-                        "expires_at": deployment.expires_at.isoformat(),
+                        "expires_at": expires_at_iso,
                         "swept_at": now.isoformat(),
                         "previous_status": deployment.status.value,
                     },

--- a/src/utils/deployment_expiry.py
+++ b/src/utils/deployment_expiry.py
@@ -1,0 +1,85 @@
+"""Pure-function helpers for deployment-lifetime arithmetic.
+
+Kept free of SQLAlchemy / Pydantic so the math is unit-testable in isolation
+and consumed by both the API ``DeploymentService.create_deployment`` /
+``extend_deployment`` paths and the Celery-Beat sweep.
+
+The "warning offset" — how long before ``expires_at`` the UI starts showing
+the expires-soon banner — scales with the deployment's actual lifetime:
+
+    warning_offset = min(14 days, runtime * 0.25)
+
+so a 1-month deployment warns ~7 days before the end (not 14 — that would be
+half its life), while everything from 8 weeks upward gets the flat 14-day cap.
+"""
+from datetime import datetime, timedelta, timezone
+
+# Maximum vs minimum-fraction shape of the warning offset. See module docstring.
+MAX_WARNING_DAYS = 14
+WARNING_FRACTION_OF_RUNTIME = 0.25
+
+# Average month length used to derive timedelta from ``runtime_months``. Calendar
+# months vary; over 1..24 months this ~30.44-day approximation drifts at most a
+# day or two from the calendar date — acceptable for an expiry deadline.
+DAYS_PER_MONTH = 30
+
+
+def _add_months(reference: datetime, months: int) -> datetime:
+    """Return ``reference + months`` using the DAYS_PER_MONTH approximation.
+
+    Anchored on ``timedelta`` rather than ``relativedelta`` so we don't pull in
+    a new dependency just for this one helper.
+    """
+    return reference + timedelta(days=DAYS_PER_MONTH * months)
+
+
+def compute_expiry(now: datetime, runtime_months: int) -> tuple[datetime, datetime]:
+    """Return ``(expires_at, expiry_warning_at)`` for a freshly created deployment.
+
+    Args:
+        now: Anchor moment, typically ``datetime.now(timezone.utc)``. Pass it in
+             so the API and the tests can use a fixed clock.
+        runtime_months: How many months the deployment should live.
+
+    Returns:
+        Two timezone-aware UTC timestamps. Both are strictly in the future
+        relative to ``now`` for any positive ``runtime_months``.
+    """
+    expires_at = _add_months(now, runtime_months)
+    runtime = expires_at - now
+    warning_offset = min(
+        timedelta(days=MAX_WARNING_DAYS),
+        runtime * WARNING_FRACTION_OF_RUNTIME,
+    )
+    return expires_at, expires_at - warning_offset
+
+
+def compute_extension(
+    now: datetime,
+    current_expires_at: datetime | None,
+    runtime_months: int,
+) -> tuple[datetime, datetime]:
+    """Return ``(new_expires_at, new_expiry_warning_at)`` after an extend call.
+
+    Anchored on ``max(now, current_expires_at)``: if a deployment expired
+    moments ago but the daily sweep hasn't run yet, the extension counts from
+    *now* (not from the stale past); if the deployment is still valid, the
+    extension stacks on top of its existing end date.
+
+    A NULL ``current_expires_at`` (legacy / admin-pinned) is treated as ``now``
+    — the extend call from the UI should give the user a fresh window to work
+    with rather than throwing an error.
+    """
+    anchor = max(now, current_expires_at) if current_expires_at else now
+    new_expires_at = _add_months(anchor, runtime_months)
+    runtime = new_expires_at - now
+    warning_offset = min(
+        timedelta(days=MAX_WARNING_DAYS),
+        runtime * WARNING_FRACTION_OF_RUNTIME,
+    )
+    return new_expires_at, new_expires_at - warning_offset
+
+
+def utcnow() -> datetime:
+    """Single source of truth for "now" in this module — easy to monkeypatch."""
+    return datetime.now(timezone.utc)

--- a/tests/api/test_course_routes.py
+++ b/tests/api/test_course_routes.py
@@ -1,0 +1,313 @@
+"""Tests for course listing endpoint with OpenStack-project scoping.
+
+These tests guard the second deployment-leak fix (the first one lived in
+``/api/v1/deployments`` and is covered by ``test_deployment_routes.py``):
+``GET /api/v1/courses`` eager-loads ``course.deployments`` and used to do so
+with no owner/project filter. The contract here mirrors ``list_deployments``:
+
+- Non-admin without ``openstack_project_id``  → 400
+- Non-admin with someone else's project       → 403
+- Non-admin with their own project            → embedded deployments are filtered
+  to (project == arg) AND (teacher.id == caller)
+- Admin                                       → no scoping enforced
+"""
+from unittest.mock import patch, MagicMock
+import pytest
+from uuid import uuid4
+from datetime import datetime
+from fastapi.testclient import TestClient
+
+from src.main import app
+from src.core.dependencies import get_current_user, get_db
+from src.models.user import UserRole
+from src.models.course import Course
+from src.models.deployment import Deployment, DeploymentStatus
+
+
+TEST_OS_PROJECT_ID = "11111111-1111-1111-1111-111111111111"
+
+
+def _patched_openstack_repo(owner_user_id: int = 1):
+    """Make ``OpenstackProjectRepository.get_by_id`` return a project owned by
+    ``owner_user_id`` so the courses-API auth helper (which lives in
+    ``src.api.courses``) accepts ``TEST_OS_PROJECT_ID``."""
+    proj = MagicMock()
+    proj.id = TEST_OS_PROJECT_ID
+    proj.owner_user_id = owner_user_id
+    repo = MagicMock()
+    repo.get_by_id.return_value = proj
+    return patch("src.api.courses.OpenstackProjectRepository", return_value=repo)
+
+
+def mock_lecturer_user():
+    return {
+        "sub": "lecturer-123",
+        "email": "lecturer@example.com",
+        "name": "Test Lecturer",
+        "preferred_username": "lecturer",
+        "roles": [UserRole.LECTURER.value],
+        "user_id": 1,
+    }
+
+
+def mock_admin_user():
+    return {
+        "sub": "admin-123",
+        "email": "admin@example.com",
+        "name": "Test Admin",
+        "preferred_username": "admin",
+        "roles": [UserRole.ADMIN.value],
+        "user_id": 2,
+    }
+
+
+client = TestClient(app)
+
+
+def _make_deployment(*, did: str, teacher_keycloak: str | None) -> Deployment:
+    """Build a Deployment mock with the minimal attrs the response schema needs.
+
+    ``teacher_keycloak`` is the value embedded into ``deployment_parameters``
+    JSON; ``get_deployment_owner_id`` walks the JSON to resolve it back to a
+    local user_id via the User-table lookup we mock below.
+    """
+    d = MagicMock(spec=Deployment)
+    d.id = did
+    d.name = f"Deployment {did}"
+    d.template_version_id = str(uuid4())
+    d.status = DeploymentStatus.RUNNING
+    d.created_at = datetime(2024, 11, 27, 10, 0, 0)
+    d.openstack_project_id = TEST_OS_PROJECT_ID
+    if teacher_keycloak is None:
+        d.deployment_parameters = None
+    else:
+        d.deployment_parameters = (
+            '{"teacher": {"id": "' + teacher_keycloak + '"}}'
+        )
+    return d
+
+
+@pytest.fixture
+def mock_course_with_mixed_deployments():
+    """One course with two deployments: one owned by the lecturer, one by
+    someone else. The repository's project-filter is mocked separately, so this
+    fixture only exercises the API-layer owner filter."""
+    own = _make_deployment(did="deploy-own", teacher_keycloak="lecturer-123")
+    foreign = _make_deployment(did="deploy-foreign", teacher_keycloak="other-456")
+
+    course = MagicMock(spec=Course)
+    course.id = str(uuid4())
+    course.name = "CS101"
+    course.keycloak_course_id = "kc-course-1"
+    course.created_at = datetime(2024, 11, 27, 10, 0, 0)
+    course.updated_at = datetime(2024, 11, 27, 10, 0, 0)
+    # Both deployments are eager-loaded by the (mocked) repo. The endpoint will
+    # strip ``deploy-foreign`` after owner-resolution because its teacher.id
+    # doesn't map to user_id=1.
+    course.deployments = [own, foreign]
+    return course
+
+
+def _install_db_with_courses(courses: list, owner_lookup_user_id: int | None = 1):
+    """Configure ``app.dependency_overrides`` so the route gets a DB whose
+    ``CourseRepository`` returns ``courses`` and whose User-lookup (used by
+    ``get_deployment_owner_id``) only resolves ``"lecturer-123"`` to user_id=1.
+
+    Returns the mock_db so callers can introspect it if needed.
+    """
+    mock_db = MagicMock()
+
+    # Course-list query: a chain that ends in ``.all()`` — used by
+    # CourseRepository.get_all_filtered.
+    course_query = MagicMock()
+    course_query.filter.return_value = course_query
+    course_query.order_by.return_value = course_query
+    course_query.count.return_value = len(courses)
+    course_query.offset.return_value = course_query
+    course_query.limit.return_value = course_query
+    course_query.options.return_value = course_query
+    course_query.all.return_value = courses
+    # CourseRepository.get_by_id_with_deployments ends in ``.first()`` — return
+    # the first course so the route's get_course path works too.
+    course_query.first.return_value = courses[0] if courses else None
+
+    # User-lookup query: ``db.query(User).filter(User.external_id == kc).first()``.
+    # We need different return values per kc-id so the owner-filter actually
+    # discriminates. Using a side_effect on filter() that captures the kc-id
+    # via the SQLAlchemy expression's right-hand side is brittle — instead we
+    # build a MagicMock whose .first() returns a user with id=1 when the most
+    # recent filter() arg encodes "lecturer-123", else None.
+    def make_user_query():
+        user_query = MagicMock()
+        captured = {"kc": None}
+
+        def filter_side_effect(*args, **kwargs):
+            # SQLAlchemy passes a BinaryExpression like (User.external_id == "kc-id").
+            # Pull the literal off the expression's right-hand side; fall back to
+            # str() for the rare case it's pre-bound.
+            if args:
+                expr = args[0]
+                rhs = getattr(expr, "right", None)
+                if rhs is not None:
+                    captured["kc"] = getattr(rhs, "value", str(rhs))
+                else:
+                    captured["kc"] = str(expr)
+            return user_query
+
+        user_query.filter.side_effect = filter_side_effect
+
+        def first_side_effect():
+            if captured["kc"] == "lecturer-123" and owner_lookup_user_id is not None:
+                u = MagicMock()
+                u.id = owner_lookup_user_id
+                return u
+            return None
+
+        user_query.first.side_effect = first_side_effect
+        return user_query
+
+    # Two model classes are queried via db.query(): Course and User. Dispatch
+    # by what was passed in.
+    def query_side_effect(model):
+        # CourseRepository passes the Course class; get_deployment_owner_id passes
+        # the User class. Distinguish by name to avoid importing the model just
+        # to do an isinstance check.
+        if getattr(model, "__name__", "") == "User":
+            return make_user_query()
+        return course_query
+
+    mock_db.query.side_effect = query_side_effect
+
+    app.dependency_overrides[get_current_user] = mock_lecturer_user
+    app.dependency_overrides[get_db] = lambda: mock_db
+    return mock_db
+
+
+# ── 400: non-admin without openstack_project_id ───────────────────────────────
+
+
+def test_list_courses_lecturer_without_project_id_returns_400():
+    """The same contract as ``list_deployments``: a lecturer must always scope
+    by project. Without it, the embedded deployments would leak again."""
+    _install_db_with_courses([])
+    response = client.get("/api/v1/courses")
+    assert response.status_code == 400
+    assert "openstack_project_id" in response.json()["detail"]
+    app.dependency_overrides.clear()
+
+
+# ── 403: non-admin with someone else's project ────────────────────────────────
+
+
+def test_list_courses_lecturer_with_foreign_project_returns_403():
+    """If the project doesn't belong to the caller, we reject before reading
+    any course rows. ``owner_user_id=99`` ≠ ``user_id=1`` triggers it."""
+    _install_db_with_courses([])
+    response = client.get(
+        f"/api/v1/courses?openstack_project_id={TEST_OS_PROJECT_ID}"
+    )
+    # No openstack-repo patch ⇒ default fallback would be a real DB call. Patch
+    # explicitly to return a project NOT owned by the caller.
+    with _patched_openstack_repo(owner_user_id=99):
+        response = client.get(
+            f"/api/v1/courses?openstack_project_id={TEST_OS_PROJECT_ID}"
+        )
+    assert response.status_code == 403
+    assert "does not belong" in response.json()["detail"]
+    app.dependency_overrides.clear()
+
+
+# ── 200: lecturer with own project ⇒ owner-filter strips foreign deployments ──
+
+
+def test_list_courses_lecturer_filters_embedded_deployments(
+    mock_course_with_mixed_deployments,
+):
+    """Both project-filter (in repo) and owner-filter (in API) must apply.
+    Repo is mocked to return the course unchanged with both deployments; the
+    API layer should drop the foreign one."""
+    _install_db_with_courses([mock_course_with_mixed_deployments])
+
+    with _patched_openstack_repo():
+        response = client.get(
+            f"/api/v1/courses?openstack_project_id={TEST_OS_PROJECT_ID}"
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert len(data["data"]) == 1
+    course = data["data"][0]
+    deployment_ids = [d["id"] for d in course["deployments"]]
+    assert deployment_ids == ["deploy-own"], (
+        f"Owner-filter leaked: expected only ['deploy-own'], got {deployment_ids}"
+    )
+    app.dependency_overrides.clear()
+
+
+# ── 200: admin without project_id ⇒ no scoping ────────────────────────────────
+
+
+def test_list_courses_admin_without_project_id_sees_all_deployments(
+    mock_course_with_mixed_deployments,
+):
+    """Admins keep their unrestricted view — the same exception we made in
+    ``list_deployments``. They can pass ``openstack_project_id`` if they want
+    to scope, but unset means no filter."""
+    mock_db = MagicMock()
+    mock_query = MagicMock()
+    mock_query.filter.return_value = mock_query
+    mock_query.order_by.return_value = mock_query
+    mock_query.count.return_value = 1
+    mock_query.offset.return_value = mock_query
+    mock_query.limit.return_value = mock_query
+    mock_query.options.return_value = mock_query
+    mock_query.all.return_value = [mock_course_with_mixed_deployments]
+    mock_db.query.return_value = mock_query
+
+    app.dependency_overrides[get_current_user] = mock_admin_user
+    app.dependency_overrides[get_db] = lambda: mock_db
+
+    response = client.get("/api/v1/courses")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["data"]) == 1
+    deployment_ids = [d["id"] for d in data["data"][0]["deployments"]]
+    # Admin path: NEITHER filter ran, both deployments embedded as-is.
+    assert sorted(deployment_ids) == ["deploy-foreign", "deploy-own"]
+    app.dependency_overrides.clear()
+
+
+# ── get_course mirrors the same contract ──────────────────────────────────────
+
+
+def test_get_course_lecturer_filters_embedded_deployments(
+    mock_course_with_mixed_deployments,
+):
+    """``GET /api/v1/courses/{id}`` shares the auth helper and owner-filter
+    with ``list_courses``; verify the same outcome on the single-course path."""
+    course = mock_course_with_mixed_deployments
+    _install_db_with_courses([course])
+
+    with _patched_openstack_repo():
+        response = client.get(
+            f"/api/v1/courses/{course.id}?openstack_project_id={TEST_OS_PROJECT_ID}"
+        )
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    deployment_ids = [d["id"] for d in data["deployments"]]
+    assert deployment_ids == ["deploy-own"]
+    app.dependency_overrides.clear()
+
+
+def test_get_course_lecturer_without_project_id_returns_400(
+    mock_course_with_mixed_deployments,
+):
+    """Single-course endpoint enforces the same query-param contract."""
+    course = mock_course_with_mixed_deployments
+    _install_db_with_courses([course])
+    response = client.get(f"/api/v1/courses/{course.id}")
+    assert response.status_code == 400
+    app.dependency_overrides.clear()

--- a/tests/api/test_deployment_routes.py
+++ b/tests/api/test_deployment_routes.py
@@ -568,6 +568,7 @@ def test_get_deployment_as_owner(mock_repo_class):
     mock_instance.status = MagicMock()
     mock_instance.status.value = "ACTIVE"
     mock_instance.ip_address = "192.168.1.10"
+    mock_instance.flavor = "gp1.small"
     mock_instance.access_methods = []
     mock_instance.created_at = "2024-11-27T10:00:00"
     mock_instance.updated_at = "2024-11-27T10:00:00"
@@ -586,6 +587,7 @@ def test_get_deployment_as_owner(mock_repo_class):
     assert data["data"]["template_version"]["id"] == "version-456"
     assert len(data["data"]["instances"]) == 1
     assert data["data"]["instances"][0]["instance_name"] == "vm-1"
+    assert data["data"]["instances"][0]["flavor"] == "gp1.small"
 
     app.dependency_overrides.clear()
 

--- a/tests/unit/test_deployment_credential_service.py
+++ b/tests/unit/test_deployment_credential_service.py
@@ -1,4 +1,6 @@
 """Tests for DeploymentCredentialService._extract_access_entries."""
+from unittest.mock import MagicMock
+
 from src.models.deployment_instance_access import AccessType
 from src.services.deployment_credential_service import DeploymentCredentialService
 
@@ -66,3 +68,45 @@ def test_skips_entries_without_password():
         "applications": [],
     }
     assert DeploymentCredentialService._extract_access_entries(user_json) == []
+
+
+def _instance_added_to(db_mock):
+    """Return the DeploymentInstance that the service handed to db.add()."""
+    from src.models.deployment_instance import DeploymentInstance
+    for call in db_mock.add.call_args_list:
+        obj = call.args[0]
+        if isinstance(obj, DeploymentInstance):
+            return obj
+    raise AssertionError("DeploymentInstance was never added to the session")
+
+
+def test_persists_flavor_on_instance():
+    """The flavor passed in must be set on the DeploymentInstance row."""
+    db = MagicMock()
+    service = DeploymentCredentialService(db)
+
+    instance = service.persist_credentials_for_stack(
+        deployment_id="deploy-1",
+        stack_name="my-stack",
+        openstack_stack_id="stack-uuid",
+        user_json={"instance": {}, "applications": []},
+        flavor="gp1.medium",
+    )
+
+    assert instance.flavor == "gp1.medium"
+    assert _instance_added_to(db).flavor == "gp1.medium"
+
+
+def test_flavor_defaults_to_none_when_omitted():
+    """Backward compat: callers that don't pass flavor still work; column stays NULL."""
+    db = MagicMock()
+    service = DeploymentCredentialService(db)
+
+    instance = service.persist_credentials_for_stack(
+        deployment_id="deploy-1",
+        stack_name="my-stack",
+        openstack_stack_id="stack-uuid",
+        user_json={"instance": {}, "applications": []},
+    )
+
+    assert instance.flavor is None

--- a/tests/unit/test_deployment_expiry_helpers.py
+++ b/tests/unit/test_deployment_expiry_helpers.py
@@ -1,0 +1,111 @@
+"""Tests for the deployment-expiry pure-function helpers.
+
+Pure math, no DB, no network — covers the warning-offset rule and the
+``max(now, current_expires_at)`` anchor on extension.
+"""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.utils.deployment_expiry import (
+    DAYS_PER_MONTH,
+    MAX_WARNING_DAYS,
+    WARNING_FRACTION_OF_RUNTIME,
+    compute_expiry,
+    compute_extension,
+)
+
+
+def _now() -> datetime:
+    return datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.mark.parametrize("months", [1, 3, 4, 6, 12, 24])
+def test_compute_expiry_returns_two_future_timestamps(months: int):
+    """expires_at and expiry_warning_at must both be in the future."""
+    now = _now()
+    expires_at, warning_at = compute_expiry(now, months)
+
+    assert expires_at > now
+    assert warning_at > now
+    # Warning must always come before the actual expiry.
+    assert warning_at < expires_at
+
+
+def test_compute_expiry_4_months_caps_warning_at_14_days():
+    """For the default 4-month lifetime, warning kicks in 14 days before end."""
+    now = _now()
+    expires_at, warning_at = compute_expiry(now, 4)
+
+    assert (expires_at - now).days == DAYS_PER_MONTH * 4
+    assert (expires_at - warning_at) == timedelta(days=MAX_WARNING_DAYS)
+
+
+def test_compute_expiry_12_months_still_caps_at_14_days():
+    """Long lifetimes hit the 14-day cap, not the 25%-of-runtime fraction."""
+    now = _now()
+    expires_at, warning_at = compute_expiry(now, 12)
+    assert (expires_at - warning_at) == timedelta(days=MAX_WARNING_DAYS)
+
+
+def test_compute_expiry_1_month_uses_runtime_fraction_not_cap():
+    """A 1-month deployment must NOT warn for half its life — 14d cap is too long.
+
+    Expected offset = 30 days * 0.25 = 7.5 days, not the 14-day cap.
+    """
+    now = _now()
+    expires_at, warning_at = compute_expiry(now, 1)
+
+    expected_offset = timedelta(days=DAYS_PER_MONTH) * WARNING_FRACTION_OF_RUNTIME
+    actual_offset = expires_at - warning_at
+    assert actual_offset == expected_offset
+    # Sanity check: this is well under the 14d cap.
+    assert actual_offset < timedelta(days=MAX_WARNING_DAYS)
+
+
+def test_compute_extension_stacks_on_existing_expires_at_when_still_valid():
+    """An extend on a still-valid deployment counts from its existing end date."""
+    now = _now()
+    current_expires_at = now + timedelta(days=30)  # 30 days left
+
+    new_expires_at, _ = compute_extension(now, current_expires_at, runtime_months=4)
+
+    expected = current_expires_at + timedelta(days=DAYS_PER_MONTH * 4)
+    assert new_expires_at == expected
+
+
+def test_compute_extension_anchors_on_now_when_already_expired():
+    """If current_expires_at lies in the past, extend from now — not from the past."""
+    now = _now()
+    current_expires_at = now - timedelta(days=2)  # already expired
+
+    new_expires_at, _ = compute_extension(now, current_expires_at, runtime_months=4)
+
+    expected = now + timedelta(days=DAYS_PER_MONTH * 4)
+    assert new_expires_at == expected
+
+
+def test_compute_extension_handles_null_current_expires_at():
+    """Legacy/admin-pinned deployments with NULL expires_at extend from now."""
+    now = _now()
+
+    new_expires_at, _ = compute_extension(now, None, runtime_months=4)
+
+    expected = now + timedelta(days=DAYS_PER_MONTH * 4)
+    assert new_expires_at == expected
+
+
+def test_compute_extension_recomputes_warning_offset_from_new_runtime():
+    """expiry_warning_at after extend must follow the same rule as creation."""
+    now = _now()
+    current_expires_at = now + timedelta(days=30)
+
+    new_expires_at, new_warning_at = compute_extension(
+        now, current_expires_at, runtime_months=4
+    )
+    runtime = new_expires_at - now
+    expected_offset = min(
+        timedelta(days=MAX_WARNING_DAYS),
+        runtime * WARNING_FRACTION_OF_RUNTIME,
+    )
+    assert (new_expires_at - new_warning_at) == expected_offset

--- a/tests/unit/test_deployment_expiry_lifecycle.py
+++ b/tests/unit/test_deployment_expiry_lifecycle.py
@@ -1,0 +1,221 @@
+"""Tests for DeploymentService.extend_deployment and the expire_deployments
+Celery-Beat sweep. Both are mocked at the repo / Celery boundary so we can
+exercise the policy logic without a live DB or Heat connection.
+"""
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.core.exceptions import BadRequestException, NotFoundException
+from src.models.deployment import DeploymentStatus
+from src.services.deployment_service import DeploymentService
+
+
+def _utc(year=2026, month=6, day=20, hour=12):
+    return datetime(year, month, day, hour, 0, 0, tzinfo=timezone.utc)
+
+
+def _build_service(deployment):
+    """DeploymentService whose deployment_repo.get_by_id returns ``deployment``.
+
+    log_service is mocked so the audit-log call doesn't hit the DB.
+    """
+    db = MagicMock()
+    service = DeploymentService.__new__(DeploymentService)
+    service.db = db
+    service.deployment_repo = MagicMock()
+    service.deployment_repo.get_by_id.return_value = deployment
+    service.openstack_repo = MagicMock()
+    service.log_service = MagicMock()
+    return service, db
+
+
+# ------------------------------ extend_deployment ----------------------------
+
+def test_extend_deployment_pushes_expires_at_forward():
+    deployment = SimpleNamespace(
+        id="d-1",
+        status=DeploymentStatus.RUNNING,
+        expires_at=_utc() + timedelta(days=30),
+        expiry_warning_at=_utc() + timedelta(days=16),
+    )
+    service, db = _build_service(deployment)
+
+    fixed_now = _utc()
+    with patch("src.services.deployment_service.utcnow", return_value=fixed_now):
+        result = service.extend_deployment("d-1", runtime_months=4)
+
+    # Anchor was current expires_at (still in the future), plus 4 months (~120 d).
+    expected_expires_at = (_utc() + timedelta(days=30)) + timedelta(days=120)
+    assert result.expires_at == expected_expires_at
+    # Warning recomputed.
+    assert result.expiry_warning_at < result.expires_at
+    db.commit.assert_called_once()
+    service.log_service.log.assert_called_once()
+
+
+def test_extend_deployment_anchored_on_now_when_already_expired():
+    """A deployment past expires_at gets the new window from now, not the past."""
+    fixed_now = _utc()
+    deployment = SimpleNamespace(
+        id="d-1",
+        status=DeploymentStatus.RUNNING,
+        expires_at=fixed_now - timedelta(days=2),  # already expired
+        expiry_warning_at=fixed_now - timedelta(days=16),
+    )
+    service, _db = _build_service(deployment)
+
+    with patch("src.services.deployment_service.utcnow", return_value=fixed_now):
+        result = service.extend_deployment("d-1", runtime_months=4)
+
+    expected_expires_at = fixed_now + timedelta(days=120)
+    assert result.expires_at == expected_expires_at
+
+
+def test_extend_deployment_handles_null_expires_at_legacy_row():
+    """Legacy rows with NULL expires_at extend from now without erroring."""
+    fixed_now = _utc()
+    deployment = SimpleNamespace(
+        id="d-1",
+        status=DeploymentStatus.RUNNING,
+        expires_at=None,
+        expiry_warning_at=None,
+    )
+    service, _db = _build_service(deployment)
+
+    with patch("src.services.deployment_service.utcnow", return_value=fixed_now):
+        result = service.extend_deployment("d-1", runtime_months=4)
+
+    assert result.expires_at == fixed_now + timedelta(days=120)
+    assert result.expiry_warning_at is not None
+
+
+def test_extend_deployment_404_when_missing():
+    db = MagicMock()
+    service = DeploymentService.__new__(DeploymentService)
+    service.db = db
+    service.deployment_repo = MagicMock()
+    service.deployment_repo.get_by_id.return_value = None
+    service.openstack_repo = MagicMock()
+    service.log_service = MagicMock()
+
+    with pytest.raises(NotFoundException):
+        service.extend_deployment("nope", runtime_months=4)
+
+
+def test_extend_deployment_rejects_already_deleted():
+    deployment = SimpleNamespace(
+        id="d-1",
+        status=DeploymentStatus.DELETED,
+        expires_at=None,
+        expiry_warning_at=None,
+    )
+    service, _db = _build_service(deployment)
+
+    with pytest.raises(BadRequestException):
+        service.extend_deployment("d-1", runtime_months=4)
+
+
+# ----------------------------- expire_deployments ----------------------------
+
+class _DeploymentQueryStub:
+    """Tiny stand-in for the chained SQLAlchemy ``db.query(...).filter(...).all()``.
+
+    The real query has 3 ``.filter()`` calls in a row; whatever filter args
+    arrive, we just keep returning self so the chain stays valid, then return
+    the deployments fed in at construction time on ``.all()``.
+    """
+
+    def __init__(self, deployments):
+        self._deployments = deployments
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def all(self):
+        return self._deployments
+
+
+def test_expire_deployments_enqueues_delete_for_each_expired():
+    """Every expired-and-non-terminal deployment should get a delete_deployment.delay."""
+    expired = SimpleNamespace(
+        id="d-1",
+        expires_at=_utc() - timedelta(days=1),
+        status=DeploymentStatus.RUNNING,
+    )
+    expired_2 = SimpleNamespace(
+        id="d-2",
+        expires_at=_utc() - timedelta(hours=2),
+        status=DeploymentStatus.FAILED,
+    )
+
+    fake_db = MagicMock()
+    fake_db.query.return_value = _DeploymentQueryStub([expired, expired_2])
+
+    with patch("src.tasks.expiry_tasks.SessionLocal", return_value=fake_db), \
+         patch("src.tasks.expiry_tasks.delete_deployment") as mock_delete, \
+         patch("src.tasks.expiry_tasks.DeploymentLogService") as mock_log_cls, \
+         patch("src.tasks.expiry_tasks.utcnow", return_value=_utc()):
+        from src.tasks.expiry_tasks import expire_deployments
+
+        # bind=True tasks expose self.request; .run() bypasses the Celery
+        # binding so we can call the function body directly.
+        result = expire_deployments.run()
+
+    assert result == {"total_expired": 2, "enqueued": 2, "skipped": 0}
+    assert mock_delete.delay.call_count == 2
+    mock_delete.delay.assert_any_call("d-1")
+    mock_delete.delay.assert_any_call("d-2")
+    # Each expired deployment got an audit log entry before deletion.
+    assert mock_log_cls.return_value.log.call_count == 2
+    fake_db.close.assert_called_once()
+
+
+def test_expire_deployments_continues_after_per_deployment_failure():
+    """A bad deployment must not poison the rest of the sweep."""
+    good = SimpleNamespace(
+        id="good",
+        expires_at=_utc() - timedelta(days=1),
+        status=DeploymentStatus.RUNNING,
+    )
+    bad = SimpleNamespace(
+        id="bad",
+        expires_at=_utc() - timedelta(days=1),
+        status=DeploymentStatus.RUNNING,
+    )
+
+    fake_db = MagicMock()
+    fake_db.query.return_value = _DeploymentQueryStub([bad, good])
+
+    with patch("src.tasks.expiry_tasks.SessionLocal", return_value=fake_db), \
+         patch("src.tasks.expiry_tasks.delete_deployment") as mock_delete, \
+         patch("src.tasks.expiry_tasks.DeploymentLogService") as mock_log_cls, \
+         patch("src.tasks.expiry_tasks.utcnow", return_value=_utc()):
+        # Make the FIRST log call (for "bad") raise; the second ("good") still runs.
+        mock_log_cls.return_value.log.side_effect = [RuntimeError("DB down"), None]
+        from src.tasks.expiry_tasks import expire_deployments
+
+        result = expire_deployments.run()
+
+    assert result["total_expired"] == 2
+    assert result["enqueued"] == 1
+    assert result["skipped"] == 1
+    mock_delete.delay.assert_called_once_with("good")
+
+
+def test_expire_deployments_returns_zero_when_nothing_expired():
+    fake_db = MagicMock()
+    fake_db.query.return_value = _DeploymentQueryStub([])
+
+    with patch("src.tasks.expiry_tasks.SessionLocal", return_value=fake_db), \
+         patch("src.tasks.expiry_tasks.delete_deployment") as mock_delete, \
+         patch("src.tasks.expiry_tasks.DeploymentLogService"), \
+         patch("src.tasks.expiry_tasks.utcnow", return_value=_utc()):
+        from src.tasks.expiry_tasks import expire_deployments
+
+        result = expire_deployments.run()
+
+    assert result == {"total_expired": 0, "enqueued": 0, "skipped": 0}
+    mock_delete.delay.assert_not_called()

--- a/tests/unit/test_deployment_runtime_validation.py
+++ b/tests/unit/test_deployment_runtime_validation.py
@@ -1,0 +1,39 @@
+"""Tests for runtime_months validation on DeploymentCreate / DeploymentExtend."""
+import pytest
+from pydantic import ValidationError
+
+from src.schemas.deployment import (
+    ALLOWED_RUNTIME_MONTHS,
+    DEFAULT_RUNTIME_MONTHS,
+    DeploymentExtend,
+)
+
+
+def test_default_runtime_months_is_4():
+    """Wizard default == backend default == 4 months."""
+    assert DEFAULT_RUNTIME_MONTHS == 4
+
+
+def test_allowed_set_matches_wizard_dropdown():
+    """Backend's allowed set must match the Wizard <Select> options exactly."""
+    assert set(ALLOWED_RUNTIME_MONTHS) == {1, 3, 4, 6, 12, 24}
+
+
+@pytest.mark.parametrize("months", [1, 3, 4, 6, 12, 24])
+def test_extend_accepts_each_allowed_runtime(months: int):
+    """Every dropdown option must validate."""
+    extend = DeploymentExtend(runtime_months=months)
+    assert extend.runtime_months == months
+
+
+@pytest.mark.parametrize("bad", [0, -1, 2, 5, 7, 18, 36, 100])
+def test_extend_rejects_disallowed_runtime(bad: int):
+    """Anything outside the wizard's offered set must fail validation."""
+    with pytest.raises(ValidationError):
+        DeploymentExtend(runtime_months=bad)
+
+
+def test_extend_default_is_4_when_omitted():
+    """Empty body extends by the default 4 months."""
+    extend = DeploymentExtend()
+    assert extend.runtime_months == DEFAULT_RUNTIME_MONTHS

--- a/tests/unit/test_openstack_resource_service.py
+++ b/tests/unit/test_openstack_resource_service.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 from src.services.openstack_resource_service import OpenstackResourceService
 from src.models.openstack_project import OpenstackProject
 from src.core.exceptions import NotFoundException, BadRequestException, ForbiddenException
+from openstack.exceptions import HttpException, SDKException
 
 
 @pytest.fixture
@@ -106,8 +107,142 @@ class TestGetQuotas:
                 with patch.object(resource_service, '_get_connection', side_effect=BadRequestException("Failed to connect to OpenStack: Connection failed")):
                     with pytest.raises(BadRequestException) as exc_info:
                         resource_service.get_quotas(user_id="user-123", force_refresh=True)
-                    
+
                     assert "Failed to connect" in str(exc_info.value)
+
+
+def _mock_flavor(flavor_id, name, vcpus, ram, disk, ephemeral=0, is_public=True):
+    """Build a Mock that mimics the openstacksdk Flavor object."""
+    flavor = MagicMock()
+    flavor.id = flavor_id
+    flavor.name = name
+    flavor.vcpus = vcpus
+    flavor.ram = ram
+    flavor.disk = disk
+    flavor.ephemeral = ephemeral
+    flavor.is_public = is_public
+    return flavor
+
+
+class TestGetFlavors:
+    """Tests for get_flavors method."""
+
+    def test_get_flavors_success(self, resource_service, mock_db_session, mock_openstack_project):
+        """Returns a sorted list of flavors with the expected fields."""
+        mock_conn = MagicMock()
+        # Intentionally out of order to verify sorting (vcpus asc, then ram asc)
+        mock_conn.compute.flavors.return_value = iter([
+            _mock_flavor("2", "gp1.medium", vcpus=4, ram=8192, disk=40),
+            _mock_flavor("1", "gp1.small", vcpus=2, ram=4096, disk=20),
+            _mock_flavor("3", "gp1.large", vcpus=8, ram=16384, disk=80, ephemeral=10, is_public=False),
+        ])
+
+        with patch.object(resource_service.repository, 'get_by_owner', return_value=[mock_openstack_project]):
+            with patch.object(resource_service, '_get_connection', return_value=mock_conn):
+                result = resource_service.get_flavors(user_id="user-123")
+
+        assert result['project_id'] == "openstack-proj-123"
+        assert result['project_name'] == "test-project"
+        assert result['owner_user_id'] == "user-123"
+        assert 'fetched_at' in result
+        assert len(result['flavors']) == 3
+
+        # Sorted by (vcpus, ram_mb)
+        names = [f['name'] for f in result['flavors']]
+        assert names == ["gp1.small", "gp1.medium", "gp1.large"]
+
+        small = result['flavors'][0]
+        assert small == {
+            'id': "1",
+            'name': "gp1.small",
+            'vcpus': 2,
+            'ram_mb': 4096,
+            'disk_gb': 20,
+            'ephemeral_gb': 0,
+            'is_public': True,
+        }
+
+        # Non-public flavor surfaced correctly
+        large = result['flavors'][2]
+        assert large['ephemeral_gb'] == 10
+        assert large['is_public'] is False
+        assert large['id'] == "3"  # IDs are stringified even if SDK returns int
+
+    def test_get_flavors_empty_list(self, resource_service, mock_db_session, mock_openstack_project):
+        """Returns an empty list when the project has no visible flavors."""
+        mock_conn = MagicMock()
+        mock_conn.compute.flavors.return_value = iter([])
+
+        with patch.object(resource_service.repository, 'get_by_owner', return_value=[mock_openstack_project]):
+            with patch.object(resource_service, '_get_connection', return_value=mock_conn):
+                result = resource_service.get_flavors(user_id="user-123")
+
+        assert result['flavors'] == []
+        assert result['project_id'] == "openstack-proj-123"
+
+    def test_get_flavors_no_project_for_user(self, resource_service, mock_db_session):
+        """Raises NotFoundException when the user has no OpenStack project."""
+        with patch.object(resource_service.repository, 'get_by_owner', return_value=[]):
+            with pytest.raises(NotFoundException) as exc_info:
+                resource_service.get_flavors(user_id="user-123")
+
+            assert "No OpenStack projects found" in str(exc_info.value)
+
+    def test_get_flavors_forbidden_other_project(self, resource_service, mock_db_session, mock_openstack_project):
+        """Raises ForbiddenException when a non-admin requests another user's project."""
+        # mock_openstack_project.owner_user_id == 'user-123', caller is 'user-456'
+        with patch.object(resource_service.repository, 'get_by_id', return_value=mock_openstack_project):
+            with pytest.raises(ForbiddenException) as exc_info:
+                resource_service.get_flavors(
+                    user_id="user-456",
+                    project_id="project-123",
+                    allow_admin_access=False,
+                )
+
+            assert "do not have permission" in str(exc_info.value)
+
+    def test_get_flavors_admin_access_to_other_project(self, resource_service, mock_db_session, mock_openstack_project):
+        """Admin (allow_admin_access=True) can read flavors of any project."""
+        mock_conn = MagicMock()
+        mock_conn.compute.flavors.return_value = iter([
+            _mock_flavor("1", "gp1.small", vcpus=2, ram=4096, disk=20),
+        ])
+
+        with patch.object(resource_service.repository, 'get_by_id', return_value=mock_openstack_project):
+            with patch.object(resource_service, '_get_connection', return_value=mock_conn):
+                result = resource_service.get_flavors(
+                    user_id="user-456",  # not the owner
+                    project_id="project-123",
+                    allow_admin_access=True,
+                )
+
+        assert len(result['flavors']) == 1
+        assert result['owner_user_id'] == "user-123"  # actual owner surfaced
+
+    def test_get_flavors_connection_failure(self, resource_service, mock_db_session, mock_openstack_project):
+        """Connection errors from _get_connection bubble up as BadRequestException."""
+        with patch.object(resource_service.repository, 'get_by_owner', return_value=[mock_openstack_project]):
+            with patch.object(
+                resource_service,
+                '_get_connection',
+                side_effect=BadRequestException("Failed to connect to OpenStack: down"),
+            ):
+                with pytest.raises(BadRequestException) as exc_info:
+                    resource_service.get_flavors(user_id="user-123")
+
+                assert "Failed to connect" in str(exc_info.value)
+
+    def test_get_flavors_sdk_error(self, resource_service, mock_db_session, mock_openstack_project):
+        """SDKException from the Nova call is mapped to BadRequestException."""
+        mock_conn = MagicMock()
+        mock_conn.compute.flavors.side_effect = SDKException("nova exploded")
+
+        with patch.object(resource_service.repository, 'get_by_owner', return_value=[mock_openstack_project]):
+            with patch.object(resource_service, '_get_connection', return_value=mock_conn):
+                with pytest.raises(BadRequestException) as exc_info:
+                    resource_service.get_flavors(user_id="user-123")
+
+                assert "Failed to retrieve flavors" in str(exc_info.value)
 
 
 class TestCheckAvailability:

--- a/tests/unit/test_openstack_resource_service.py
+++ b/tests/unit/test_openstack_resource_service.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 from src.services.openstack_resource_service import OpenstackResourceService
 from src.models.openstack_project import OpenstackProject
 from src.core.exceptions import NotFoundException, BadRequestException, ForbiddenException
-from openstack.exceptions import HttpException, SDKException
+from openstack.exceptions import SDKException
 
 
 @pytest.fixture

--- a/tests/unit/test_template_response_schema.py
+++ b/tests/unit/test_template_response_schema.py
@@ -1,0 +1,84 @@
+"""Tests for TemplateResponse — owner display fields are surfaced from the
+ORM ``owner`` relationship without exposing the User object itself.
+"""
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from src.schemas.template import TemplateResponse
+
+
+def _orm_template(owner=None, **overrides):
+    """Build a SimpleNamespace that mimics the Template ORM attributes Pydantic reads."""
+    defaults = dict(
+        id="tmpl-1",
+        name="Test Template",
+        description="A test template",
+        owner_id="user-1",
+        repo_url="https://github.com/example/test",
+        icon_url=None,
+        visibility="private",
+        versions=None,
+        owner=owner,
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def test_owner_name_email_username_pulled_from_owner_relationship():
+    """When the joined User row has display fields, they appear in the response."""
+    owner = SimpleNamespace(
+        id="user-1",
+        display_name="Prof. Dr. Bernd Berg",
+        email="berg@dhbw.de",
+        username="bberg",
+    )
+    response = TemplateResponse.model_validate(_orm_template(owner=owner))
+
+    assert response.owner_name == "Prof. Dr. Bernd Berg"
+    assert response.owner_email == "berg@dhbw.de"
+    assert response.owner_username == "bberg"
+
+
+def test_owner_name_is_none_for_legacy_user_without_cached_fields():
+    """Pre-migration users have NULL display fields; clients fall back to owner_id."""
+    owner = SimpleNamespace(
+        id="user-1",
+        display_name=None,
+        email=None,
+        username=None,
+    )
+    response = TemplateResponse.model_validate(_orm_template(owner=owner))
+
+    assert response.owner_name is None
+    assert response.owner_email is None
+    assert response.owner_username is None
+    assert response.owner_id == "user-1"  # always present
+
+
+def test_owner_name_is_none_when_owner_relationship_not_loaded():
+    """Defensive: if upstream forgets to eager-load owner, response stays valid."""
+    response = TemplateResponse.model_validate(_orm_template(owner=None))
+
+    assert response.owner_name is None
+    assert response.owner_email is None
+    assert response.owner_username is None
+
+
+def test_serialized_payload_excludes_raw_owner_object():
+    """The User ORM row must not leak into the JSON response."""
+    owner = SimpleNamespace(
+        id="user-1",
+        display_name="Berg",
+        email="berg@dhbw.de",
+        username="bberg",
+    )
+    payload = TemplateResponse.model_validate(_orm_template(owner=owner)).model_dump(mode="json")
+
+    assert "owner" not in payload
+    assert payload["owner_name"] == "Berg"
+    assert payload["owner_email"] == "berg@dhbw.de"
+    assert payload["owner_username"] == "bberg"
+    # owner_id stays — it's the stable foreign key the frontend keys off of.
+    assert payload["owner_id"] == "user-1"

--- a/tests/unit/test_user_sync_service.py
+++ b/tests/unit/test_user_sync_service.py
@@ -1,0 +1,134 @@
+"""Tests for UserSyncService — token-claim caching of display fields.
+
+The service caches `display_name`, `email`, `username` from the JWT on every
+login so the API can render owner names without round-tripping to Keycloak.
+Roles continue to be read from the token, never from the DB.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from src.services.user_sync_service import UserSyncService
+
+
+def _service_with_existing_user(existing):
+    """Build a UserSyncService whose repo returns ``existing`` for any sub."""
+    db = MagicMock()
+    service = UserSyncService(db)
+    service.user_repo = MagicMock()
+    service.user_repo.get_by_external_id.return_value = existing
+    return service, db
+
+
+def _service_without_existing_user(created):
+    """Build a UserSyncService whose repo creates and returns ``created``."""
+    db = MagicMock()
+    service = UserSyncService(db)
+    service.user_repo = MagicMock()
+    service.user_repo.get_by_external_id.return_value = None
+    service.user_repo.create.return_value = created
+    return service, db
+
+
+def test_create_persists_display_fields_from_token():
+    """First-login path stores name/email/username on the new User row."""
+    created = SimpleNamespace(id="local-1", external_id="kc-1")
+    service, _db = _service_without_existing_user(created)
+
+    service.sync_user_from_token({
+        "sub": "kc-1",
+        "name": "Prof. Dr. Bernd Berg",
+        "email": "berg@dhbw.de",
+        "preferred_username": "bberg",
+    })
+
+    service.user_repo.create.assert_called_once_with(
+        external_id="kc-1",
+        display_name="Prof. Dr. Bernd Berg",
+        email="berg@dhbw.de",
+        username="bberg",
+    )
+
+
+def test_create_with_missing_claims_stores_none():
+    """Tokens without optional claims still create the user (fields stay NULL)."""
+    created = SimpleNamespace(id="local-2", external_id="kc-2")
+    service, _db = _service_without_existing_user(created)
+
+    service.sync_user_from_token({"sub": "kc-2"})
+
+    service.user_repo.create.assert_called_once_with(
+        external_id="kc-2",
+        display_name=None,
+        email=None,
+        username=None,
+    )
+
+
+def test_existing_user_refreshes_changed_display_fields():
+    """If Keycloak claims differ from what's stored, the cached values update."""
+    existing = SimpleNamespace(
+        id="local-3",
+        external_id="kc-3",
+        display_name="Old Name",
+        email="old@dhbw.de",
+        username="oldname",
+        last_login_at=None,
+    )
+    service, db = _service_with_existing_user(existing)
+
+    service.sync_user_from_token({
+        "sub": "kc-3",
+        "name": "New Name",
+        "email": "new@dhbw.de",
+        "preferred_username": "newname",
+    })
+
+    assert existing.display_name == "New Name"
+    assert existing.email == "new@dhbw.de"
+    assert existing.username == "newname"
+    db.commit.assert_called_once()
+
+
+def test_existing_user_unchanged_when_claims_match():
+    """Same claims as before: values stay; commit still happens for last_login_at."""
+    existing = SimpleNamespace(
+        id="local-4",
+        external_id="kc-4",
+        display_name="Stable Name",
+        email="stable@dhbw.de",
+        username="stable",
+        last_login_at=None,
+    )
+    service, db = _service_with_existing_user(existing)
+
+    service.sync_user_from_token({
+        "sub": "kc-4",
+        "name": "Stable Name",
+        "email": "stable@dhbw.de",
+        "preferred_username": "stable",
+    })
+
+    # No surprise overwrites with falsy values.
+    assert existing.display_name == "Stable Name"
+    assert existing.email == "stable@dhbw.de"
+    assert existing.username == "stable"
+    db.commit.assert_called_once()
+
+
+def test_existing_user_clears_field_when_claim_disappears():
+    """If a claim is removed in Keycloak, the cached copy is cleared too."""
+    existing = SimpleNamespace(
+        id="local-5",
+        external_id="kc-5",
+        display_name="Some Name",
+        email="some@dhbw.de",
+        username="some",
+        last_login_at=None,
+    )
+    service, _db = _service_with_existing_user(existing)
+
+    service.sync_user_from_token({"sub": "kc-5"})
+
+    assert existing.display_name is None
+    assert existing.email is None
+    assert existing.username is None


### PR DESCRIPTION
## Übersicht

Vier in sich abgeschlossene Backend-Tickets aus dem Hardcoded-Values-Plan, jeweils ein Commit. Jeder Commit ist alleine reviewbar, alle haben grüne Tests. Ein Frontend-Adaption-Markdown pro Ticket liegt **lokal** unter `Documentation/Frontend/Hardcoded-Fixes/` (im monorepo-parent, nicht in diesem Repo).

| # | Commit | Was | Frontend-Issue |
|---|---|---|---|
| B1 | `fe4de18` | `GET /openstack/flavors` — proxy auf Nova-Flavor-Liste, sortiert, mit gleichem Auth-Pattern wie `/quotas` | unblockt [#73](https://github.com/DoziLab/appstore-frontend/issues/73) |
| B1.5 | `45509c2` | `deployment_instances.flavor` Spalte + Persistenz aus den Heat-Stack-Parametern + im DeploymentResponse | folgt aus B1; macht F2 möglich |
| B2 | `150550d` | Cached `display_name`/`email`/`username` auf `users` (UserSyncService refreshed bei jedem Login), `TemplateResponse.owner_name`/`owner_email`/`owner_username` mit `joinedload` | unblockt [#74](https://github.com/DoziLab/appstore-frontend/issues/74) |
| B6 | `12a20f9` | Deployment-Lifecycle: `runtime_months` (Default 4, allowed 1/3/4/6/12/24) → `expires_at` + `expiry_warning_at`, `PATCH /deployments/{id}/extend`, daily Celery-Beat sweep der existierende `delete_deployment` aufruft | neu — Wizard-Laufzeit war vorher reiner Frontend-State |

## Migrationen (3 Stück, alle nullable + no backfill)

```
ab7ece9fa8cc  add flavor to deployment_instances        (B1.5)
d3f1b2c8a47e  add display fields to users               (B2)
f7a92e3b8c41  add expiry fields to deployments          (B6)
```

Reihenfolge wie hier aufgelistet — alle aufeinander aufbauend (`Revises:` Chain).

## API-Vertrag

### Neu

- `GET /api/v1/openstack/flavors` (B1)
- `PATCH /api/v1/deployments/{id}/extend` (B6)

### Erweitert (rein additiv, keine Breaking Changes)

- `DeploymentResponse`: `+ flavor` pro Instance (B1.5), `+ expires_at`, `+ expiry_warning_at` (B6)
- `DeploymentCreate`: `+ runtime_months` mit Default 4 (B6) — bestehende Frontend-Calls funktionieren unverändert
- `TemplateResponse`: `+ owner_name`, `+ owner_email`, `+ owner_username` (B2)

## Neue Infrastruktur

- **Celery-Beat-Schedule** in `src/celery_app.py` — vorher kein periodischer Task im System. Daily sweep `expire_deployments` um 03:17 UTC. Ops müssen ab Merge `celery beat` als zusätzlichen Prozess laufen lassen (nicht nur den Worker).

## Tests

- Vor diesem PR: 264 passed, 4 skipped
- Nach diesem PR: **311 passed, 4 skipped** (47 neue Tests across alle vier Tickets)

```bash
.venv/bin/python -m pytest tests/   # 311 passed, 4 skipped
```

Pre-existing failure von `test_parameters_manual.py` an der Repo-Wurzel ist nicht durch diesen PR verursacht (DB-abhängiger Manual-Smoke-Test, schon vorher rot).

## Was nicht in diesem PR ist

- **B3** (Admin-Lecturers-Usage Endpoint) — vertagt, brauchte erst Privacy-Diskussion
- **B7** (App-Versionen `1.3.2`/`4.3.2`) — geskippt, sind nur Print-String in cloud-init, kein echtes Problem
- **B8** (Mock-Email-Domains `@dozi.local`/`@dozilab.local`) — geskippt, separate Investigation

## Frontend-Migration

Die Adaption-Markdowns liegen lokal beim Plan-Inhaber. Pro Ticket:

- **B1**: neuer API-Wrapper `getFlavors()`, AdminMonitoring zeigt vCPU/RAM/Storage statt Hardcode-Multiplier
- **B1.5**: DeploymentDetailsPage liest `instance.flavor` und löst gegen Flavor-Liste auf
- **B2**: AdminMonitoring Template-Approval-Card zeigt `owner_name` neben dem Eingereicht-Datum
- **B6**: Wizard sendet `runtime_months`, DetailPage rendert "läuft bald ab"-Banner mit Verlängern-Button, Listen zeigen ⚠️-Icon
