### PR TITLE
fix(deployment): TIMESTAMPTZ for expiry fields + revert beat schedule + prod-rollout ci

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -188,7 +188,7 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.PROD_SERVER_SSH_KEY }}
 
-      - name: Deploy api + celery-worker on Production
+      - name: Deploy api + celery-worker + celery-beat on Production
         env:
           SERVER_HOST: ${{ secrets.PROD_SERVER_HOST }}
         run: |
@@ -199,8 +199,8 @@ jobs:
 
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-            docker compose -f docker-compose.yml -f docker-compose.prod.yml pull api celery-worker
-            docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d api celery-worker
+            docker compose -f docker-compose.yml -f docker-compose.prod.yml pull api celery-worker celery-beat
+            docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d api celery-worker celery-beat
 
             docker compose -f docker-compose.yml -f docker-compose.prod.yml exec -T api alembic upgrade head
 

--- a/alembic/versions/c4b8e1f6a209_make_deployment_expiry_tz_aware.py
+++ b/alembic/versions/c4b8e1f6a209_make_deployment_expiry_tz_aware.py
@@ -1,0 +1,75 @@
+"""make deployment expiry timestamps timezone-aware
+
+Revision ID: c4b8e1f6a209
+Revises: a1c5e8d2f307
+Create Date: 2026-06-21 17:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c4b8e1f6a209'
+down_revision: Union[str, Sequence[str], None] = 'a1c5e8d2f307'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    The B6 expiry work persisted ``expires_at`` and ``expiry_warning_at`` as
+    ``TIMESTAMP WITHOUT TIME ZONE``. The application code, by contrast,
+    always works with timezone-aware UTC datetimes (``datetime.now(timezone.utc)``).
+    On round-trip through SQLAlchemy the values come back naive, which broke
+    two flows in production:
+
+    1. ``DeploymentService.extend_deployment`` calls
+       ``max(now, deployment.expires_at)`` — ``TypeError`` because ``now`` is
+       aware while the column value is naive.
+
+    2. The frontend renders the JSON timestamp without a TZ suffix as local
+       time, causing a 2-hour drift in MESZ on the "expires soon" banner.
+
+    Both root-cause from the same column-type mismatch. Switching to
+    ``TIMESTAMP WITH TIME ZONE`` fixes both:
+
+    - SQLAlchemy returns aware datetimes, so the ``max()`` works.
+    - The JSON serializer emits ``...+00:00``, so the frontend parses it as UTC.
+
+    The ``USING expires_at AT TIME ZONE 'UTC'`` clause tells Postgres to
+    re-interpret existing naive values as UTC moments — which is correct
+    because the application has been writing ``datetime.now(timezone.utc)``
+    all along; only the storage type was wrong.
+    """
+    op.execute(
+        "ALTER TABLE deployments "
+        "ALTER COLUMN expires_at TYPE TIMESTAMP WITH TIME ZONE "
+        "USING expires_at AT TIME ZONE 'UTC'"
+    )
+    op.execute(
+        "ALTER TABLE deployments "
+        "ALTER COLUMN expiry_warning_at TYPE TIMESTAMP WITH TIME ZONE "
+        "USING expiry_warning_at AT TIME ZONE 'UTC'"
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    The reverse cast strips the timezone, leaving the underlying instant
+    unchanged when viewed as UTC. Pre-rollback callers should expect to lose
+    the aware-vs-naive distinction.
+    """
+    op.execute(
+        "ALTER TABLE deployments "
+        "ALTER COLUMN expiry_warning_at TYPE TIMESTAMP WITHOUT TIME ZONE "
+        "USING expiry_warning_at AT TIME ZONE 'UTC'"
+    )
+    op.execute(
+        "ALTER TABLE deployments "
+        "ALTER COLUMN expires_at TYPE TIMESTAMP WITHOUT TIME ZONE "
+        "USING expires_at AT TIME ZONE 'UTC'"
+    )

--- a/src/celery_app.py
+++ b/src/celery_app.py
@@ -36,15 +36,13 @@ celery_app.conf.update(
 # ``expires_at`` lies in the past — see src/tasks/expiry_tasks.py for the
 # semantics.
 #
-# Temporarily scheduled at 15:00 UTC (= 17:00 MESZ) so we can observe the
-# next automatic firing during staging soak after the enum-values fix
-# lands. Once we've seen one or two clean runs and the prod rollout is
-# done, this goes back to 03:17 UTC (off-the-hour, low-traffic) which was
-# the original prod choice.
+# Fires at 03:17 UTC: off-the-hour to avoid colliding with everyone else's
+# cron jobs, and during the low-traffic window so a misbehaving sweep does
+# not compete with classroom usage.
 celery_app.conf.beat_schedule = {
     "expire-deployments-daily": {
         "task": "src.tasks.expiry_tasks.expire_deployments",
-        "schedule": crontab(hour=15, minute=0),
+        "schedule": crontab(hour=3, minute=17),
     },
 }
 

--- a/src/models/deployment.py
+++ b/src/models/deployment.py
@@ -43,13 +43,13 @@ class Deployment(Base):
     openstack_stack_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     deployment_parameters: Mapped[Optional[str]] = mapped_column(String, nullable=True, comment="Heat parameters, stack_assignments, and teacher info as JSON")
     expires_at: Mapped[Optional[datetime]] = mapped_column(
-        DateTime,
+        DateTime(timezone=True),
         nullable=True,
         index=True,
         comment="When this deployment is hard-deleted by the daily expire_deployments_task; NULL = never expire",
     )
     expiry_warning_at: Mapped[Optional[datetime]] = mapped_column(
-        DateTime,
+        DateTime(timezone=True),
         nullable=True,
         comment="When the UI should start showing the 'expires soon' warning; computed at creation/extend",
     )


### PR DESCRIPTION
## Was und warum

Drei Sachen, alle aus dem Beat-Soak-Lernerfahrungen:

### 1. TZ-Fix für `expires_at` / `expiry_warning_at` (Commit 1)

Beide Spalten lagen als `TIMESTAMP WITHOUT TIME ZONE` in der DB, während der Anwendungscode immer `datetime.now(timezone.utc)` schreibt. Auf dem Round-Trip durch SQLAlchemy kamen die Werte **naive** zurück, was zwei Bugs erzeugte:

**a) Extend-Endpoint crasht mit `TypeError`**
[deployment_expiry.py:73](appstore-backend/src/utils/deployment_expiry.py#L73):
```python
anchor = max(now, current_expires_at) if current_expires_at else now
```
- `now` = aware (`datetime.now(timezone.utc)`)
- `current_expires_at` = naive (aus DB)
- `max(aware, naive)` → `TypeError: can't compare offset-naive and offset-aware datetimes`

Heißt: `PATCH /deployments/{id}/extend` 500-t für **jedes** Deployment das `expires_at` gesetzt hat — also alles was nach B6 erzeugt wurde. Discovered nach dem End-to-End-Verify des Sweep-Pfads heute.

**b) Frontend-Banner-Drift (2h in MESZ)**
JSON-Serializer emittiert `"2026-06-21T13:00:00"` (ohne TZ-Suffix), Frontend parst als Lokalzeit → Banner zeigt Uhrzeiten in MESZ um 2h verschoben. Dasselbe Symptom, dasselbe Root-Cause.

**Fix:** Migration `c4b8e1f6a209` castet beide Spalten auf `TIMESTAMP WITH TIME ZONE` mit `USING ... AT TIME ZONE 'UTC'`. Das ist data-preserving: die bisher gespeicherten Werte werden korrekt als UTC-Momente re-interpretiert (passend zu dem was die App tatsächlich geschrieben hat). Modell zieht mit auf `DateTime(timezone=True)`.

Tests in `test_deployment_expiry_helpers.py` und `test_deployment_expiry_lifecycle.py` benutzen seit jeher aware datetimes — sie blieben grün, fingen den Bug aber nicht, weil sie an `SimpleNamespace`-Mocks statt echten SQLAlchemy-Roundtrips testen. Beweis ihr Output:
```
========== 21 passed, 1 warning in 9.23s ==========
```

### 2. Schedule zurück auf 03:17 UTC (Commit 2)

Soak war erfolgreich (13:00 UTC fire fand den Enum-Bug, 15:00 UTC fire nach Fix lief sauber durch). Zurück auf den ursprünglich vorgesehenen `crontab(hour=3, minute=17)` — off-the-hour, low-traffic.

### 3. Prod-Deploy-Step inkludiert celery-beat (Commit 3)

`ci-cd.yml` Z. 191-203: `docker compose pull/up` jetzt mit `api celery-worker celery-beat` (analog zum staging-Step). Erweitert sich beim nächsten staging→main Promotion. Setzt voraus dass der celery-beat Service in der Base-Compose existiert — das tut er nach **appstore-infra#3** (folgt parallel).

## Reihenfolge zum Mergen (wichtig)

1. **[appstore-infra PR](https://github.com/DoziLab/appstore-infra/pull/3)** — moved `celery-beat` aus staging-override in base compose. Muss zuerst.
2. **Diese PR**: TZ-Fix kann auf staging deployt werden ohne dass die ci-cd-Änderung wirkt (sie betrifft nur den `main`/Prod-Pfad).
3. Später, beim staging→main merge: Prod-CI bekommt den celery-beat Pull-Step. Setzt voraus dass die infra-PR auf prod schon angekommen ist (über die übliche Infra-Repo-Deploy-Mechanik — der prod-Server `git pull`-t aus `appstore-infra` main).

Wenn jemand **diese** PR nach `main` mergt **bevor** die infra-PR die compose-Definition auf den Prod-Server gebracht hat: prod-deploy failt am `docker compose pull celery-beat` weil der Service unbekannt ist. Reihenfolge bewusst so.

## Was diese PR NICHT macht

- **Bestehende abgelaufene Deployments** auf staging/prod werden durch die Migration nicht geändert (USING-Cast ist value-preserving). Sie waren UTC-korrekt geschrieben, sie sind danach UTC-korrekt typisiert.
- **Frontend-Anpassung**: der TZ-Fix lässt den JSON-Output von `expires_at` von `"2026-06-21T13:00:00"` auf `"2026-06-21T13:00:00+00:00"` wechseln. Korrekt parsing-fähige Frontends (alle modernen Date-APIs) ändern nichts. Falls irgendwo im Frontend ein hartnäckiges `new Date(str + "Z")` Hack steht, sollte er gefunden werden — separate Frontend-Doku falls nötig.

## Risiko

Mittel-niedrig:
- Migration ist DDL-only, kein Daten-Touch. PG `ALTER COLUMN ... TYPE TIMESTAMPTZ USING ... AT TIME ZONE 'UTC'` rewriteset den Spalten-Storage, aber Werte bleiben semantisch identisch.
- Während der Migration kurzzeitiges Lock auf `deployments` — auf staging mit einer Handvoll Rows nicht spürbar; auf prod wenn die Tabelle wächst kann es einen Moment dauern, ist aber kein Index-Rebuild.
- Rollback-Pfad existiert (`downgrade()` castet zurück auf naive); dokumentiert dass dabei die aware-vs-naive Unterscheidung verloren geht — was ok ist, weil die App eh aware schreibt.