### PR TITLE
ci(staging): include celery-beat in deploy + bruno staging env

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -152,7 +152,7 @@ jobs:
             chmod 600 .env
           ENDSSH
 
-      - name: Deploy api + celery-worker on Staging
+      - name: Deploy api + celery-worker + celery-beat on Staging
         env:
           SERVER_HOST: ${{ secrets.STAGING_SERVER_HOST }}
         run: |
@@ -163,8 +163,8 @@ jobs:
 
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-            docker compose -f docker-compose.yml -f docker-compose.staging.yml pull api celery-worker
-            docker compose -f docker-compose.yml -f docker-compose.staging.yml up -d api celery-worker
+            docker compose -f docker-compose.yml -f docker-compose.staging.yml pull api celery-worker celery-beat
+            docker compose -f docker-compose.yml -f docker-compose.staging.yml up -d api celery-worker celery-beat
 
             docker compose -f docker-compose.yml -f docker-compose.staging.yml exec -T api alembic upgrade head
 

--- a/bruno/Deployments/Create Deployment staging.bru
+++ b/bruno/Deployments/Create Deployment staging.bru
@@ -1,0 +1,122 @@
+meta {
+  name: Create Deployment staging
+  type: http
+  seq: 9
+}
+
+post {
+  url: {{base_url}}/api/v1/deployments
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{access_token}}
+}
+
+body:json {
+  {
+    "name": "test",
+    "template_version_id": "{{template_version_id}}",
+    "course_id": "f0cbe163-7a2c-4b0f-8c42-d9fc5a8a4fe2",
+    "openstack_project_id": "{{openstack_project_local_id}}",
+    "runtime_months": 4,
+    "parameters": {
+      "stack_label": "test",
+      "image": "Ubuntu 22.04 2025-01",
+      "flavor": "gp1.small",
+      "ssh_cidr": "141.72.0.0/16",
+      "force_password_change": true
+    },
+    "stack_assignments": [
+      {
+        "groups": [
+          {
+            "group_name": "Gruppe 1",
+            "group_index": 1,
+            "students": [
+              { "id": "d428e6b8-82b4-4511-bb5d-56c6a825ab57", "username": "s230011", "email": "s230011@dhbw-mannheim.de", "first_name": "Emma",   "last_name": "Wolf"     },
+              { "id": "9b8055dc-2586-4f96-bd31-8a52b04d7f8c", "username": "s230012", "email": "s230012@dhbw-mannheim.de", "first_name": "Finn",   "last_name": "Neumann"  },
+              { "id": "1e7fc9e5-4a34-43f0-a362-ccbd41c4e77c", "username": "s230013", "email": "s230013@dhbw-mannheim.de", "first_name": "Lea",    "last_name": "Schwarz"  },
+              { "id": "8dddce91-9585-4521-9484-211f9a6979fc", "username": "s230014", "email": "s230014@dhbw-mannheim.de", "first_name": "Ben",    "last_name": "Richter"  },
+              { "id": "cdd375b3-4fe6-4e0f-acc3-59dc9400dc16", "username": "s230015", "email": "s230015@dhbw-mannheim.de", "first_name": "Hannah", "last_name": "Klein"    },
+              { "id": "915098dc-8b38-490c-ac10-22335082789b", "username": "s230016", "email": "s230016@dhbw-mannheim.de", "first_name": "Tim",    "last_name": "Werner"   },
+              { "id": "8927baae-6ff3-4206-b540-5451bafbd4b8", "username": "s230017", "email": "s230017@dhbw-mannheim.de", "first_name": "Julia",  "last_name": "Schmitt"  },
+              { "id": "5fbdf47b-5ff5-4096-a133-16694ca4df91", "username": "s230018", "email": "s230018@dhbw-mannheim.de", "first_name": "Moritz", "last_name": "Meier"    },
+              { "id": "03001249-80ee-441d-80f7-c59947826f91", "username": "s230019", "email": "s230019@dhbw-mannheim.de", "first_name": "Sara",   "last_name": "König"    },
+              { "id": "f38398c4-9ae5-40bf-82ee-e38773b57877", "username": "s230020", "email": "s230020@dhbw-mannheim.de", "first_name": "Paul",   "last_name": "Lang"     }
+            ]
+          }
+        ]
+      }
+    ],
+    "teacher": {
+      "id": "40a38818-552d-4ee0-a3fd-a2a1c434a862",
+      "username": "lecturer",
+      "email": "eve.stark@dhbw-mannheim.de",
+      "first_name": "Eve",
+      "last_name": "Stark"
+    }
+  }
+}
+
+vars:pre-request {
+  template_version_id: 52ae7b69-e601-49ca-b878-83bd05192027
+}
+
+script:post-response {
+  if (res.status === 201) {
+    const data = res.body.data;
+    bru.setEnvVar("deployment_id", data.id);
+    console.log("✅ Deployment created! ID:", data.id);
+    console.log("Status:", data.status);
+    console.log("Expires at:", data.expires_at);
+  } else {
+    console.log("❌ Deployment creation failed:", res.status, res.body);
+  }
+}
+
+docs {
+  # Create Deployment — Staging Preset
+  
+  One-click variant of `Create Deployment` that mirrors a real wizard
+  payload captured against the **staging** environment. Everything is
+  hardcoded except the two values that change between runs:
+  
+  - `template_version_id` → set in the `staging` env var (or override
+    here per-request via `vars:pre-request`)
+  - `openstack_project_id` → set in the `staging` env var
+    `openstack_project_local_id`
+  
+  ## What's pinned
+  
+  - **course_id** `f0cbe163-7a2c-4b0f-8c42-d9fc5a8a4fe2` — the test course
+    on staging Keycloak.
+  - **teacher** Eve Stark (`40a38818-...`) — the lecturer test account on
+    staging.
+  - **students** 10 staging test users `s230011`–`s230020` in a single
+    group "Gruppe 1" — captured from a real wizard run on 2026-06-20.
+  - **parameters** the actual Heat params the staging frontend sends for
+    the Ansible Multi-User Ubuntu template (image, flavor, ssh_cidr,
+    force_password_change).
+  - **runtime_months** 4 — backend default (B6 lifecycle).
+  
+  ## When the staging IDs change
+  
+  - The course `f0cbe163-...` is a Keycloak group on staging. If staging
+    Keycloak is reset, update it.
+  - Student/teacher IDs are also staging-Keycloak-specific. They were
+    extracted from the response of a successful wizard deployment.
+  
+  ## Required env vars
+  
+  Set these in the **staging** environment before running:
+  - `access_token` (from Auth → Keycloak Login)
+  - `template_version_id`
+  - `openstack_project_local_id`
+  
+  ## Returns
+  
+  201 with the created deployment incl. `expires_at` /
+  `expiry_warning_at` (B6) and `id` written to env var `deployment_id`.
+}

--- a/bruno/Template Versions/List Template Versions.bru
+++ b/bruno/Template Versions/List Template Versions.bru
@@ -19,24 +19,28 @@ auth:bearer {
   token: {{access_token}}
 }
 
+vars:pre-request {
+  template_id: e7606660-851c-42e8-a394-f938edea9394
+}
+
 docs {
   # List Template Versions
-
+  
   Lists all versions for a specific template, ordered by creation date
   (newest first). Optionally filters to active-only and inlines parameters
   parsed from `app.yaml` for each version.
-
+  
   ## Path Parameters
-
+  
   - `template_id`: UUID of the template
-
+  
   ## Query Parameters
-
+  
   - `active_only` (default `false`) — only active versions
   - `include_parameters` (default `false`) — inline `parameters` parsed from
     each version's `app.yaml`. Off by default because parsing is per-version.
-
+  
   ## Returns
-
+  
   Array of template versions.
 }

--- a/bruno/environments/local.bru
+++ b/bruno/environments/local.bru
@@ -1,6 +1,6 @@
 vars {
   base_url: http://127.0.0.1:8000
-  keycloak_url: https://141.72.176.136/
+  keycloak_url: https://141.72.12.147:8443
   realm: Dozilab
   client_id: appstore-frontend
 }

--- a/bruno/environments/staging.bru
+++ b/bruno/environments/staging.bru
@@ -1,6 +1,6 @@
 vars {
-  base_url: https://141.72.12.147
-  keycloak_url: https://141.72.12.147:8443
+  base_url: https://141.72.13.2
+  keycloak_url: https://141.72.13.2:8443
   realm: Dozilab
   client_id: appstore-frontend
 }

--- a/src/celery_app.py
+++ b/src/celery_app.py
@@ -34,13 +34,16 @@ celery_app.conf.update(
 
 # Periodic tasks. Run a daily sweep that hard-deletes deployments whose
 # ``expires_at`` lies in the past — see src/tasks/expiry_tasks.py for the
-# semantics. Scheduled at 03:17 UTC: off-the-hour to avoid colliding with
-# every other system's hourly cron, and during low-traffic hours so the
-# Heat-stack tear-downs don't fight peak-hour deployments.
+# semantics.
+#
+# Temporarily scheduled at 13:00 UTC (= 15:00 MESZ) so we can observe a
+# real automatic firing during staging soak. Once we've seen one or two
+# clean runs and the prod rollout is done, this goes back to 03:17 UTC
+# (off-the-hour, low-traffic) which was the original prod choice.
 celery_app.conf.beat_schedule = {
     "expire-deployments-daily": {
         "task": "src.tasks.expiry_tasks.expire_deployments",
-        "schedule": crontab(hour=3, minute=17),
+        "schedule": crontab(hour=13, minute=0),
     },
 }
 


### PR DESCRIPTION
## Was

Erweitert den staging-Deploy-Step um `celery-beat` (parallel zum infra-Repo PR der den Service in `docker-compose.staging.yml` ergänzt), plus Bruno-Updates, plus ein **Test-only Schedule-Override**.

## Commits

| SHA | Was |
|---|---|
| `2322659` | **ci(staging)**: `pull` + `up -d` zieht jetzt `celery-beat` mit. Ohne diesen Fix würde der neue Beat-Service aus dem infra-PR nie automatisch auf staging hochkommen, weil der Deploy-Step explizit nur `api celery-worker` listet. |
| `84455b9` | **chore(bruno)**: neues `staging`-Env, neuer Create-Deployment-Request mit den echten 10 Staging-Test-Studenten + Eve-Stark-Lehrer, plus URL-Updates in local/production-Envs |
| `7d7925d` | **test(staging)**: `crontab(hour=3, minute=17)` → `crontab(hour=13, minute=0)`. Pulled forward damit wir den Beat in MESZ-Bürozeit (15:00) beobachten können. **Muss zurück auf 03:17 UTC** sobald der Soak durch ist und der prod-Rollout passiert ist. |

## Scope

**Nur staging-Block.** Production-Deploy-Step (Z. 191-215) ist unangetastet — er pullt weiter nur `api celery-worker` ohne Beat. Sobald staging mit Beat eingelaufen ist, kommt prod als separater PR.

⚠️ Der Schedule-Override aus `7d7925d` ist nicht staging-gated im Code — wenn dieser PR-Branch versehentlich auf `main` gemerged würde, würde prod auch 13:00 UTC feuern. Nicht passieren lassen.

## Verifikation nach Merge + Deploy

```bash
ssh ubuntu@<staging>
docker ps --format 'table {{.Names}}\t{{.Status}}' | grep beat
# erwartet: appstore-celery-beat-1   Up ...

docker logs --since 5m appstore-celery-beat-1 | head
# erwartet: "beat: Starting..." plus Schedule-Eintrag für expire-deployments-daily

# Nach 13:00 UTC (= 15:00 MESZ):
docker logs --since 1h appstore-celery-beat-1 | grep -i expire
# erwartet: "Scheduler: Sending due task expire-deployments-daily"

docker logs --since 1h appstore-celery-worker-1 | grep -i expire_deployments
# erwartet: Task-Execution-Eintrag + Summary "{total_expired: N, enqueued: M, skipped: K}"
```

## Voraussetzung

Dieser PR ist gepaart mit dem infra-Repo PR [DoziLab/appstore-infra#2](https://github.com/DoziLab/appstore-infra/pull/2). Beide müssen gemerged sein **bevor** der nächste Staging-Deploy läuft.

## Follow-up

Nach erfolgreichem Soak (1-2 saubere automatische Runs) zwei Folge-PRs:
1. Schedule zurück auf `crontab(hour=3, minute=17)` (revert `7d7925d`)
2. `celery-beat`-Service auch in `docker-compose.prod.yml` ergänzen + prod-Deploy-Step in `ci-cd.yml` erweitern