### PR TITLE
fix(db): TIMESTAMPTZ for all remaining timestamp columns + utcnow refactor

### DIFF
--- a/alembic/versions/e7f3a91d05b8_make_all_timestamps_tz_aware.py
+++ b/alembic/versions/e7f3a91d05b8_make_all_timestamps_tz_aware.py
@@ -1,0 +1,119 @@
+"""make all timestamp columns timezone-aware
+
+Revision ID: e7f3a91d05b8
+Revises: c4b8e1f6a209
+Create Date: 2026-06-22 11:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'e7f3a91d05b8'
+down_revision: Union[str, Sequence[str], None] = 'c4b8e1f6a209'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# (table, column) pairs to convert. Kept as data — the upgrade/downgrade
+# loops emit one ALTER COLUMN per entry. Ordered alphabetically by table for
+# review readability; execution order is irrelevant because every statement
+# is value-preserving and the conversion target is identical across columns.
+_COLUMNS_TO_CONVERT: tuple[tuple[str, str], ...] = (
+    ("courses", "created_at"),
+    ("courses", "updated_at"),
+    ("course_groups", "created_at"),
+    ("course_groups", "updated_at"),
+    ("course_members", "joined_at"),
+    ("course_members", "left_at"),
+    ("deployments", "created_at"),
+    ("deployments", "updated_at"),
+    # deployments.expires_at + expiry_warning_at already migrated in c4b8e1f6a209
+    ("deployment_instances", "created_at"),
+    ("deployment_instances", "updated_at"),
+    ("deployment_instance_access", "expires_at"),
+    ("deployment_instance_access", "created_at"),
+    ("deployment_instance_access", "updated_at"),
+    ("deployment_logs", "created_at"),
+    ("group_members", "joined_at"),
+    ("openstack_projects", "created_at"),
+    ("openstack_projects", "updated_at"),
+    ("templates", "created_at"),
+    ("templates", "updated_at"),
+    ("template_categories", "created_at"),
+    ("template_categories", "updated_at"),
+    ("template_category_assignments", "assigned_at"),
+    ("template_versions", "approved_at"),
+    ("template_versions", "created_at"),
+    ("template_version_files", "created_at"),
+    ("template_version_files", "updated_at"),
+    ("users", "created_at"),
+    ("users", "last_login_at"),
+)
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    Converts every remaining ``TIMESTAMP WITHOUT TIME ZONE`` column in the
+    application schema to ``TIMESTAMP WITH TIME ZONE``. This is the
+    company-wide follow-up to ``c4b8e1f6a209``, which fixed only the two
+    deployment-expiry columns where the symptom was most acute (extend
+    endpoint crashed; expiry banner drifted by 2 h in MESZ).
+
+    The same root cause was already proven there: the application code has
+    always written ``datetime.now(timezone.utc)`` (aware), but the storage
+    type stripped the tzinfo, so values came back naive on read. Symptoms
+    visible across the UI:
+
+    - "Gestartet: 16:16" on the Deployment-Details page when the deployment
+      actually started at 18:16 MESZ — Browser interprets the suffix-less
+      ISO string as local time.
+    - "Aktualisiert vor 2 Stunden" on the Dashboard immediately after an
+      update, for the same reason.
+    - AdminMonitoring tables showing log / template / user timestamps off
+      by the local-time offset.
+
+    The ``USING <col> AT TIME ZONE 'UTC'`` clause re-interprets the existing
+    naive values as UTC moments. This matches what the application has
+    always written, so no data movement occurs — only the storage type
+    changes. Postgres rewrites the column's tuple representation (catalog
+    update plus the cheapest of column rewrites since the stored values
+    don't change), holding an exclusive lock for the duration of each
+    ALTER. All affected tables are small in this codebase (deployments in
+    the tens, users in the dozens), so the cumulative lock time is in the
+    millisecond range.
+
+    All 28 statements run in a single Alembic transaction — on failure of
+    any one, the entire migration rolls back and the database state is
+    exactly as before. The set was confirmed exhaustive by grepping all
+    SQLAlchemy ``DateTime``-without-``timezone=True`` columns across
+    ``src/models/`` before drafting this migration.
+    """
+    for table, column in _COLUMNS_TO_CONVERT:
+        op.execute(
+            f"ALTER TABLE {table} "
+            f"ALTER COLUMN {column} TYPE TIMESTAMP WITH TIME ZONE "
+            f"USING {column} AT TIME ZONE 'UTC'"
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Reverses every conversion. The reverse cast strips the timezone marker
+    while leaving the underlying instant unchanged when viewed as UTC.
+    Callers downgrading past this migration should be aware that the
+    aware-vs-naive distinction is lost on the column — which is acceptable
+    in practice because the application code has always written aware
+    timestamps, and reverting the application code is the correct response
+    if a downgrade is ever needed.
+    """
+    for table, column in _COLUMNS_TO_CONVERT:
+        op.execute(
+            f"ALTER TABLE {table} "
+            f"ALTER COLUMN {column} TYPE TIMESTAMP WITHOUT TIME ZONE "
+            f"USING {column} AT TIME ZONE 'UTC'"
+        )

--- a/src/core/logging_config.py
+++ b/src/core/logging_config.py
@@ -2,22 +2,22 @@
 import logging
 import sys
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict
 
 
 class JSONFormatter(logging.Formatter):
     """
     Custom JSON formatter for structured logging compatible with Loki.
-    
+
     Outputs logs as JSON with consistent field names for easy parsing and querying.
     """
-    
+
     def format(self, record: logging.LogRecord) -> str:
         """Format log record as JSON string."""
         # Base log data
         log_data: Dict[str, Any] = {
-            'timestamp': datetime.utcnow().isoformat() + 'Z',
+            'timestamp': datetime.now(timezone.utc).isoformat(),
             'level': record.levelname,
             'logger': record.name,
             'message': record.getMessage(),

--- a/src/core/response_builder.py
+++ b/src/core/response_builder.py
@@ -4,7 +4,7 @@ This module provides the ResponseBuilder class for creating consistent
 JSON responses across all API endpoints. All responses follow the same
 structure defined in responses.py (APIResponse and PaginatedResponse).
 """
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, List
 import logging
 
@@ -46,7 +46,7 @@ class ResponseBuilder:
             message=message,
             data=data,
             errors=None,
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(timezone.utc),
             request_id=request_id,
         )
         return JSONResponse(
@@ -98,7 +98,7 @@ class ResponseBuilder:
             message=message,
             data=None,
             errors=None,
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(timezone.utc),
             request_id=request_id,
         )
         return JSONResponse(
@@ -129,7 +129,7 @@ class ResponseBuilder:
             message=message,
             data=None,
             errors=errors,
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(timezone.utc),
             request_id=request_id,
         )
         content = response_data.model_dump(mode="json")
@@ -289,7 +289,7 @@ class ResponseBuilder:
             data=data,
             pagination=pagination_meta,
             errors=None,
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(timezone.utc),
             request_id=request_id,
         )
         

--- a/src/core/responses.py
+++ b/src/core/responses.py
@@ -1,5 +1,5 @@
 """Standardized response models for API endpoints."""
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Generic, TypeVar, Any
 from pydantic import BaseModel, Field
 
@@ -13,9 +13,9 @@ class APIResponse(BaseModel, Generic[T]):
     message: str | None = Field(None, description="Human-readable message")
     data: T | None = Field(None, description="Response payload")
     errors: Any | None = Field(None, description="Error details if any")
-    timestamp: datetime = Field(default_factory=datetime.utcnow, description="Response timestamp")
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="Response timestamp")
     request_id: str | None = Field(None, description="Unique request identifier")
-    
+
     class Config:
         json_schema_extra = {
             "example": {
@@ -23,7 +23,7 @@ class APIResponse(BaseModel, Generic[T]):
                 "message": "Operation successful",
                 "data": {"id": "123", "name": "Example"},
                 "errors": None,
-                "timestamp": "2024-11-27T10:00:00Z",
+                "timestamp": "2024-11-27T10:00:00+00:00",
                 "request_id": "req-123-456"
             }
         }
@@ -51,5 +51,5 @@ class PaginatedResponse(BaseModel, Generic[T]):
     data: list[T] = Field(..., description="List of items for current page")
     pagination: PaginationMeta = Field(..., description="Pagination metadata")
     errors: Any | None = Field(None, description="Error details if any")
-    timestamp: datetime = Field(default_factory=datetime.utcnow, description="Response timestamp")
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="Response timestamp")
     request_id: str | None = Field(None, description="Unique request identifier")

--- a/src/models/course.py
+++ b/src/models/course.py
@@ -16,8 +16,8 @@ class Course(Base):
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
     name: Mapped[str] = mapped_column(String(255), nullable=False, comment="Course name")
     keycloak_course_id: Mapped[str] = mapped_column(String(255), nullable=False, unique=True, comment="Keycloak group ID for this course")
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
-    updated_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
     
     # Relationships
     deployments: Mapped[list["Deployment"]] = relationship("Deployment", back_populates="course")

--- a/src/models/course_group.py
+++ b/src/models/course_group.py
@@ -16,8 +16,8 @@ class CourseGroup(Base):
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
     course_id: Mapped[str] = mapped_column(String(36), ForeignKey("courses.id"), nullable=False)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
-    updated_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
     
     # Relationships
     course: Mapped["Course"] = relationship("Course", back_populates="groups")

--- a/src/models/course_member.py
+++ b/src/models/course_member.py
@@ -16,8 +16,8 @@ class CourseMember(Base):
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
     user_id: Mapped[str] = mapped_column(String(36), ForeignKey("users.id"), nullable=False)
     course_id: Mapped[str] = mapped_column(String(36), ForeignKey("courses.id"), nullable=False)
-    joined_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
-    left_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    joined_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    left_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     
     # Relationships
     user: Mapped["User"] = relationship("User", back_populates="course_memberships")

--- a/src/models/deployment.py
+++ b/src/models/deployment.py
@@ -53,8 +53,8 @@ class Deployment(Base):
         nullable=True,
         comment="When the UI should start showing the 'expires soon' warning; computed at creation/extend",
     )
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
-    updated_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
     # Relationships
     course: Mapped["Course"] = relationship("Course", back_populates="deployments")

--- a/src/models/deployment_instance.py
+++ b/src/models/deployment_instance.py
@@ -39,8 +39,8 @@ class DeploymentInstance(Base):
         SQLEnum(DeploymentInstanceStatus), 
         default=DeploymentInstanceStatus.CREATING
     )
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
-    updated_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
     # Relationships
     deployment: Mapped["Deployment"] = relationship("Deployment", back_populates="instances")

--- a/src/models/deployment_instance_access.py
+++ b/src/models/deployment_instance_access.py
@@ -43,10 +43,10 @@ class DeploymentInstanceAccess(Base):
 
     # Access control
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
-    expires_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
-    updated_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
     # Relationships
     deployment_instance: Mapped["DeploymentInstance"] = relationship("DeploymentInstance", back_populates="access_methods")

--- a/src/models/deployment_log.py
+++ b/src/models/deployment_log.py
@@ -56,7 +56,7 @@ class DeploymentLog(Base):
     message: Mapped[str] = mapped_column(Text, nullable=False)
     details_json: Mapped[str | None] = mapped_column(Text, nullable=True)
     request_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     
     # Relationships
     deployment: Mapped["Deployment"] = relationship("Deployment", back_populates="logs")

--- a/src/models/group_member.py
+++ b/src/models/group_member.py
@@ -16,7 +16,7 @@ class GroupMember(Base):
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
     group_id: Mapped[str] = mapped_column(String(36), ForeignKey("course_groups.id"), nullable=False)
     course_member_id: Mapped[str] = mapped_column(String(36), ForeignKey("course_members.id"), nullable=False)
-    joined_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
+    joined_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     
     # Relationships
     group: Mapped["CourseGroup"] = relationship("CourseGroup", back_populates="members")

--- a/src/models/openstack_project.py
+++ b/src/models/openstack_project.py
@@ -37,8 +37,8 @@ class OpenstackProject(Base):
     user_domain_name: Mapped[str] = mapped_column(String(255), nullable=False, default="Default")
     region_name: Mapped[str] = mapped_column(String(100), nullable=False)
     
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
-    updated_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
     
     # Relationships
     owner_user: Mapped["User"] = relationship("User", back_populates="openstack_projects")

--- a/src/models/template.py
+++ b/src/models/template.py
@@ -34,8 +34,8 @@ class Template(Base):
         SQLEnum(TemplateVisibility),
         default=TemplateVisibility.PRIVATE
     )
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
-    updated_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
     # Relationships
     owner: Mapped["User"] = relationship("User", back_populates="owned_templates")

--- a/src/models/template_category.py
+++ b/src/models/template_category.py
@@ -16,8 +16,8 @@ class TemplateCategory(Base):
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
     name: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
-    updated_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
     
     # Relationships
     template_assignments: Mapped[list["TemplateCategoryAssignment"]] = relationship("TemplateCategoryAssignment", back_populates="category")

--- a/src/models/template_category_assignment.py
+++ b/src/models/template_category_assignment.py
@@ -14,7 +14,7 @@ class TemplateCategoryAssignment(Base):
     
     template_id: Mapped[str] = mapped_column(String(36), ForeignKey("templates.id"), primary_key=True)
     template_categories_id: Mapped[str] = mapped_column(String(36), ForeignKey("template_categories.id"), primary_key=True)
-    assigned_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
+    assigned_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     
     # Relationships
     template: Mapped["Template"] = relationship("Template", back_populates="category_assignments")

--- a/src/models/template_version.py
+++ b/src/models/template_version.py
@@ -42,12 +42,12 @@ class TemplateVersion(Base):
         String(36), ForeignKey("users.id"), nullable=True,
         comment="Admin who approved/rejected this version",
     )
-    approved_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    approved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     rejection_reason: Mapped[str | None] = mapped_column(
         Text, nullable=True,
         comment="Optional admin-provided reason when approval_status == REJECTED",
     )
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
     # Relationships
     template: Mapped["Template"] = relationship("Template", back_populates="versions")

--- a/src/models/template_version_file.py
+++ b/src/models/template_version_file.py
@@ -47,9 +47,9 @@ class TemplateVersionFile(Base):
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     is_primary: Mapped[bool] = mapped_column(default=False, comment="Primary file for deployment (e.g., main heat.yaml)")
     order: Mapped[int] = mapped_column(Integer, default=0, comment="Execution order if applicable")
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime,
+        DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc)
     )

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -98,15 +98,15 @@ class User(Base):
 
     # Audit: When was user first seen?
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, 
+        DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
         comment="First login timestamp"
     )
-    
+
     # Audit: When did user last login?
     last_login_at: Mapped[datetime] = mapped_column(
-        DateTime,
+        DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
         comment="Last successful login timestamp"


### PR DESCRIPTION
## Was und warum

PR #146 hat `deployments.expires_at` + `expiry_warning_at` auf `TIMESTAMPTZ` umgestellt, weil dort der akute Crash war (Extend-Endpoint) und der Banner-Drift sofort sichtbar war. Auf staging hat sich danach gezeigt: **das Drift-Symptom betrifft die gesamte App** — jede UI-Stelle die ein `created_at` / `updated_at` rendert (Dashboard, DeploymentDetails "Gestartet: 16:16" statt 18:16, AdminMonitoring etc.) zeigt UTC-Zeit als wäre es Lokalzeit.

Root cause überall identisch: **DB-Spalten waren `TIMESTAMP WITHOUT TIME ZONE`, der Anwendungscode schreibt aber konsistent `datetime.now(timezone.utc)`**. Auf dem Round-Trip durch SQLAlchemy kamen die Werte naive zurück. Der JSON-Serializer emittierte `"2026-06-21T16:16:00"` ohne Suffix, Browser interpretierte als Lokalzeit → 2h Drift in MESZ.

Diese PR macht das app-weit zu Ende.

## Commits

### `3a1c9a0` — fix(db): make all timestamp columns TIMESTAMPTZ

**Migration `e7f3a91d05b8`** wandelt alle restlichen 28 Timestamp-Spalten auf `TIMESTAMP WITH TIME ZONE`:

| Tabelle | Spalten |
|---|---|
| `courses` | `created_at`, `updated_at` |
| `course_groups` | `created_at`, `updated_at` |
| `course_members` | `joined_at`, `left_at` |
| `deployments` | `created_at`, `updated_at` (expires_at/expiry_warning_at in PR #146 schon TIMESTAMPTZ) |
| `deployment_instances` | `created_at`, `updated_at` |
| `deployment_instance_access` | `expires_at`, `created_at`, `updated_at` |
| `deployment_logs` | `created_at` |
| `group_members` | `joined_at` |
| `openstack_projects` | `created_at`, `updated_at` |
| `templates` | `created_at`, `updated_at` |
| `template_categories` | `created_at`, `updated_at` |
| `template_category_assignments` | `assigned_at` |
| `template_versions` | `approved_at`, `created_at` |
| `template_version_files` | `created_at`, `updated_at` |
| `users` | `created_at`, `last_login_at` |

Pattern pro Spalte, alle 28 in einer Transaktion — selbes value-preserving Statement das in PR #146 schon live verifiziert wurde:

```sql
ALTER TABLE <t> ALTER COLUMN <c> TYPE TIMESTAMP WITH TIME ZONE
USING <c> AT TIME ZONE 'UTC';
```

Plus die passenden Model-Updates in 15 Dateien: `DateTime` → `DateTime(timezone=True)`. Defaults (`datetime.now(timezone.utc)`) bleiben unverändert — waren immer schon korrekt.

### `ef21b51` — refactor(core): replace `datetime.utcnow()` with timezone-aware `now()`

7 verbliebene Stellen mit `datetime.utcnow()` (deprecated, naive):

| Datei | Stellen |
|---|---|
| `src/core/response_builder.py` | 4 × `timestamp=...` in success / no_content / error / paginated |
| `src/core/responses.py` | 2 × `default_factory=...` in APIResponse + PaginatedResponse + Schema-Example angepasst |
| `src/core/logging_config.py` | 1 × — der manuelle `+ 'Z'`-Hack fällt weg, weil aware-Output schon `+00:00` trägt |

Der `utcnow()`-Helper in `src/utils/deployment_expiry.py:83` ist **NICHT** angefasst — der gibt schon eine aware datetime zurück (`datetime.now(timezone.utc)`), ist unsere eigene Wrapper-Function fürs gerade auch im Sweep verwendete `now`.

## Verifikation

**Lokal** (alles grün):
```
$ uv run pytest tests/ --tb=short -q
311 passed, 4 skipped, 1 warning in 5.30s
```

- 522 DeprecationWarnings (`utcnow()`) auf 1 reduziert — die verbliebene ist orthogonal (Pydantic `class Config` → `ConfigDict`)
- Expiry-Helpers und Lifecycle-Tests grün — sie nutzten schon aware datetimes, sind also nach unserem Fix immer noch konsistent

**Auf staging nach CI-Deploy**:

```bash
# 1. Migration angekommen
docker exec appstore-db-1 psql -U postgres -d dozilab -c \
  "SELECT version_num FROM alembic_version;"
# Erwartung: e7f3a91d05b8

# 2. Spalten-Typ-Spotcheck
docker exec appstore-db-1 psql -U postgres -d dozilab -c "
  SELECT table_name, column_name, data_type
  FROM information_schema.columns
  WHERE column_name IN
    ('created_at','updated_at','last_login_at','approved_at',
     'joined_at','assigned_at','left_at','expires_at')
  ORDER BY table_name, column_name;
"
# Erwartung: alle data_type = 'timestamp with time zone'

# 3. JSON-Spotcheck (Bruno oder curl gegen GET /api/v1/deployments):
#    created_at muss '+00:00' Suffix tragen
```

**Frontend manual**:
- DeploymentDetails: "Gestartet: 18:16" statt "16:16" (in MESZ)
- Dashboard: "Aktualisiert vor wenigen Minuten" statt "vor 2 Stunden" direkt nach Update
- AdminMonitoring: alle Tabellen mit `created_at`/`updated_at`/`last_login_at` zeigen Lokalzeit

## Was NICHT angefasst wird

- **Frontend**: Keine Änderungen. TypeScript-Types sind `string`, `new Date(...)` parst aware-Strings korrekt, `toLocaleString('de-DE')` macht automatisch die TZ-Umrechnung. Keine manuellen `+ "Z"`-Hacks im Frontend gefunden, die brechen könnten.
- **Tests**: Keine Anpassungen nötig — die Suite war schon aware-konsistent.
- **`compare_type=True` in alembic.ini**: Separate Hygiene-Maßnahme; gehört nicht in diesen Scope.
- **GitHub-API-Parsing** in `github_app_service.py:127`: parst externe Strings, nicht unsere DB.

## Risiko & Rollback

**Niedrig:**
- DDL-only, kein Daten-Touch. Selber Mechanismus wie PR #146 (dort live verifiziert).
- 28 ALTERs in einer Transaktion, alle Tabellen klein → Lock im Millisekunden-Bereich.
- App-Code-`now(timezone.utc)` ist semantisch identisch zu `utcnow()` plus TZ-Info.

**Rollback:** Migration `downgrade()` castet alle 28 zurück (Storage-Typ-Wechsel ist value-preserving, die aware-vs-naive Unterscheidung geht dabei verloren — akzeptabel weil App immer aware schreibt). App-Code-Commit ist isoliert revertbar.