### PR TITLE
fix(deploy-log): add missing expiry enum values + push staging soak to 15:00 UTC

### DIFF
--- a/alembic/versions/a1c5e8d2f307_add_expiry_enum_values_to_deployment_log.py
+++ b/alembic/versions/a1c5e8d2f307_add_expiry_enum_values_to_deployment_log.py
@@ -1,0 +1,70 @@
+"""add expiry enum values to deployment log event type
+
+Revision ID: a1c5e8d2f307
+Revises: f7a92e3b8c41
+Create Date: 2026-06-21 16:30:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a1c5e8d2f307'
+down_revision: Union[str, Sequence[str], None] = 'f7a92e3b8c41'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    The B6 expiry work (f7a92e3b8c41) added ``expires_at`` /
+    ``expiry_warning_at`` columns and the Celery-Beat sweep, but forgot to
+    extend the ``deploymentlogeventtype`` PG enum with the two new audit
+    events the code now emits:
+
+    - ``DEPLOYMENT_EXPIRED`` — written by ``expire_deployments`` before each
+      enqueued hard delete (see src/tasks/expiry_tasks.py).
+    - ``DEPLOYMENT_LIFETIME_EXTENDED`` — written when an admin extends a
+      deployment's runtime via the extend-lifetime endpoint.
+
+    Without these labels, the first sweep on staging (2026-06-21 13:00 UTC)
+    raised ``psycopg2.errors.InvalidTextRepresentation`` on the audit-log
+    INSERT, which aborted the per-deployment transaction so the
+    ``delete_deployment`` task was never enqueued. The sweep reported
+    ``{'total_expired': 1, 'enqueued': 0, 'skipped': 1}`` and the expired
+    deployment lived on.
+
+    Both values are added with ``IF NOT EXISTS`` so this migration is safe
+    to run against a database where someone (e.g. an emergency manual
+    ALTER) has already added them.
+
+    Note on Postgres semantics: ``ALTER TYPE ... ADD VALUE`` is allowed in
+    a transaction since PG 12, but the newly-added value is only usable
+    after the transaction commits. We do not write rows with the new value
+    in this migration, so the default Alembic transaction wrap is fine.
+    """
+    op.execute(
+        "ALTER TYPE deploymentlogeventtype "
+        "ADD VALUE IF NOT EXISTS 'DEPLOYMENT_EXPIRED'"
+    )
+    op.execute(
+        "ALTER TYPE deploymentlogeventtype "
+        "ADD VALUE IF NOT EXISTS 'DEPLOYMENT_LIFETIME_EXTENDED'"
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Postgres does not support removing values from an enum type without
+    rebuilding the type and all dependent columns. Since the missing values
+    were a bug (the application code already emitted them), there is no
+    sensible downgrade path — rolling back the application code is the
+    correct response, and the now-unused enum labels are harmless.
+
+    Left intentionally empty.
+    """
+    pass

--- a/src/celery_app.py
+++ b/src/celery_app.py
@@ -36,14 +36,15 @@ celery_app.conf.update(
 # ``expires_at`` lies in the past — see src/tasks/expiry_tasks.py for the
 # semantics.
 #
-# Temporarily scheduled at 13:00 UTC (= 15:00 MESZ) so we can observe a
-# real automatic firing during staging soak. Once we've seen one or two
-# clean runs and the prod rollout is done, this goes back to 03:17 UTC
-# (off-the-hour, low-traffic) which was the original prod choice.
+# Temporarily scheduled at 15:00 UTC (= 17:00 MESZ) so we can observe the
+# next automatic firing during staging soak after the enum-values fix
+# lands. Once we've seen one or two clean runs and the prod rollout is
+# done, this goes back to 03:17 UTC (off-the-hour, low-traffic) which was
+# the original prod choice.
 celery_app.conf.beat_schedule = {
     "expire-deployments-daily": {
         "task": "src.tasks.expiry_tasks.expire_deployments",
-        "schedule": crontab(hour=13, minute=0),
+        "schedule": crontab(hour=15, minute=0),
     },
 }
 


### PR DESCRIPTION
## Was und warum

Der erste echte Beat-Sweep auf staging (heute 13:00 UTC) ist über einen DB-Bug aus B6 gestolpert:

```
psycopg2.errors.InvalidTextRepresentation:
invalid input value for enum deploymentlogeventtype: "DEPLOYMENT_EXPIRED"
```

Sweep-Resultat: `{'total_expired': 1, 'enqueued': 0, 'skipped': 1}` — das eine abgelaufene Deployment lebt weiter.

**Root cause:** Die B6-Migration `f7a92e3b8c41` hat `expires_at` / `expiry_warning_at` als Spalten hinzugefügt + den Celery-Sweep eingeführt, aber **vergessen, den `deploymentlogeventtype` PG-Enum zu erweitern**. Im Python-Enum stehen `DEPLOYMENT_EXPIRED` und `DEPLOYMENT_LIFETIME_EXTENDED` als Member, in Postgres fehlen sie. Sobald der Sweep den ersten Audit-Log-Eintrag schreiben will, knallt der INSERT, die Transaktion rollt zurück, `delete_deployment` wird nie enqueued.

## Was diese PR macht

**Commit 1 — die eigentliche Korrektur:**
- Neue Alembic-Migration `a1c5e8d2f307` hängt an `f7a92e3b8c41`
- `ALTER TYPE deploymentlogeventtype ADD VALUE IF NOT EXISTS 'DEPLOYMENT_EXPIRED'`
- `ALTER TYPE deploymentlogeventtype ADD VALUE IF NOT EXISTS 'DEPLOYMENT_LIFETIME_EXTENDED'`
- `IF NOT EXISTS` macht die Migration idempotent (falls jemand auf staging manuell gepatcht hätte, hätten wir nicht — über genau diesen Punkt haben wir entschieden, alles über Alembic laufen zu lassen damit staging und prod identisch behandelt werden)
- `downgrade()` ist leer + dokumentiert: PG kann Enum-Werte nicht entfernen ohne Type-Rebuild; die Werte sind sowieso korrekt, also kein sinnvoller Down-Pfad

**Commit 2 — Soak-Schedule verschoben:**
- `crontab(hour=15, minute=0)` (= 17:00 MESZ) statt 13:00 UTC
- Heutiger Fire ist durch (mit Bug), nächster regulärer Tick wäre sonst erst morgen
- Original-Plan bleibt: nach erfolgreichem Soak zurück auf `crontab(hour=3, minute=17)` vor Prod-Rollout (TODO im Code-Kommentar erwähnt)

## Wie ich's verifiziert habe

Lokal nur Plausi (Datei syntaktisch korrekt, `down_revision` zeigt auf aktuellen Head). Der echte Test passiert nach Merge:

1. CI deployed → `docker compose exec api alembic upgrade head` läuft → unsere Migration läuft
2. Verifizieren auf staging:
   ```bash
   docker exec appstore-db-1 psql -U postgres -d dozilab -c \
     "SELECT enumlabel FROM pg_enum WHERE enumtypid = 'deploymentlogeventtype'::regtype ORDER BY enumsortorder;"
   ```
   Sollte jetzt 16 Werte zeigen (vorher 14).
3. Bei 15:00 UTC: Beat feuert wieder, diesmal sollte der Worker `{'total_expired': N, 'enqueued': N, 'skipped': 0}` reporten und `delete_deployment` für jedes Kandidaten-Deployment enqueuen.

## Was diese PR explizit NICHT tut

- **TZ-Bug auf `DateTime` Spalten:** `expires_at` und `expiry_warning_at` sind nach wie vor `DateTime` (timezone-naive) statt `DateTime(timezone=True)`. Frontend interpretiert die JSON-Strings ohne TZ-Suffix als Lokalzeit → 2h-Drift in MESZ. Separater Fix.
- **Prod-Rollout:** Nach erfolgreichem 15:00-UTC-Soak: (a) Schedule zurück auf 03:17 UTC, (b) `celery-beat` Service in `docker-compose.prod.yml` + Prod-Deploy-Step in ci-cd.yml ergänzen.

## Risiko

Niedrig. `ALTER TYPE ... ADD VALUE` ist eine reine additive DDL ohne Locking auf existierende Daten. `IF NOT EXISTS` macht ihn re-run-safe. Worst case: Migration läuft auf einer DB wo die Werte schon da sind → No-Op.