### PR TITLE
feat(deployments): per-group + admin SSH keys with download

### DIFF
--- a/src/_common/playbooks/base.yml
+++ b/src/_common/playbooks/base.yml
@@ -23,6 +23,14 @@
       shell: "echo '{{ teacher.linux.username }}:{{ teacher.linux.password }}' | chpasswd"
       no_log: true
 
+    - name: Lehrer SSH Admin-Key installieren
+      ansible.posix.authorized_key:
+        user:  "{{ teacher.linux.username }}"
+        key:   "{{ teacher.linux.ssh_key.public_key }}"
+        state: present
+      when: teacher.linux.ssh_key is defined and teacher.linux.ssh_key.public_key is defined
+      no_log: true
+
     # --- SSH konfigurieren ---
 
     - name: SSH Passwort-Login aktivieren

--- a/src/api/deployments.py
+++ b/src/api/deployments.py
@@ -3,7 +3,7 @@ from uuid import UUID
 import asyncio
 import json
 from fastapi import APIRouter, status, Query, Depends, HTTPException
-from fastapi.responses import StreamingResponse
+from fastapi.responses import StreamingResponse, PlainTextResponse
 from src.core.exceptions import NotFoundException
 from src.models.user import UserRole, User
 from src.core.dependencies import DBSession
@@ -25,6 +25,7 @@ from src.tasks.deploy_tasks import delete_deployment as delete_deployment_task
 from src.tasks.deploy_tasks import restart_deployment as restart_deployment_task
 from src.models.deployment import DeploymentStatus, Deployment
 from src.models.deployment_instance import DeploymentInstance
+from src.models.deployment_instance_access import DeploymentInstanceAccess
 from src.models.template_version import TemplateVersion
 
 router = APIRouter(
@@ -573,6 +574,7 @@ async def get_deployment_credentials(
                     access_type=access.access_type.value,
                     username=access.username,
                     password=access.password,
+                    ssh_private_key=access.ssh_private_key,
                     connection_url=access.connection_url,
                     port=access.port,
                 )
@@ -591,6 +593,57 @@ async def get_deployment_credentials(
         data=payload.model_dump(),
         message=f"Retrieved credentials for {len(instance_payloads)} instance(s)",
         request_id=request_id,
+    )
+
+
+@router.get(
+    "/{deployment_id}/credentials/access/{access_id}/ssh-key",
+    response_class=PlainTextResponse,
+)
+async def download_ssh_private_key(
+    deployment_id: str,
+    access_id: str,
+    db: DBSession,
+    user: CurrentUser,
+    openstack_project_id: UUID | None = Query(
+        None,
+        description="OpenStack project (local DB id) the deployment must belong to. Required for non-admin users.",
+    ),
+):
+    """Download an SSH private key as a downloadable file.
+
+    Returned as ``application/x-pem-file`` with a ``Content-Disposition``
+    attachment header so the browser saves it as ``id_ed25519`` rather than
+    rendering the PEM in-line. Accessible to the deployment owner (lecturer)
+    or any admin.
+    """
+    deployment_repo = DeploymentRepository(db)
+    deployment = deployment_repo.get_by_id(deployment_id)
+    if not deployment:
+        raise NotFoundException(f"Deployment with ID {deployment_id} not found")
+
+    authorize_deployment_access(deployment, user, openstack_project_id, db)
+
+    access = (
+        db.query(DeploymentInstanceAccess)
+        .join(DeploymentInstance, DeploymentInstance.id == DeploymentInstanceAccess.deployment_instance_id)
+        .filter(
+            DeploymentInstanceAccess.id == access_id,
+            DeploymentInstance.deployment_id == deployment_id,
+        )
+        .first()
+    )
+    if not access:
+        raise NotFoundException(f"Access entry {access_id} not found for deployment {deployment_id}")
+    if not access.ssh_private_key:
+        raise HTTPException(status_code=404, detail="No SSH private key available for this access entry")
+
+    # OpenSSH PEM contents — decrypted automatically by EncryptedString on read
+    filename = f"id_ed25519_{(access.username or 'user')}"
+    return PlainTextResponse(
+        content=access.ssh_private_key,
+        media_type="application/x-pem-file",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )
 
 

--- a/src/core/responses.py
+++ b/src/core/responses.py
@@ -1,14 +1,14 @@
 """Standardized response models for API endpoints."""
 from datetime import datetime, timezone
 from typing import Generic, TypeVar, Any
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 T = TypeVar("T")
 
 
 class APIResponse(BaseModel, Generic[T]):
     """Standard API response format."""
-    
+
     success: bool = Field(..., description="Whether the operation was successful")
     message: str | None = Field(None, description="Human-readable message")
     data: T | None = Field(None, description="Response payload")
@@ -16,17 +16,18 @@ class APIResponse(BaseModel, Generic[T]):
     timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="Response timestamp")
     request_id: str | None = Field(None, description="Unique request identifier")
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "success": True,
                 "message": "Operation successful",
                 "data": {"id": "123", "name": "Example"},
                 "errors": None,
                 "timestamp": "2024-11-27T10:00:00+00:00",
-                "request_id": "req-123-456"
+                "request_id": "req-123-456",
             }
         }
+    )
 
 
 class PaginationMeta(BaseModel):

--- a/src/core/seed_data.py
+++ b/src/core/seed_data.py
@@ -1676,7 +1676,7 @@ parameters:
 
 credentials:
 
-  per_student:
+  per_group:
     - linux:
         username: "{{ username }}"
         password: generate

--- a/src/schemas/deployment.py
+++ b/src/schemas/deployment.py
@@ -249,6 +249,11 @@ class DeploymentCredentialEntry(BaseModel):
     access_type: str = Field(..., description="Access type, e.g. ssh or database")
     username: Optional[str] = Field(None, description="Account username")
     password: Optional[str] = Field(None, description="Plaintext password (decrypted on read)")
+    ssh_private_key: Optional[str] = Field(
+        None,
+        description="Plaintext SSH private key in OpenSSH PEM format (decrypted on read). "
+                    "Present for SSH access where a keypair was generated.",
+    )
     connection_url: Optional[str] = Field(None, description="Connection URL if applicable")
     port: Optional[int] = Field(None, description="Port number if applicable")
 

--- a/src/services/credential_generator_service.py
+++ b/src/services/credential_generator_service.py
@@ -62,7 +62,7 @@ def _build_credential_entry(
         ``ssh_key: generate``   → generates an Ed25519 keypair; the field
                                   expands to ``{"private_key": ..., "public_key": ...}``.
     """
-    result = {}
+    result: dict[str, Any] = {}
     for field, value in spec.items():
         if value == "generate":
             if field == "ssh_key":

--- a/src/services/credential_generator_service.py
+++ b/src/services/credential_generator_service.py
@@ -5,6 +5,7 @@ import string
 from typing import Any
 
 from src.schemas.deployment import StackAssignment, TeacherInfo
+from src.services.ssh_keypair_generator_service import generate_ed25519_keypair
 
 
 _SPECIAL = "!@#$%^&*"
@@ -54,11 +55,20 @@ def _build_credential_entry(
     spec: dict[str, Any],
     context: dict[str, Any],
 ) -> dict[str, Any]:
-    """Build a single credential dict by resolving all field values."""
+    """Build a single credential dict by resolving all field values.
+
+    Magic markers:
+        ``password: generate``  → generates a 16-char complex password.
+        ``ssh_key: generate``   → generates an Ed25519 keypair; the field
+                                  expands to ``{"private_key": ..., "public_key": ...}``.
+    """
     result = {}
     for field, value in spec.items():
         if value == "generate":
-            result[field] = _generate_password()
+            if field == "ssh_key":
+                result[field] = generate_ed25519_keypair()
+            else:
+                result[field] = _generate_password()
         else:
             result[field] = _resolve_field(str(value), context)
     return result
@@ -77,8 +87,8 @@ class CredentialGeneratorService:
             stack_assignment=stack_assignment,
             teacher=teacher,
         )
-        # creds["students"]  → list, one entry per group
-        # creds["teacher"]   → dict
+        # creds["groups"]   → list, one entry per group
+        # creds["teacher"]  → dict
     """
 
     @staticmethod
@@ -91,19 +101,23 @@ class CredentialGeneratorService:
 
         Args:
             credentials_spec: The parsed credentials block from app.yaml.
-                              {"per_student": [...], "teacher": [...]}
+                              {"per_group": [...], "teacher": [...]}
             stack_assignment:  The stack's groups and students.
             teacher:           Teacher info from Keycloak.
 
         Returns:
             {
-              "students": [
+              "groups": [
                 {
                   "username": "gruppe01",
                   "email": "...",
                   "group_name": "Gruppe 1",
                   "group_index": 1,
-                  "linux":    {"username": "gruppe01", "password": "..."},
+                  "linux":    {
+                      "username": "gruppe01",
+                      "password": "...",                        # optional, only if app.yaml asks for it
+                      "ssh_key": {"private_key": ..., "public_key": ...},  # optional
+                  },
                   "postgres": {"db_user": "grp01", "db_name": "db_g01", "password": "..."},
                   ...
                 },
@@ -112,13 +126,17 @@ class CredentialGeneratorService:
               "teacher": {
                 "username": "prof-berg",
                 "email": "...",
-                "linux": {"username": "prof-berg", "password": "..."},  # always added
+                "linux": {
+                    "username": "prof-berg",
+                    "password": "...",                                       # always generated
+                    "ssh_key": {"private_key": ..., "public_key": ...},      # ALWAYS generated (admin key)
+                },
                 "postgres": {"db_user": "teacher", "password": "..."},
                 ...
               }
             }
         """
-        per_student_specs: list[dict] = credentials_spec.get("per_student") or []
+        per_group_specs: list[dict] = credentials_spec.get("per_group") or []
         teacher_specs: list[dict] = credentials_spec.get("teacher") or []
 
         # --- Teacher ---
@@ -133,10 +151,14 @@ class CredentialGeneratorService:
         teacher_creds: dict[str, Any] = {
             "username": teacher_username,
             "email": teacher.email,
-            # linux is always generated for the teacher so Ansible can connect
+            # linux is always generated for the teacher so Ansible can connect.
+            # The SSH key is ALWAYS generated too — it serves as the teacher's
+            # admin key, giving them direct sudo access to every VM of the
+            # deployment regardless of what the app.yaml requests.
             "linux": {
                 "username": teacher_username,
                 "password": _generate_password(),
+                "ssh_key": generate_ed25519_keypair(),
             },
         }
         for spec_item in teacher_specs:
@@ -148,15 +170,15 @@ class CredentialGeneratorService:
                 else:
                     teacher_creds[cred_type] = _build_credential_entry(fields, teacher_ctx)
 
-        # --- Students (one entry per group) ---
-        students: list[dict[str, Any]] = []
+        # --- Groups (one entry per group) ---
+        groups: list[dict[str, Any]] = []
         for group in stack_assignment.groups:
             # Use group name as the shared Linux username for the group
             group_username = _sanitize_username(group.group_name)
             # Use first student's email as group email (or generate a fallback)
             group_email = group.students[0].email if group.students else f"{group_username}@dozilab.local"
 
-            student_ctx = {
+            group_ctx = {
                 "username": group_username,
                 "email": group_email,
                 "group_name": group.group_name,
@@ -180,13 +202,13 @@ class CredentialGeneratorService:
                 ],
             }
 
-            for spec_item in per_student_specs:
+            for spec_item in per_group_specs:
                 for cred_type, fields in spec_item.items():
-                    entry[cred_type] = _build_credential_entry(fields, student_ctx)
+                    entry[cred_type] = _build_credential_entry(fields, group_ctx)
 
-            students.append(entry)
+            groups.append(entry)
 
         return {
-            "students": students,
+            "groups": groups,
             "teacher": teacher_creds,
         }

--- a/src/services/deployment_credential_service.py
+++ b/src/services/deployment_credential_service.py
@@ -40,6 +40,7 @@ class DeploymentCredentialService:
                     access_type=entry["access_type"],
                     username=entry.get("username"),
                     password=entry.get("password"),
+                    ssh_private_key=entry.get("ssh_private_key"),
                     connection_url=entry.get("connection_url"),
                     port=entry.get("port"),
                 )
@@ -65,6 +66,7 @@ class DeploymentCredentialService:
                 "access_type": AccessType.SSH,
                 "username": username,
                 "password": cred.get("password"),
+                "ssh_private_key": cred.get("ssh_private_key"),
                 "connection_url": f"ssh {username}@{floating_ip}" if username and floating_ip else None,
                 "port": 22,
             })
@@ -75,6 +77,7 @@ class DeploymentCredentialService:
                 "access_type": AccessType.SSH,
                 "username": username,
                 "password": admin.get("password"),
+                "ssh_private_key": admin.get("ssh_private_key"),
                 "connection_url": f"ssh {username}@{floating_ip}" if username and floating_ip else None,
                 "port": 22,
             })
@@ -105,4 +108,4 @@ class DeploymentCredentialService:
                     "port": 80 if is_pgadmin else None,
                 })
 
-        return [e for e in entries if e.get("password")]
+        return [e for e in entries if e.get("password") or e.get("ssh_private_key")]

--- a/src/services/secret_encryption_service.py
+++ b/src/services/secret_encryption_service.py
@@ -90,34 +90,36 @@ def get_encryption_service(key: Optional[str] = None) -> SecretEncryptionService
 
 class EncryptedString(TypeDecorator):
     """SQLAlchemy type that automatically encrypts/decrypts string values.
-    
+
     Usage:
         password: Mapped[str] = mapped_column(EncryptedString(255))
-    
+
     IMPORTANT: Never log the decrypted value.
+
+    Behavior on misconfiguration: if ``ENCRYPTION_KEY`` is missing or invalid,
+    both directions raise ``SecretEncryptionError`` — we never silently store
+    or return plaintext. Treat ``ENCRYPTION_KEY`` as a hard runtime requirement.
     """
     impl = String
     cache_ok = True
 
     def process_bind_param(self, value: Optional[str], dialect: Any) -> Optional[str]:
-        """Encrypt value before storing in database."""
+        """Encrypt value before storing in database.
+
+        Raises ``SecretEncryptionError`` if encryption is not configured —
+        better to fail the write than to persist a plaintext secret unnoticed.
+        """
         if value is None:
             return None
-        try:
-            service = get_encryption_service()
-            return service.encrypt(value)
-        except SecretEncryptionError:
-            # If encryption not configured, store as-is (for development only)
-            # In production, this should raise an error
-            return value
+        return get_encryption_service().encrypt(value)
 
     def process_result_value(self, value: Optional[str], dialect: Any) -> Optional[str]:
-        """Decrypt value when loading from database."""
+        """Decrypt value when loading from database.
+
+        Raises ``SecretEncryptionError`` if decryption fails (missing key,
+        wrong key, or corrupted token). The caller should not see a
+        possibly-encrypted blob masquerading as plaintext.
+        """
         if value is None:
             return None
-        try:
-            service = get_encryption_service()
-            return service.decrypt(value)
-        except SecretEncryptionError:
-            # If decryption fails, return encrypted value (backward compatibility)
-            return value
+        return get_encryption_service().decrypt(value)

--- a/src/services/ssh_keypair_generator_service.py
+++ b/src/services/ssh_keypair_generator_service.py
@@ -1,0 +1,48 @@
+"""Generate Ed25519 SSH keypairs for deployment credentials.
+
+Used by the credential generator to produce per-group and per-teacher SSH keys
+that get injected into the VM's ``authorized_keys`` via Ansible. Private keys
+are returned in OpenSSH PEM format so users can save them as standard
+``~/.ssh/id_ed25519`` files; public keys are returned in the single-line
+OpenSSH format expected by ``authorized_keys`` (and by Ansible's
+``ansible.posix.authorized_key`` module).
+
+Ed25519 is the default: shorter than RSA (one-line public key, ~400 byte
+private key), well-supported on every modern SSH client/server, and
+considered the current best practice.
+"""
+from __future__ import annotations
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+
+def generate_ed25519_keypair() -> dict[str, str]:
+    """Generate a fresh Ed25519 keypair.
+
+    Returns:
+        ``{"private_key": "-----BEGIN OPENSSH PRIVATE KEY-----\\n...",
+          "public_key":  "ssh-ed25519 AAAA..."}``
+
+        ``private_key`` is in OpenSSH PEM format (unencrypted) — ready to be
+        saved as ``~/.ssh/id_ed25519``.
+        ``public_key`` is in single-line OpenSSH format — ready to be appended
+        to ``~/.ssh/authorized_keys``.
+    """
+    private_key = Ed25519PrivateKey.generate()
+
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.OpenSSH,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+
+    public_openssh = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.OpenSSH,
+        format=serialization.PublicFormat.OpenSSH,
+    ).decode("utf-8")
+
+    return {
+        "private_key": private_pem,
+        "public_key": public_openssh,
+    }

--- a/src/tasks/deploy_tasks.py
+++ b/src/tasks/deploy_tasks.py
@@ -101,7 +101,7 @@ def deploy_stack(self, deployment_id: str) -> dict:
 
         # Parse app.yaml for credentials spec and playbook list
         app_yaml_file = next((f for f in files if f.file_name == "app.yaml"), None)
-        credentials_spec: dict[str, list] = {"per_student": [], "teacher": []}
+        credentials_spec: dict[str, list] = {"per_group": [], "teacher": []}
         playbooks: list[tuple[str, str]] = []
         scripts: dict[str, str] = {}
         template_files: dict[str, str] = {}
@@ -223,13 +223,15 @@ def deploy_stack(self, deployment_id: str) -> dict:
                                 {
                                     "username": s["linux"]["username"],
                                     "password": s["linux"]["password"],
+                                    "ssh_private_key": (s.get("linux", {}).get("ssh_key") or {}).get("private_key"),
                                 }
-                                for s in generated.get("students", [])
+                                for s in generated.get("groups", [])
                                 if s.get("linux", {}).get("password")
                             ],
                             "admin_credentials": {
                                 "username": generated["teacher"]["linux"]["username"],
                                 "password": generated["teacher"]["linux"]["password"],
+                                "ssh_private_key": (generated["teacher"]["linux"].get("ssh_key") or {}).get("private_key"),
                             } if generated.get("teacher", {}).get("linux", {}).get("password") else None,
                         },
                     }
@@ -279,7 +281,7 @@ def deploy_stack(self, deployment_id: str) -> dict:
                             "stack_label": stack_name,
                             "ssh_allow_users": [
                                 s["linux"]["username"]
-                                for s in generated.get("students", [])
+                                for s in generated.get("groups", [])
                                 if s.get("linux", {}).get("password")
                             ],
                         }

--- a/src/utils/app_manifest_parser.py
+++ b/src/utils/app_manifest_parser.py
@@ -99,7 +99,7 @@ class AppManifestParser:
             # Credentials
             credentials_raw = data.get("credentials") or {}
             credentials = {
-                "per_student": credentials_raw.get("per_student") or [],
+                "per_group": credentials_raw.get("per_group") or [],
                 "teacher": credentials_raw.get("teacher") or [],
             }
 
@@ -149,9 +149,9 @@ class AppManifestParser:
     def extract_credentials(content: str) -> dict:
         """Return the credentials block or empty structure on failure."""
         try:
-            return AppManifestParser.parse(content).get("credentials", {"per_student": [], "teacher": []})
+            return AppManifestParser.parse(content).get("credentials", {"per_group": [], "teacher": []})
         except Exception:
-            return {"per_student": [], "teacher": []}
+            return {"per_group": [], "teacher": []}
 
     @staticmethod
     def extract_user_files(content: str) -> list[dict]:

--- a/tests/api/test_deployment_credentials_routes.py
+++ b/tests/api/test_deployment_credentials_routes.py
@@ -1,0 +1,386 @@
+"""Integration tests for the deployment credentials endpoints.
+
+Covers:
+- ``GET /deployments/{id}/credentials`` returns ``ssh_private_key`` in the JSON.
+- ``GET /deployments/{id}/credentials/access/{access_id}/ssh-key`` returns the
+  decrypted PEM with the right headers (download flow used by the frontend).
+"""
+from unittest.mock import patch, MagicMock
+
+from fastapi.testclient import TestClient
+
+from src.main import app
+from src.core.dependencies import get_current_user, get_db
+from src.models.user import UserRole
+
+
+# Same fixed-UUID pattern the rest of tests/api/ uses.
+TEST_OS_PROJECT_ID = "11111111-1111-1111-1111-111111111111"
+
+_SAMPLE_PEM = (
+    "-----BEGIN OPENSSH PRIVATE KEY-----\n"
+    "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZWQy\n"
+    "NTUxOQAAACBJYWWFAKEKEYZ0123456789AAAAAAAAAAAAAAAAAAAAA==\n"
+    "-----END OPENSSH PRIVATE KEY-----\n"
+)
+
+
+def _mock_lecturer():
+    return {
+        "sub": "lecturer-123",
+        "email": "lecturer@example.com",
+        "preferred_username": "lecturer",
+        "roles": [UserRole.LECTURER.value],
+        "user_id": 1,
+    }
+
+
+def _mock_admin():
+    return {
+        "sub": "admin-123",
+        "email": "admin@example.com",
+        "preferred_username": "admin",
+        "roles": [UserRole.ADMIN.value],
+        "user_id": 2,
+    }
+
+
+def _patched_openstack_repo(owner_user_id: int = 1):
+    """Tell ``authorize_deployment_access`` that TEST_OS_PROJECT_ID belongs to the user."""
+    proj = MagicMock()
+    proj.id = TEST_OS_PROJECT_ID
+    proj.owner_user_id = owner_user_id
+    repo = MagicMock()
+    repo.get_by_id.return_value = proj
+    return patch("src.api.deployments.OpenstackProjectRepository", return_value=repo)
+
+
+def _build_deployment(*, deployment_id="deploy-1"):
+    """Minimal Deployment mock that passes authorize_deployment_access for the lecturer."""
+    d = MagicMock()
+    d.id = deployment_id
+    d.openstack_project_id = TEST_OS_PROJECT_ID
+    # authorize_deployment_access reads teacher.id and looks the User row up by sub.
+    d.deployment_parameters = '{"teacher": {"id": "lecturer-123"}}'
+    return d
+
+
+def _build_access(
+    *,
+    access_id="access-abc",
+    username="gruppe-1",
+    ssh_private_key=_SAMPLE_PEM,
+    password="P@ssw0rd-1234567",
+):
+    """Mirror of a DeploymentInstanceAccess row (post-decryption)."""
+    access = MagicMock()
+    access.id = access_id
+    access.username = username
+    access.password = password
+    access.ssh_private_key = ssh_private_key
+    access.connection_url = f"ssh {username}@1.2.3.4"
+    access.port = 22
+    access.access_type = MagicMock()
+    access.access_type.value = "ssh"
+    return access
+
+
+client = TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# GET /credentials — JSON response now includes ssh_private_key
+# ---------------------------------------------------------------------------
+
+
+@patch("src.api.deployments.DeploymentRepository")
+def test_get_credentials_includes_ssh_private_key(mock_repo_class):
+    """The full credentials response surfaces the decrypted SSH key alongside the password."""
+    app.dependency_overrides[get_current_user] = _mock_lecturer
+
+    deployment = _build_deployment()
+    mock_repo = MagicMock()
+    mock_repo.get_by_id.return_value = deployment
+    mock_repo_class.return_value = mock_repo
+
+    access = _build_access()
+    instance = MagicMock()
+    instance.id = "instance-1"
+    instance.vm_name = "vm-1"
+    instance.openstack_server_id = "stack-1"
+    instance.access_methods = [access]
+
+    db = MagicMock()
+    user_row = MagicMock()
+    user_row.id = 1  # matches _mock_lecturer's user_id → owner check passes
+    db.query.return_value.filter.return_value.first.return_value = user_row
+    # The endpoint also runs a separate query for DeploymentInstance — return our list.
+    db.query.return_value.filter.return_value.all.return_value = [instance]
+    app.dependency_overrides[get_db] = lambda: db
+
+    with _patched_openstack_repo(owner_user_id=1):
+        response = client.get(
+            "/api/v1/deployments/deploy-1/credentials"
+            f"?openstack_project_id={TEST_OS_PROJECT_ID}"
+        )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()["data"]
+    assert len(payload["instances"]) == 1
+    entry = payload["instances"][0]["accesses"][0]
+    assert entry["ssh_private_key"] == _SAMPLE_PEM
+    assert entry["password"] == "P@ssw0rd-1234567"
+
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# GET /credentials/access/{id}/ssh-key — download endpoint
+# ---------------------------------------------------------------------------
+
+
+@patch("src.api.deployments.DeploymentRepository")
+def test_download_ssh_key_returns_pem_with_attachment_header(mock_repo_class):
+    """Happy path: PEM body, correct media type, attachment filename includes username."""
+    app.dependency_overrides[get_current_user] = _mock_lecturer
+
+    deployment = _build_deployment()
+    mock_repo = MagicMock()
+    mock_repo.get_by_id.return_value = deployment
+    mock_repo_class.return_value = mock_repo
+
+    access = _build_access(access_id="acc-1", username="gruppe-1")
+    db = MagicMock()
+    user_row = MagicMock()
+    user_row.id = 1
+    db.query.return_value.filter.return_value.first.return_value = user_row
+    # The endpoint's access lookup chains .join().filter().first() — keep the
+    # call chain alive by routing everything back to the same MagicMock and
+    # making .first() the access row at the end.
+    access_query = MagicMock()
+    access_query.join.return_value.filter.return_value.first.return_value = access
+    # First .query() call is for User, second for DeploymentInstanceAccess.
+    db.query.side_effect = [db.query.return_value, access_query]
+    app.dependency_overrides[get_db] = lambda: db
+
+    with _patched_openstack_repo(owner_user_id=1):
+        response = client.get(
+            "/api/v1/deployments/deploy-1/credentials/access/acc-1/ssh-key"
+            f"?openstack_project_id={TEST_OS_PROJECT_ID}"
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.text == _SAMPLE_PEM
+    assert response.headers["content-type"].startswith("application/x-pem-file")
+    assert 'attachment; filename="id_ed25519_gruppe-1"' in response.headers["content-disposition"]
+
+    app.dependency_overrides.clear()
+
+
+@patch("src.api.deployments.DeploymentRepository")
+def test_download_ssh_key_404_when_access_has_no_key(mock_repo_class):
+    """An access row that exists but has no key returns 404, not a 200 with empty body."""
+    app.dependency_overrides[get_current_user] = _mock_lecturer
+
+    deployment = _build_deployment()
+    mock_repo = MagicMock()
+    mock_repo.get_by_id.return_value = deployment
+    mock_repo_class.return_value = mock_repo
+
+    access = _build_access(ssh_private_key=None)
+    db = MagicMock()
+    user_row = MagicMock()
+    user_row.id = 1
+    db.query.return_value.filter.return_value.first.return_value = user_row
+    access_query = MagicMock()
+    access_query.join.return_value.filter.return_value.first.return_value = access
+    db.query.side_effect = [db.query.return_value, access_query]
+    app.dependency_overrides[get_db] = lambda: db
+
+    with _patched_openstack_repo(owner_user_id=1):
+        response = client.get(
+            "/api/v1/deployments/deploy-1/credentials/access/acc-1/ssh-key"
+            f"?openstack_project_id={TEST_OS_PROJECT_ID}"
+        )
+
+    assert response.status_code == 404
+    assert "No SSH private key" in response.text
+
+    app.dependency_overrides.clear()
+
+
+@patch("src.api.deployments.DeploymentRepository")
+def test_download_ssh_key_404_when_access_id_unknown(mock_repo_class):
+    """Unknown access_id returns 404 even if the deployment itself exists."""
+    app.dependency_overrides[get_current_user] = _mock_lecturer
+
+    deployment = _build_deployment()
+    mock_repo = MagicMock()
+    mock_repo.get_by_id.return_value = deployment
+    mock_repo_class.return_value = mock_repo
+
+    db = MagicMock()
+    user_row = MagicMock()
+    user_row.id = 1
+    db.query.return_value.filter.return_value.first.return_value = user_row
+    access_query = MagicMock()
+    access_query.join.return_value.filter.return_value.first.return_value = None
+    db.query.side_effect = [db.query.return_value, access_query]
+    app.dependency_overrides[get_db] = lambda: db
+
+    with _patched_openstack_repo(owner_user_id=1):
+        response = client.get(
+            "/api/v1/deployments/deploy-1/credentials/access/missing/ssh-key"
+            f"?openstack_project_id={TEST_OS_PROJECT_ID}"
+        )
+
+    assert response.status_code == 404
+
+    app.dependency_overrides.clear()
+
+
+@patch("src.api.deployments.DeploymentRepository")
+def test_download_ssh_key_404_when_deployment_missing(mock_repo_class):
+    """Unknown deployment returns 404 before any access lookup."""
+    app.dependency_overrides[get_current_user] = _mock_lecturer
+
+    mock_repo = MagicMock()
+    mock_repo.get_by_id.return_value = None
+    mock_repo_class.return_value = mock_repo
+
+    app.dependency_overrides[get_db] = lambda: MagicMock()
+
+    response = client.get(
+        "/api/v1/deployments/does-not-exist/credentials/access/whatever/ssh-key"
+        f"?openstack_project_id={TEST_OS_PROJECT_ID}"
+    )
+
+    assert response.status_code == 404
+
+    app.dependency_overrides.clear()
+
+
+@patch("src.api.deployments.DeploymentRepository")
+def test_download_ssh_key_admin_can_download_any_deployments_key(mock_repo_class):
+    """ADMINs bypass the lecturer-ownership check (matches the existing pattern)."""
+    app.dependency_overrides[get_current_user] = _mock_admin
+
+    # Deployment owned by someone else — admin can still access.
+    deployment = _build_deployment()
+    deployment.deployment_parameters = '{"teacher": {"id": "someone-else-999"}}'
+    mock_repo = MagicMock()
+    mock_repo.get_by_id.return_value = deployment
+    mock_repo_class.return_value = mock_repo
+
+    access = _build_access(username="prof-berg")
+    db = MagicMock()
+    # Admin path skips the User-ownership lookup entirely; only the access query runs.
+    db.query.return_value.join.return_value.filter.return_value.first.return_value = access
+    app.dependency_overrides[get_db] = lambda: db
+
+    response = client.get(
+        "/api/v1/deployments/deploy-1/credentials/access/acc-1/ssh-key"
+    )
+
+    assert response.status_code == 200
+    assert 'filename="id_ed25519_prof-berg"' in response.headers["content-disposition"]
+
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Ownership enforcement — the crown jewel: no lecturer steals another's keys
+# ---------------------------------------------------------------------------
+
+
+@patch("src.api.deployments.DeploymentRepository")
+def test_download_ssh_key_forbidden_for_non_owning_lecturer(mock_repo_class):
+    """A lecturer who is NOT the deployment owner gets 403, not the PEM.
+
+    This is the security-critical case: lecturers must only access their own
+    deployments. Without this guard, any lecturer with the deployment_id and
+    access_id could download another lecturer's admin/group keys.
+    """
+    app.dependency_overrides[get_current_user] = _mock_lecturer  # user_id=1
+
+    # Deployment is owned by a DIFFERENT teacher (keycloak id "someone-else").
+    deployment = _build_deployment()
+    deployment.deployment_parameters = '{"teacher": {"id": "someone-else-keycloak-id"}}'
+    mock_repo = MagicMock()
+    mock_repo.get_by_id.return_value = deployment
+    mock_repo_class.return_value = mock_repo
+
+    # get_deployment_owner_id resolves the keycloak id to a User row with id=42 — not us.
+    other_owner = MagicMock()
+    other_owner.id = 42
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = other_owner
+    app.dependency_overrides[get_db] = lambda: db
+
+    with _patched_openstack_repo(owner_user_id=1):
+        response = client.get(
+            "/api/v1/deployments/deploy-1/credentials/access/acc-1/ssh-key"
+            f"?openstack_project_id={TEST_OS_PROJECT_ID}"
+        )
+
+    assert response.status_code == 403
+    # And critically: no PEM in the body, no Content-Disposition attachment header.
+    assert "BEGIN OPENSSH PRIVATE KEY" not in response.text
+    assert "content-disposition" not in {k.lower() for k in response.headers}
+
+    app.dependency_overrides.clear()
+
+
+@patch("src.api.deployments.DeploymentRepository")
+def test_download_ssh_key_forbidden_when_project_id_mismatches(mock_repo_class):
+    """Even the owning lecturer is rejected if the deployment lives in a different project.
+
+    Guards against a scoped-project mix-up: passing the wrong openstack_project_id
+    must fail closed instead of returning data tied to a different project.
+    """
+    app.dependency_overrides[get_current_user] = _mock_lecturer
+
+    deployment = _build_deployment()
+    # Different project than the one the caller passes in the query string.
+    deployment.openstack_project_id = "99999999-9999-9999-9999-999999999999"
+    mock_repo = MagicMock()
+    mock_repo.get_by_id.return_value = deployment
+    mock_repo_class.return_value = mock_repo
+
+    db = MagicMock()
+    owner = MagicMock()
+    owner.id = 1
+    db.query.return_value.filter.return_value.first.return_value = owner
+    app.dependency_overrides[get_db] = lambda: db
+
+    with _patched_openstack_repo(owner_user_id=1):
+        response = client.get(
+            "/api/v1/deployments/deploy-1/credentials/access/acc-1/ssh-key"
+            f"?openstack_project_id={TEST_OS_PROJECT_ID}"
+        )
+
+    assert response.status_code == 403
+
+    app.dependency_overrides.clear()
+
+
+@patch("src.api.deployments.DeploymentRepository")
+def test_download_ssh_key_400_without_openstack_project_id(mock_repo_class):
+    """Non-admin caller must supply openstack_project_id — else 400 (defence in depth)."""
+    app.dependency_overrides[get_current_user] = _mock_lecturer
+
+    deployment = _build_deployment()
+    mock_repo = MagicMock()
+    mock_repo.get_by_id.return_value = deployment
+    mock_repo_class.return_value = mock_repo
+
+    app.dependency_overrides[get_db] = lambda: MagicMock()
+
+    # No openstack_project_id query param!
+    response = client.get(
+        "/api/v1/deployments/deploy-1/credentials/access/acc-1/ssh-key"
+    )
+
+    assert response.status_code == 400
+
+    app.dependency_overrides.clear()

--- a/tests/unit/test_credential_generator_service.py
+++ b/tests/unit/test_credential_generator_service.py
@@ -1,0 +1,147 @@
+"""Tests for CredentialGeneratorService.
+
+Covers the new ``per_group`` schema (replacing ``per_student``) and the new
+``ssh_key: generate`` magic marker that produces an Ed25519 keypair, plus the
+always-on admin SSH key for the teacher.
+"""
+from src.schemas.deployment import GroupInfo, StackAssignment, StudentInfo, TeacherInfo
+from src.services.credential_generator_service import CredentialGeneratorService
+
+
+def _teacher():
+    return TeacherInfo(
+        id="t-1",
+        username="prof.berg",
+        email="prof@uni.de",
+        first_name="Petra",
+        last_name="Berg",
+    )
+
+
+def _stack_with_groups(*, count: int = 1):
+    groups = [
+        GroupInfo(
+            group_name=f"Gruppe {i}",
+            group_index=i,
+            students=[
+                StudentInfo(
+                    id=f"s-{i}",
+                    username=f"stud{i}",
+                    email=f"stud{i}@uni.de",
+                    first_name="Stud",
+                    last_name=str(i),
+                ),
+            ],
+        )
+        for i in range(1, count + 1)
+    ]
+    return StackAssignment(stack_index=1, groups=groups)
+
+
+def test_teacher_always_gets_admin_ssh_key_even_with_empty_spec():
+    """Admin SSH key is auto-generated for the teacher — no app.yaml entry needed."""
+    creds = CredentialGeneratorService.generate(
+        credentials_spec={"per_group": [], "teacher": []},
+        stack_assignment=_stack_with_groups(count=0),
+        teacher=_teacher(),
+    )
+
+    assert "ssh_key" in creds["teacher"]["linux"]
+    assert creds["teacher"]["linux"]["ssh_key"]["private_key"].startswith(
+        "-----BEGIN OPENSSH PRIVATE KEY-----"
+    )
+    assert creds["teacher"]["linux"]["ssh_key"]["public_key"].startswith("ssh-ed25519 ")
+    # Password is still auto-generated alongside the key (both auth methods).
+    assert creds["teacher"]["linux"]["password"]
+
+
+def test_per_group_replaces_per_student():
+    """``per_group`` is the spec key (not ``per_student``); output key is ``groups``."""
+    creds = CredentialGeneratorService.generate(
+        credentials_spec={
+            "per_group": [{"linux": {"username": "{{ username }}", "password": "generate"}}],
+            "teacher": [],
+        },
+        stack_assignment=_stack_with_groups(count=2),
+        teacher=_teacher(),
+    )
+
+    assert "groups" in creds
+    assert "students" not in creds  # hard cut — old key must not leak through
+    assert len(creds["groups"]) == 2
+    for entry in creds["groups"]:
+        assert entry["linux"]["password"]
+        assert entry["linux"]["username"] == entry["username"]
+
+
+def test_per_group_ssh_key_generate_produces_keypair():
+    """``ssh_key: generate`` expands to a dict with private + public keys."""
+    creds = CredentialGeneratorService.generate(
+        credentials_spec={
+            "per_group": [{
+                "linux": {
+                    "username": "{{ username }}",
+                    "password": "generate",
+                    "ssh_key": "generate",
+                },
+            }],
+            "teacher": [],
+        },
+        stack_assignment=_stack_with_groups(count=2),
+        teacher=_teacher(),
+    )
+
+    for entry in creds["groups"]:
+        kp = entry["linux"]["ssh_key"]
+        assert isinstance(kp, dict)
+        assert kp["private_key"].startswith("-----BEGIN OPENSSH PRIVATE KEY-----")
+        assert kp["public_key"].startswith("ssh-ed25519 ")
+
+
+def test_per_group_without_ssh_key_marker_omits_keypair():
+    """No ``ssh_key`` in app.yaml → no keypair generated for groups."""
+    creds = CredentialGeneratorService.generate(
+        credentials_spec={
+            "per_group": [{"linux": {"username": "{{ username }}", "password": "generate"}}],
+            "teacher": [],
+        },
+        stack_assignment=_stack_with_groups(count=1),
+        teacher=_teacher(),
+    )
+
+    assert "ssh_key" not in creds["groups"][0]["linux"]
+
+
+def test_each_group_gets_a_distinct_keypair():
+    """Different groups must receive different keys — never share private material."""
+    creds = CredentialGeneratorService.generate(
+        credentials_spec={
+            "per_group": [{
+                "linux": {"username": "{{ username }}", "ssh_key": "generate"},
+            }],
+            "teacher": [],
+        },
+        stack_assignment=_stack_with_groups(count=3),
+        teacher=_teacher(),
+    )
+
+    private_keys = [g["linux"]["ssh_key"]["private_key"] for g in creds["groups"]]
+    assert len(set(private_keys)) == len(private_keys)
+
+
+def test_teacher_spec_can_override_auto_generated_ssh_key():
+    """If the teacher spec explicitly includes ``ssh_key: generate`` it merges into linux,
+    re-rolling the key — the merge logic must not duplicate or break the dict."""
+    creds = CredentialGeneratorService.generate(
+        credentials_spec={
+            "per_group": [],
+            "teacher": [{"linux": {"ssh_key": "generate"}}],
+        },
+        stack_assignment=_stack_with_groups(count=0),
+        teacher=_teacher(),
+    )
+
+    # Still a valid keypair dict regardless of override path
+    kp = creds["teacher"]["linux"]["ssh_key"]
+    assert kp["private_key"].startswith("-----BEGIN OPENSSH PRIVATE KEY-----")
+    assert kp["public_key"].startswith("ssh-ed25519 ")

--- a/tests/unit/test_deployment_credential_service.py
+++ b/tests/unit/test_deployment_credential_service.py
@@ -70,6 +70,69 @@ def test_skips_entries_without_password():
     assert DeploymentCredentialService._extract_access_entries(user_json) == []
 
 
+def test_extracts_ssh_private_keys_for_group_and_admin():
+    """SSH private keys flow through both per-group credentials and admin_credentials."""
+    user_json = {
+        "instance": {
+            "credentials": [
+                {
+                    "username": "gruppe-1",
+                    "password": "Grp1-azure-tiger-42",
+                    "ssh_private_key": "-----BEGIN OPENSSH PRIVATE KEY-----\nGROUP1KEY\n-----END OPENSSH PRIVATE KEY-----",
+                },
+            ],
+            "admin_credentials": {
+                "username": "prof-berg",
+                "password": "Teacher-witty-cedar-58",
+                "ssh_private_key": "-----BEGIN OPENSSH PRIVATE KEY-----\nADMINKEY\n-----END OPENSSH PRIVATE KEY-----",
+            },
+        },
+        "applications": [],
+    }
+
+    rows = DeploymentCredentialService._extract_access_entries(user_json)
+
+    assert len(rows) == 2
+    assert "GROUP1KEY" in rows[0]["ssh_private_key"]
+    assert "ADMINKEY" in rows[1]["ssh_private_key"]
+
+
+def test_keeps_entries_with_only_ssh_private_key_no_password():
+    """Key-only auth (no password) must still produce a row — filter is OR, not AND."""
+    user_json = {
+        "instance": {
+            "credentials": [
+                {
+                    "username": "key-only",
+                    "password": None,
+                    "ssh_private_key": "-----BEGIN OPENSSH PRIVATE KEY-----\nKEYONLY\n-----END OPENSSH PRIVATE KEY-----",
+                },
+            ],
+        },
+        "applications": [],
+    }
+
+    rows = DeploymentCredentialService._extract_access_entries(user_json)
+
+    assert len(rows) == 1
+    assert rows[0]["username"] == "key-only"
+    assert rows[0]["password"] is None
+    assert "KEYONLY" in rows[0]["ssh_private_key"]
+
+
+def test_extract_handles_missing_ssh_private_key_field():
+    """Legacy / password-only payloads (no ssh_private_key field) still work."""
+    user_json = {
+        "instance": {
+            "credentials": [{"username": "legacy", "password": "Pw-abc-123"}],
+        },
+        "applications": [],
+    }
+    rows = DeploymentCredentialService._extract_access_entries(user_json)
+    assert len(rows) == 1
+    assert rows[0]["ssh_private_key"] is None
+
+
 def _instance_added_to(db_mock):
     """Return the DeploymentInstance that the service handed to db.add()."""
     from src.models.deployment_instance import DeploymentInstance

--- a/tests/unit/test_secret_encryption.py
+++ b/tests/unit/test_secret_encryption.py
@@ -1,5 +1,11 @@
 """Tests for SecretEncryptionService and EncryptedString TypeDecorator."""
-from src.services.secret_encryption_service import get_encryption_service, EncryptedString
+import pytest
+
+from src.services.secret_encryption_service import (
+    EncryptedString,
+    SecretEncryptionError,
+    get_encryption_service,
+)
 from cryptography.fernet import Fernet
 from sqlalchemy import create_engine, String, text
 from sqlalchemy.orm import Session, DeclarativeBase, Mapped, mapped_column
@@ -21,32 +27,32 @@ def test_encrypted_string_type_decorator():
     # Create test model
     class Base(DeclarativeBase):
         pass
-    
+
     class TestModel(Base):
         __tablename__ = "test_secrets"
         id: Mapped[int] = mapped_column(primary_key=True)
         secret_value: Mapped[str] = mapped_column(EncryptedString(255))
         plain_value: Mapped[str] = mapped_column(String(255))
-    
+
     # Setup encryption
     key = Fernet.generate_key().decode()
     get_encryption_service(key=key)
-    
+
     # Create in-memory database
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
-    
+
     # Test write and read
     with Session(engine) as session:
         obj = TestModel(secret_value="my-secret-password", plain_value="not-secret")
         session.add(obj)
         session.commit()
         session.refresh(obj)
-        
+
         # Verify we can read decrypted value
         assert obj.secret_value == "my-secret-password"
         assert obj.plain_value == "not-secret"
-    
+
     # Verify encrypted value is actually encrypted in database
     with Session(engine) as session:
         result = session.execute(text("SELECT secret_value FROM test_secrets WHERE id = 1"))
@@ -55,3 +61,43 @@ def test_encrypted_string_type_decorator():
         assert encrypted_value != "my-secret-password"
         # Should start with gAAAAA (Fernet token prefix)
         assert encrypted_value.startswith("gAAAAA")
+
+
+def test_encrypted_string_raises_when_encryption_misconfigured(monkeypatch):
+    """Writing/reading an EncryptedString without a configured key must fail loudly.
+
+    Silently storing plaintext or returning ciphertext masquerading as
+    plaintext would be a security bug — the type decorator now propagates
+    ``SecretEncryptionError`` in both directions.
+    """
+    import src.services.secret_encryption_service as svc_mod
+
+    # Force the singleton to be re-created without a valid key
+    monkeypatch.setattr(svc_mod, "_encryption_service_instance", None)
+
+    # Pretend ENCRYPTION_KEY is unset for the duration of this test
+    from src.core.config import get_settings
+    settings = get_settings()
+    monkeypatch.setattr(settings, "encryption_key", None)
+
+    decorator = EncryptedString()
+
+    with pytest.raises(SecretEncryptionError):
+        decorator.process_bind_param("plaintext-secret", dialect=None)
+
+    with pytest.raises(SecretEncryptionError):
+        decorator.process_result_value("gAAAAAfake-token", dialect=None)
+
+
+def test_encrypted_string_raises_on_invalid_token(monkeypatch):
+    """A garbage value in the column raises rather than returning it as plaintext."""
+    # Ensure a valid key is configured first
+    import src.services.secret_encryption_service as svc_mod
+    monkeypatch.setattr(svc_mod, "_encryption_service_instance", None)
+    get_encryption_service(key=Fernet.generate_key().decode())
+
+    decorator = EncryptedString()
+
+    with pytest.raises(SecretEncryptionError):
+        # Not a valid Fernet token — must NOT be silently returned
+        decorator.process_result_value("not-a-real-token", dialect=None)

--- a/tests/unit/test_ssh_keypair_generator_service.py
+++ b/tests/unit/test_ssh_keypair_generator_service.py
@@ -1,0 +1,66 @@
+"""Tests for the Ed25519 SSH keypair generator."""
+import re
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
+from cryptography.hazmat.primitives.serialization import (
+    load_ssh_private_key,
+    load_ssh_public_key,
+)
+
+from src.services.ssh_keypair_generator_service import generate_ed25519_keypair
+
+
+def test_generate_returns_private_and_public_keys():
+    """Generator returns both keys with the expected dict shape."""
+    kp = generate_ed25519_keypair()
+    assert set(kp.keys()) == {"private_key", "public_key"}
+    assert isinstance(kp["private_key"], str)
+    assert isinstance(kp["public_key"], str)
+
+
+def test_private_key_is_openssh_pem():
+    """Private key must be in OpenSSH PEM format (the format ssh-keygen produces)."""
+    kp = generate_ed25519_keypair()
+    pem = kp["private_key"]
+    assert pem.startswith("-----BEGIN OPENSSH PRIVATE KEY-----")
+    assert pem.rstrip().endswith("-----END OPENSSH PRIVATE KEY-----")
+    # Must be parseable as an Ed25519 private key
+    parsed = load_ssh_private_key(pem.encode(), password=None)
+    assert isinstance(parsed, Ed25519PrivateKey)
+
+
+def test_public_key_is_single_line_openssh():
+    """Public key must be in the single-line OpenSSH format used in authorized_keys."""
+    kp = generate_ed25519_keypair()
+    pub = kp["public_key"]
+    # Single-line format: "ssh-ed25519 <base64-blob>"
+    assert "\n" not in pub.strip()
+    assert pub.startswith("ssh-ed25519 ")
+    assert re.match(r"^ssh-ed25519 [A-Za-z0-9+/=]+", pub)
+    # Must be parseable as an Ed25519 public key
+    parsed = load_ssh_public_key(pub.encode())
+    assert isinstance(parsed, Ed25519PublicKey)
+
+
+def test_each_call_produces_a_fresh_keypair():
+    """Successive calls must not return the same key — entropy check."""
+    kp1 = generate_ed25519_keypair()
+    kp2 = generate_ed25519_keypair()
+    assert kp1["private_key"] != kp2["private_key"]
+    assert kp1["public_key"] != kp2["public_key"]
+
+
+def test_public_key_matches_private_key():
+    """The public key in the dict must be the actual public key of the private key."""
+    kp = generate_ed25519_keypair()
+
+    priv = load_ssh_private_key(kp["private_key"].encode(), password=None)
+    derived_pub = priv.public_key()
+    parsed_pub = load_ssh_public_key(kp["public_key"].encode())
+
+    # Compare raw public bytes — equality on the key objects themselves doesn't always hold.
+    from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+    assert (
+        derived_pub.public_bytes(Encoding.Raw, PublicFormat.Raw)
+        == parsed_pub.public_bytes(Encoding.Raw, PublicFormat.Raw)
+    )


### PR DESCRIPTION
- Generate Ed25519 keypairs per group (opt-in via app.yaml ssh_key: generate) and always for the teacher as admin SSH key
- Rename per_student -> per_group in app.yaml credentials schema (hard cut); generator output key students -> groups
- Persist ssh_private_key in deployment_instance_access (Fernet-encrypted via existing EncryptedString TypeDecorator; reuses the column already in DB)
- Install teacher admin public key into authorized_keys via base.yml playbook (ansible.posix.authorized_key)
- Expose ssh_private_key in GET /deployments/{id}/credentials response
- Add GET /deployments/{id}/credentials/access/{access_id}/ssh-key download endpoint returning application/x-pem-file with Content-Disposition attachment
- Make EncryptedString fail loudly on misconfig instead of silently storing plaintext / returning ciphertext as plaintext
- Migrate APIResponse to ConfigDict (Pydantic V2 deprecation cleanup)

Tests: +20 unit/api tests covering keypair generation, credential generator with new schema, persistence + decryption, ownership/project-scope enforcement (including 403 for non-owning lecturers), and admin bypass.