### PR TITLE
fix: resolve merge conflicts between staging and main

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -8,6 +8,19 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-source-branch:
+    name: Only staging can merge into main
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
+    steps:
+      - name: Check source branch
+        run: |
+          if [ "${{ github.head_ref }}" != "staging" ]; then
+            echo "PRs to main are only allowed from 'staging' branch!"
+            echo "Current branch: ${{ github.head_ref }}"
+            exit 1
+          fi
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/bruno/Template Versions/List Template Versions.bru
+++ b/bruno/Template Versions/List Template Versions.bru
@@ -25,22 +25,22 @@ vars:pre-request {
 
 docs {
   # List Template Versions
-  
+
   Lists all versions for a specific template, ordered by creation date
   (newest first). Optionally filters to active-only and inlines parameters
   parsed from `app.yaml` for each version.
-  
+
   ## Path Parameters
-  
+
   - `template_id`: UUID of the template
-  
+
   ## Query Parameters
-  
+
   - `active_only` (default `false`) — only active versions
   - `include_parameters` (default `false`) — inline `parameters` parsed from
     each version's `app.yaml`. Off by default because parsing is per-version.
-  
+
   ## Returns
-  
+
   Array of template versions.
 }


### PR DESCRIPTION
## Summary

Resolves all merge conflicts that were blocking the `staging → main` PR (#149).

### Conflicts resolved

All conflicts were between the current `staging` state (HEAD) and an older release commit (`a072cde — Release: staging → main #136`). In every case the `staging` version was kept as it contains the newer, more complete code.

| File | Resolution |
|------|-----------|
| `Dockerfile` | Keep `ENV PATH="/app/.venv/bin:$PATH"` from staging |
| `src/models/template.py` | Keep `DateTime(timezone=True)` (tz-aware) from staging |
| `src/models/template_version.py` | Keep `DateTime(timezone=True)` for `approved_at` and `created_at` |
| `src/models/user.py` | Keep `DateTime(timezone=True)` for `last_login_at` |
| `src/api/__init__.py` | Keep `openstack_flavors_router` import and registration from staging |
| `src/repositories/template_repository.py` | Keep `joinedload` + `get_by_id` override from staging |
| `src/schemas/template.py` | Keep `owner_name`/`owner_email`/`owner_username` computed fields from staging |
| `bruno/Template Versions/List Template Versions.bru` | Whitespace-only difference, kept staging formatting |

### Test plan

- [ ] No conflict markers remain in any file
- [ ] All models use `DateTime(timezone=True)` consistently
- [ ] `openstack_flavors_router` is correctly registered
- [ ] `TemplateResponse` still exposes `owner_name`, `owner_email`, `owner_username`