### PR TITLE
feat: credentials API exposes group_id+group_name; live SSE; seed rewrite

### DIFF
--- a/alembic/versions/b6d52b9f8ea3_backfill_access_group_id.py
+++ b/alembic/versions/b6d52b9f8ea3_backfill_access_group_id.py
@@ -42,10 +42,13 @@ def _sanitize_username(name: str) -> str:
     """Mirror of credential_generator_service._sanitize_username.
 
     Kept inline (not imported) so the migration is self-contained and
-    immune to future service-code refactors.
+    immune to future service-code refactors. MUST be kept byte-for-byte
+    in sync with the service implementation — otherwise the backfill
+    can't match existing DeploymentInstanceAccess.username rows against
+    GroupMember-derived group names.
     """
-    username = name.lower().replace(" ", "-").replace(".", "-")
-    username = re.sub(r"[^a-z0-9\-_]", "", username)
+    username = name.lower().replace(" ", "_").replace(".", "_").replace("-", "_")
+    username = re.sub(r"[^a-z0-9_]", "", username)
     if username and username[0].isdigit():
         username = "u" + username
     return (username or "user")[:32]

--- a/scripts/sync_app_files_to_db.py
+++ b/scripts/sync_app_files_to_db.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Sync template files for an existing app from disk to the local DB.
+
+Usage:
+  uv run python scripts/sync_app_files_to_db.py <template-name> <app-dir>
+
+Examples:
+  uv run python scripts/sync_app_files_to_db.py \
+    "Ansible Multi-User Ubuntu" \
+    ../appstore-apps/ansible_multiuser
+
+  uv run python scripts/sync_app_files_to_db.py \
+    "Ansible PostgreSQL Group DB" \
+    ../appstore-apps/ansible_postgres_group_db
+
+Why this exists:
+  add_*.py scripts create a new template from scratch but fail on the second
+  run (template name conflict). After editing a playbook on disk you don't
+  want to delete + recreate the template every time — that loses Stack-IDs,
+  course bindings, and history. This script just refreshes the *files* of
+  the currently active version, matched by file_name. Bytes change, IDs
+  don't.
+"""
+import sys
+from pathlib import Path
+
+# Make src/ importable so we can reuse the model + session.
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from src.core.database import SessionLocal
+from src.models.template import Template
+from src.models.template_version import TemplateVersion
+from src.models.template_version_file import TemplateVersionFile
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(__doc__)
+        sys.exit(1)
+
+    template_name = sys.argv[1]
+    app_dir = Path(sys.argv[2]).resolve()
+
+    if not app_dir.is_dir():
+        print(f"✗ App-Dir not found: {app_dir}")
+        sys.exit(1)
+
+    db = SessionLocal()
+    try:
+        template = db.query(Template).filter(Template.name == template_name).first()
+        if not template:
+            print(f"✗ Template not found in DB: {template_name!r}")
+            sys.exit(1)
+
+        # Pick the latest version (sort by created_at desc).
+        version = (
+            db.query(TemplateVersion)
+            .filter(TemplateVersion.template_id == template.id)
+            .order_by(TemplateVersion.created_at.desc())
+            .first()
+        )
+        if not version:
+            print(f"✗ No version exists for template {template_name!r}")
+            sys.exit(1)
+
+        print(f"Template:   {template.name} (id={template.id})")
+        print(f"Version:    {version.version} (id={version.id})")
+        print(f"Source dir: {app_dir}")
+        print()
+
+        files_in_db = (
+            db.query(TemplateVersionFile)
+            .filter(TemplateVersionFile.template_version_id == version.id)
+            .all()
+        )
+        by_name = {f.file_name: f for f in files_in_db}
+
+        # Recursively look for any file matching a DB file_name in the app dir.
+        # Match by basename only — file_name in the DB is e.g. "main.yml",
+        # not "playbooks/main.yml".
+        disk_by_name: dict[str, Path] = {}
+        for p in app_dir.rglob("*"):
+            if p.is_file() and p.name in by_name:
+                disk_by_name[p.name] = p
+
+        updated = 0
+        skipped_missing: list[str] = []
+
+        for name, db_row in by_name.items():
+            disk_path = disk_by_name.get(name)
+            if not disk_path:
+                skipped_missing.append(name)
+                continue
+
+            new_content = disk_path.read_text(encoding="utf-8")
+            if new_content == (db_row.content or ""):
+                print(f"  = {name}  (unchanged)")
+                continue
+
+            old_size = len(db_row.content or "")
+            db_row.content = new_content
+            db_row.file_size = len(new_content.encode())
+            print(f"  ✓ {name}  ({old_size} → {db_row.file_size} bytes)  from {disk_path.relative_to(app_dir)}")
+            updated += 1
+
+        if skipped_missing:
+            print()
+            print("⚠ Files in DB but not on disk (left untouched):")
+            for n in skipped_missing:
+                print(f"    {n}")
+
+        db.commit()
+        print()
+        print("=" * 60)
+        print(f"Updated {updated} file(s).")
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/api/deployments.py
+++ b/src/api/deployments.py
@@ -471,6 +471,16 @@ async def stream_deployment_logs(
     Sends all existing logs immediately, then polls for new ones every second
     until the deployment reaches a terminal state (RUNNING, FAILED, DELETED).
     The stream closes automatically when done.
+
+    Implementation notes:
+      * Authorization runs against the request's DB session, but the polling
+        loop opens its OWN fresh SessionLocal each tick. Reusing the request
+        session would never see commits from the Celery worker (the session
+        caches identity-mapped objects within a single transaction).
+      * Sync SQLAlchemy calls are wrapped in run_in_threadpool so the event
+        loop stays free for other SSE clients.
+      * A heartbeat comment is sent every ~15s so proxies/browsers don't
+        consider the connection dead during long Ansible phases.
     """
     deployment_repo = DeploymentRepository(db)
     deployment = deployment_repo.get_by_id(deployment_id)
@@ -481,47 +491,89 @@ async def stream_deployment_logs(
     authorize_deployment_access(deployment, user, openstack_project_id, db)
 
     TERMINAL_STATUSES = {"RUNNING", "FAILED", "DELETED", "CANCELLED"}
+    HEARTBEAT_EVERY_SECONDS = 15
+    POLL_INTERVAL_SECONDS = 1
+
+    # Snapshot the (immutable) deployment_id for the closure; do NOT capture
+    # the ORM `deployment` object — it's bound to the request session which
+    # closes when this handler returns.
+    dep_id = deployment_id
+
+    def _fetch_state(since_seen: set[str], since_id_param: str | None):
+        """Open a fresh DB session, return (new_log_payloads, current_status).
+
+        Runs in the threadpool so the event loop isn't blocked on DB I/O.
+        """
+        from src.core.database import SessionLocal
+        local_db = SessionLocal()
+        try:
+            local_repo = DeploymentRepository(local_db)
+            current = local_repo.get_by_id(dep_id)
+            if current is None:
+                return [], "DELETED"
+
+            current_status = (
+                current.status.value if hasattr(current.status, "value") else str(current.status)
+            ).upper()
+
+            local_log_service = DeploymentLogService(local_db)
+            logs = local_log_service.get_deployment_logs(dep_id)
+
+            # First iteration: seed seen-set from since_id if provided
+            if since_id_param and not since_seen:
+                for log in logs:
+                    if str(log.id) == since_id_param:
+                        break
+                    since_seen.add(str(log.id))
+
+            new_payloads: list[str] = []
+            for log in logs:
+                lid = str(log.id)
+                if lid in since_seen:
+                    continue
+                since_seen.add(lid)
+                new_payloads.append(json.dumps({
+                    "id": lid,
+                    "deployment_id": str(log.deployment_id),
+                    "event_type": log.event_type.value if hasattr(log.event_type, "value") else str(log.event_type),
+                    "message": log.message,
+                    "level": log.level.value if hasattr(log.level, "value") else str(log.level),
+                    "details": json.loads(log.details_json) if log.details_json else None,
+                    "created_at": log.created_at.isoformat() if hasattr(log.created_at, "isoformat") else str(log.created_at),
+                }))
+            return new_payloads, current_status
+        finally:
+            local_db.close()
 
     async def event_generator():
-        log_service = DeploymentLogService(db)
-        seen_ids: set[str] = set()
+        from fastapi.concurrency import run_in_threadpool
 
-        # Seed seen_ids from since_id position
-        if since_id:
-            all_logs = log_service.get_deployment_logs(deployment_id)
-            for log in all_logs:
-                if str(log.id) == since_id:
-                    break
-                seen_ids.add(str(log.id))
+        seen_ids: set[str] = set()
+        seconds_since_heartbeat = 0
+        first = True
 
         try:
             while True:
-                # Refresh deployment status
-                db.expire(deployment)
-                current = deployment_repo.get_by_id(deployment_id)
-                current_status = (current.status.value if hasattr(current.status, "value") else str(current.status)).upper()
+                payloads, current_status = await run_in_threadpool(
+                    _fetch_state, seen_ids, since_id if first else None
+                )
+                first = False
 
-                # Fetch all logs and emit unseen ones
-                logs = log_service.get_deployment_logs(deployment_id)
-                new_logs = [log for log in logs if str(log.id) not in seen_ids]
-                for log in new_logs:
-                    seen_ids.add(str(log.id))
-                    payload = json.dumps({
-                        "id": str(log.id),
-                        "deployment_id": str(log.deployment_id),
-                        "event_type": log.event_type.value if hasattr(log.event_type, "value") else str(log.event_type),
-                        "message": log.message,
-                        "level": log.level.value if hasattr(log.level, "value") else str(log.level),
-                        "details": json.loads(log.details_json) if log.details_json else None,
-                        "created_at": log.created_at.isoformat() if hasattr(log.created_at, "isoformat") else str(log.created_at),
-                    })
+                for payload in payloads:
                     yield f"data: {payload}\n\n"
+                    seconds_since_heartbeat = 0
 
                 if current_status in TERMINAL_STATUSES:
                     yield "event: done\ndata: {}\n\n"
                     break
 
-                await asyncio.sleep(1)
+                if seconds_since_heartbeat >= HEARTBEAT_EVERY_SECONDS:
+                    # SSE comment line — clients ignore it, proxies keep the socket alive.
+                    yield ": ping\n\n"
+                    seconds_since_heartbeat = 0
+
+                await asyncio.sleep(POLL_INTERVAL_SECONDS)
+                seconds_since_heartbeat += POLL_INTERVAL_SECONDS
         except asyncio.CancelledError:
             pass
 
@@ -531,6 +583,7 @@ async def stream_deployment_logs(
         headers={
             "Cache-Control": "no-cache",
             "X-Accel-Buffering": "no",
+            "Connection": "keep-alive",
         },
     )
 
@@ -578,6 +631,11 @@ async def get_deployment_credentials(
                     ssh_private_key=access.ssh_private_key,
                     connection_url=access.connection_url,
                     port=access.port,
+                    group_id=access.group_id,
+                    # Frontend renders Dozent/Gruppen tabs from group_id + group_name.
+                    # group_id=NULL → admin/lecturer row → "Dozent" tab.
+                    # group_id=set → student group row → "Gruppen" tab, accordion by group_name.
+                    group_name=access.group.name if access.group else None,
                 )
                 for access in instance.access_methods
             ],

--- a/src/core/seed_data.py
+++ b/src/core/seed_data.py
@@ -1,4 +1,17 @@
-"""Seed mock data for development and testing."""
+"""Seed mock data for development and testing.
+
+Seeds two templates pulled directly from appstore-apps/:
+  * Multi-User Ubuntu           (from appstore-apps/ansible_multiuser)
+  * PostgreSQL Group DB         (from appstore-apps/ansible_postgres_group_db)
+
+The file contents below are inlined at generation time (see scripts that
+build this file). To refresh them after editing an app file on disk,
+re-run the embed step or use scripts/sync_app_files_to_db.py to push the
+disk version into an already-seeded DB without restarting.
+
+Legacy templates (older names from earlier iterations) are deleted on
+seeder run so the dashboard stays clean.
+"""
 import logging
 from sqlalchemy.orm import Session
 
@@ -10,75 +23,106 @@ from src.models.user import User
 logger = logging.getLogger(__name__)
 
 
-MULTISTUDENT_APP_YAML = """
+# ============================================================================
+# File contents — inlined from appstore-apps/. Regenerate to pick up changes.
+# ============================================================================
+
+MULTIUSER_APP_YAML = r'''
 app:
-  name: multiuser-ubuntu
-  label: Multi-User Ubuntu
-  version: 1.0.0
+  name: ansible-multiuser
+  label: Ansible Multi-User Ubuntu
+  version: 2.1.0
   description: >
-    Deploy one Ubuntu VM for a course with multiple local student accounts (username/password),
-    SSH allowed only from DHBW/VPN CIDR, and a Floating IP on DHBW.
+    Ubuntu VM mit mehreren Benutzerkonten, verwaltet durch Ansible.
+    Pro Gruppe wird ein Linux-Account mit eigenem Arbeitsverzeichnis erstellt.
+    Root disk is a Cinder volume (Boot from Volume) so "Speicher" can be configured.
   owner_team: dozilab-app-team
 
-artifacts:
-  heat_template: heat/main.yaml
-  cloud_init: cloud-init/user-data.yaml
+  allow_user_files: true
 
-# Parameters exposed to the AppStore UI.
-# Keep only what is meaningful for users; platform-fixed settings are hidden or fixed via allowed_values in Heat.
+# Maps each role-bearing file in this folder to its FileType so the backend's
+# GitHub-import wiring picks them up at deploy time. Without this block every
+# file is imported as OTHER and the deploy pipeline finds no Heat template
+# and no playbook. ``heat_template`` is also marked as the primary file
+# (deployment entrypoint).
+#
+# ``shell_scripts`` and ``config_files`` accept a list of paths so that
+# multiple helper scripts (scripts/) and configuration files (files/) get
+# their FileType set correctly — without that, the deploy-side copy step
+# would skip them and the playbook would fail with "file not found" when
+# trying to read /opt/dozilab/files/bashrc or /opt/dozilab/scripts/*.
+artifacts:
+  heat_template:    heat/main.yaml
+  ansible_playbook: playbooks/main.yml
+  shell_scripts:
+    - scripts/check_student_setup.sh
+    - scripts/reset_password.sh
+  config_files:
+    - files/bashrc
+    - files/motd
+
 parameters:
-  # --- VM basics ---
   - name: stack_label
-    label: Label
+    label: Stack-Label
     step: template
     type: string
-    default: multistudent
+    default: ansible
     required: true
     description: >
-      Short course/stack label used in VM name and metadata (e.g. kurs-01).
-      Must match: ^[a-z0-9][a-z0-9-]{0,30}$
+      Kurzes Label für diesen Stack (z.B. kurs-ws2026).
+      Muss passen zu: ^[a-z0-9][a-z0-9-]{0,30}$
 
   - name: image
-    label: Image
+    label: Betriebssystem-Image
     step: konfiguration
     type: string
     default: "Ubuntu 22.04 2025-01"
+    required: true
     enum:
       - "Ubuntu 22.04 2025-01"
       - "Ubuntu 24.04 2025-01"
       - "Ubuntu 24.04 2026-01"
-    required: true
-    description: "Base image for the VM (restricted to known good images)."
 
   - name: flavor
-    label: Flavor
+    label: VM-Größe (Flavor)
     step: konfiguration
     type: string
     default: "gp1.small"
+    required: true
     enum:
       - "gp1.small"
       - "gp1.medium"
-    required: true
-    description: "VM size. Keep small/medium for student workloads."
 
-  # --- Access control / networking ---
+  - name: volume_size
+    label: Speicher (GB)
+    step: konfiguration
+    type: number
+    default: 8
+    enum:
+      - 8
+      - 16
+      - 32
+      - 64
+      - 128
+    required: true
+    description: "Größe der Root-Disk als Cinder-Volume (Boot from Volume)."
+
   - name: ssh_cidr
-    label: SSH erlaubtes Netz (CIDR)
+    label: SSH-Zugriff (CIDR)
     step: netzwerk
     type: string
     default: "141.72.0.0/16"
     required: true
     description: >
-      IPv4 CIDR allowed to SSH and ICMP (ping). Default is DHBW/VPN range.
-      Examples: 141.72.0.0/16 (VPN/Campus) or 1.2.3.4/32 (single IP).
+      Nur dieses Netz darf per SSH zugreifen.
+      Standard: DHBW/VPN. Beispiel: 141.72.0.0/16 oder 1.2.3.4/32.
 
   - name: force_password_change
-    label: Passwortwechsel beim ersten Login
+    label: Passwort-Änderung beim ersten Login erzwingen
     step: zugriff
     type: boolean
     default: true
     required: true
-    description: "If true, student users must change their password on first login."
 
   - name: workdir
     label: Arbeitsordner
@@ -86,9 +130,8 @@ parameters:
     type: string
     default: "work"
     required: true
-    description: "Directory created under each student's home and used as default login directory."
+    description: "Directory created under each group user's home and used as default login directory."
 
-  # --- Password policy (showcase / configurable in V1) ---
   - name: pw_min_length
     label: Minimale Passwortlänge
     step: zugriff
@@ -121,8 +164,6 @@ parameters:
     required: true
     description: "Require at least one special character."
 
-  # --- Platform-fixed parameters (not shown in UI) ---
-  # Heat enforces allowed_values for these anyway. Keeping them hidden avoids confusion.
   - name: network
     label: Internes Netzwerk
     step: netzwerk
@@ -138,1550 +179,16 @@ parameters:
     default: "DHBW"
     hidden: true
     description: "External/FloatingIP network (fixed)."
-
-  - name: key_name
-    label: Admin SSH-Key
-    step: zugriff
-    type: string
-    default: "heat-bastion-key"
-    hidden: true
-    description: "Admin/support SSH keypair (fixed in v1)."
-
-outputs:
-  - name: floating_ip
-    from_heat_output: floating_ip
-    description: "Public floating IP address."
-
-  - name: server_id
-    from_heat_output: server_id
-    description: "Nova server ID (useful for console-log polling)."
-
-  - name: ssh_hint
-    from_heat_output: ssh_hint
-    description: "How students login (template string)."
-
-  - name: ready_marker
-    from_heat_output: ready_marker
-    description: "Marker string that appears in Nova console log when provisioning is done. Auch nach was müsst ihr im log ausschau halten dass ihr wisst dass die VM Ready ist"
-"""
-
-POSTGRES_APP_YAML = """
-app:
-  name: postgres-group-db
-  label: PostgreSQL Group DB
-  version: 1.1.0
-  description: >
-    Provision one Ubuntu VM with PostgreSQL (localhost-only) and optional pgAdmin.
-    Creates group databases, student logins, and teacher access. Backend can wait
-    for the DOZILAB_READY marker in the Nova console log.
-  owner_team: dozilab-app-team
-
-artifacts:
-  heat_template: heat/main.yaml
-  cloud_init: cloud-init/user-data.yaml
-
-# Parameters exposed to the AppStore UI.
-parameters:
-  # --- VM basics ---
-  - name: stack_label
-    label: Label
-    step: template
-    type: string
-    default: "sql"
-    required: true
-    description: >
-      Short course/stack label used in VM name and log markers (e.g. sql-2026-01).
-      Must match: ^[a-z0-9][a-z0-9-]{0,30}$
-
-  - name: image
-    label: Image
-    step: konfiguration
-    type: string
-    default: "Ubuntu 22.04 2025-01"
-    enum:
-      - "Ubuntu 22.04 2025-01"
-      - "Ubuntu 24.04 2025-01"
-      - "Ubuntu 24.04 2026-01"
-    required: true
-    description: "Base image for the VM (restricted to known good images)."
-
-  - name: flavor
-    label: Flavor
-    step: konfiguration
-    type: string
-    default: "gp1.small"
-    enum:
-      - "gp1.small"
-      - "gp1.medium"
-    required: true
-    description: "VM size. Keep small/medium for student workloads."
-
-  - name: volume_size
-    label: Speicher (GB)
-    step: konfiguration
-    type: number
-    default: 8
-    enum:
-      - 8
-      - 16
-      - 32
-      - 64
-      - 128
-    required: true
-    description: "Größe der Root-Disk als Cinder-Volume (Boot from Volume)."
-
-  # --- Access control / networking ---
-  - name: ssh_cidr
-    label: SSH erlaubtes Netz (CIDR)
-    step: netzwerk
-    type: string
-    default: "141.72.0.0/16"
-    required: true
-    description: >
-      IPv4 CIDR allowed to SSH. Default is DHBW/VPN range.
-      Examples: 141.72.0.0/16 or 1.2.3.4/32.
-
-  - name: web_cidr
-    label: pgAdmin erlaubtes Netz (CIDR)
-    step: netzwerk
-    type: string
-    default: "141.72.0.0/16"
-    required: true
-    description: "IPv4 CIDR allowed to reach pgAdmin (HTTP port 80)."
-
-
-  # --- Platform-fixed parameters (not shown in UI) ---
-  - name: network
-    label: Internes Netzwerk
-    step: netzwerk
-    type: string
-    default: "NAT"
-    hidden: true
-    description: "Internal network (fixed)."
-
-  - name: external_network
-    label: Externes Netzwerk (Floating IP)
-    step: netzwerk
-    type: string
-    default: "DHBW"
-    hidden: true
-    description: "External/FloatingIP network (fixed)."
-
-  - name: key_name
-    label: Admin SSH-Key
-    step: zugriff
-    type: string
-    default: "heat-bastion-key"
-    hidden: true
-    description: "Admin/support SSH keypair (fixed)."
-
-outputs:
-  - name: ssh_user
-    from_heat_output: ssh_user
-    description: "SSH username (ubuntu)."
-
-  - name: floating_ip
-    from_heat_output: floating_ip
-    description: "Public floating IP address."
-
-  - name: private_ip
-    from_heat_output: private_ip
-    description: "Private IP on tenant network."
-
-  - name: server_id
-    from_heat_output: server_id
-    description: "Nova server ID (useful for console-log polling)."
-
-  - name: pgadmin_url
-    from_heat_output: pgadmin_url
-    description: "pgAdmin4 URL (if enabled)."
-
-  - name: ssh_hint
-    from_heat_output: ssh_hint
-    description: "Admin SSH command template."
-
-  - name: ssh_tunnel_hint
-    from_heat_output: ssh_tunnel_hint
-    description: "How to access Postgres securely via SSH tunnel."
-
-  - name: ready_marker
-    from_heat_output: ready_marker
-    description: "Marker string that appears in Nova console log when provisioning is done."
-
-  - name: root_volume_id
-    from_heat_output: root_volume_id
-    description: "Cinder root volume ID (debug/traceability)."
-
-"""
-
-MULTISTUDENT_HEAT_TEMPLATE = """
-heat_template_version: 2018-08-31
-
-description: >
-  DoziLab Multi-Student VM: Ubuntu VM + Floating IP + password SSH for multiple users.
-
-parameters:
-  image:
-    type: string
-    default: "Ubuntu 22.04 2025-01"
-    constraints:
-      - allowed_values:
-          - "Ubuntu 22.04 2025-01"
-          - "Ubuntu 24.04 2025-01"
-          - "Ubuntu 24.04 2026-01"
-    description: "Base image for the VM."
-
-  flavor:
-    type: string
-    default: "gp1.small"
-    constraints:
-      - allowed_values:
-          - "gp1.small"
-          - "gp1.medium"
-    description: "VM size. Keep small/medium for student workloads."
-
-  network:
-    type: string
-    default: "NAT"
-    constraints:
-      - allowed_values: ["NAT"]
-
-  external_network:
-    type: string
-    default: "DHBW"
-    constraints:
-      - allowed_values: ["DHBW"]
-
-  key_name:
-    type: string
-    default: "heat-bastion-key"
-    constraints:
-      - allowed_values: ["heat-bastion-key"]
-    description: "Admin/support SSH keypair (später erweiterbar)"
-
-  ssh_cidr:
-    type: string
-    default: "141.72.0.0/16"
-    constraints:
-      - allowed_pattern: '^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$'
-    description: "IPv4 CIDR allowed to SSH (default DHBW/VPN)."
-
-  user_json:
-    type: string
-    default: |
-      {"course_label":"","instance":{"credentials":[]},"applications":[]}
-    description: "Base64-encoded JSON payload (raw JSON also accepted; multi-line allowed)."
-    constraints:
-      - length: { min: 2 }
-
-  force_password_change:
-    type: boolean
-    default: true
-
-  workdir:
-    type: string
-    default: "work"
-    constraints:
-      - allowed_pattern: '^[A-Za-z0-9._-]{1,32}$'
-    description: "Work directory under each user's home (e.g. work)."
-
-  stack_label:
-    type: string
-    default: "multistudent"
-    constraints:
-      - allowed_pattern: '^[a-z0-9][a-z0-9-]{0,30}$'
-    description: "Internal label used for resource names/metadata."
-
-  pw_min_length:
-    type: number
-    default: 12
-    constraints:
-      - range: { min: 4, max: 128 }
-
-  pw_require_digit:
-    type: boolean
-    default: true
-
-  pw_require_upper:
-    type: boolean
-    default: true
-
-  pw_require_special:
-    type: boolean
-    default: true
-
-resources:
-  secgroup:
-    type: OS::Neutron::SecurityGroup
-    properties:
-      description: Allow SSH + ICMP (VPN/Campus only)
-      rules:
-        - direction: ingress
-          ethertype: IPv4
-          protocol: tcp
-          port_range_min: 22
-          port_range_max: 22
-          remote_ip_prefix: { get_param: ssh_cidr }
-
-        - direction: ingress
-          ethertype: IPv4
-          protocol: icmp
-          remote_ip_prefix: { get_param: ssh_cidr }
-
-  port:
-    type: OS::Neutron::Port
-    properties:
-      network: { get_param: network }
-      security_groups:
-        - { get_resource: secgroup }
-
-  server:
-    type: OS::Nova::Server
-    properties:
-      name:
-        str_replace:
-          template: "dozilab-STACK"
-          params:
-            STACK: { get_param: stack_label }
-
-      image: { get_param: image }
-      flavor: { get_param: flavor }
-      key_name: { get_param: key_name }
-
-      networks:
-        - port: { get_resource: port }
-
-      metadata:
-        dozilab_stack_label: { get_param: stack_label }
-        dozilab_ready_marker: "DOZILAB_READY"
-
-      user_data_format: RAW
-      user_data:
-        str_replace:
-          template: { get_file: ../cloud-init/user-data.yaml }
-          params:
-            __USER_JSON__: { get_param: user_json }
-    
-            __FORCE_CHANGE__: { get_param: force_password_change }
-            __WORKDIR__: { get_param: workdir }
-
-            __PW_MIN_LENGTH__: { get_param: pw_min_length }
-            __PW_REQUIRE_DIGIT__: { get_param: pw_require_digit }
-            __PW_REQUIRE_UPPER__: { get_param: pw_require_upper }
-            __PW_REQUIRE_SPECIAL__: { get_param: pw_require_special }
-
-            __STACK_LABEL__: { get_param: stack_label }
-
-  fip:
-    type: OS::Neutron::FloatingIP
-    properties:
-      floating_network: { get_param: external_network }
-
-  fip_assoc:
-    type: OS::Neutron::FloatingIPAssociation
-    properties:
-      floatingip_id: { get_resource: fip }
-      port_id: { get_resource: port }
-
-outputs:
-  floating_ip:
-    value: { get_attr: [fip, floating_ip_address] }
-
-  server_id:
-    description: "Nova server ID (useful for console-log polling)"
-    value: { get_resource: server }
-
-  ssh_hint:
-    description: "Students login like: ssh <username>@<floating_ip>"
-    value:
-      str_replace:
-        template: "ssh <username>@FIP"
-        params:
-          FIP: { get_attr: [fip, floating_ip_address] }
-
-  ready_marker:
-    description: "Backend should wait until this marker appears in the Nova console log"
-    value:
-      str_replace:
-        template: "DOZILAB_READY stack=STACK"
-        params:
-          STACK: { get_param: stack_label }
-"""
-
-POSTGRES_HEAT_TEMPLATE = """
-heat_template_version: 2018-08-31
-
-description: DoziLab PostgreSQL VM (localhost-only) + optional pgAdmin4 Web UI (boot from Cinder volume)
-
-parameters:
-  stack_label:
-    type: string
-    description: Short label used in hostname/log markers
-    default: "sql"
-
-  image:
-    type: string
-    description: Glance image name or ID
-
-  flavor:
-    type: string
-    description: Nova flavor name or ID
-
-  volume_size:
-    type: number
-    description: Root volume size in GB
-    default: 8
-    constraints:
-      - range: { min: 8, max: 200 }
-
-  network:
-    type: string
-    description: Tenant network name or ID
-
-  external_network:
-    type: string
-    description: External network name or ID for Floating IP
-
-  key_name:
-    type: string
-    description: Nova keypair name for SSH
-    default: "heat-bastion-key"
-
-  ssh_cidr:
-    type: string
-    description: Allowed CIDR for SSH
-    default: "0.0.0.0/0"
-
-  web_cidr:
-    type: string
-    description: Allowed CIDR for pgAdmin over HTTP (port 80)
-    default: "0.0.0.0/0"
-
-  user_json:
-    type: string
-    description: Base64-encoded JSON payload from backend (raw JSON also accepted; multi-line allowed)
-
-resources:
-  secgroup:
-    type: OS::Neutron::SecurityGroup
-    properties:
-      name: { str_replace: { template: "dozilab-pg-__LABEL__", params: { "__LABEL__": { get_param: stack_label } } } }
-      description: Security group for DoziLab Postgres+pgAdmin VM
-      rules:
-        - direction: ingress
-          ethertype: IPv4
-          protocol: tcp
-          port_range_min: 22
-          port_range_max: 22
-          remote_ip_prefix: { get_param: ssh_cidr }
-
-        - direction: ingress
-          ethertype: IPv4
-          protocol: tcp
-          port_range_min: 80
-          port_range_max: 80
-          remote_ip_prefix: { get_param: web_cidr }
-
-        # egress allow all (default in many setups; define explicitly to be safe)
-        - direction: egress
-          ethertype: IPv4
-
-  port:
-    type: OS::Neutron::Port
-    properties:
-      network: { get_param: network }
-      security_groups: [ { get_resource: secgroup } ]
-
-  root_volume:
-    type: OS::Cinder::Volume
-    properties:
-      name:
-        str_replace:
-          template: "dozilab-pg-__LABEL__-root"
-          params:
-            "__LABEL__": { get_param: stack_label }
-      size: { get_param: volume_size }
-      image: { get_param: image }
-      metadata:
-        dozilab_stack_label: { get_param: stack_label }
-
-  server:
-    type: OS::Nova::Server
-    properties:
-      name: { str_replace: { template: "dozilab-pg-__LABEL__", params: { "__LABEL__": { get_param: stack_label } } } }
-      flavor: { get_param: flavor }
-      key_name: { get_param: key_name }
-      block_device_mapping_v2:
-        - boot_index: 0
-          volume_id: { get_resource: root_volume }
-          delete_on_termination: true
-      networks:
-        - port: { get_resource: port }
-      user_data_format: RAW
-      user_data:
-        str_replace:
-          template: { get_file: ../cloud-init/user-data.yaml }
-          params:
-            "__STACK_LABEL__": { get_param: stack_label }
-            "__USER_JSON__": { get_param: user_json }
-                
-
-  fip:
-    type: OS::Neutron::FloatingIP
-    properties:
-      floating_network: { get_param: external_network }
-
-  fip_assoc:
-    type: OS::Neutron::FloatingIPAssociation
-    properties:
-      floatingip_id: { get_resource: fip }
-      port_id: { get_resource: port }
-
-outputs:
-  ssh_user:
-    description: SSH username
-    value: ubuntu
-
-  floating_ip:
-    description: Public Floating IP
-    value: { get_attr: [ fip, floating_ip_address ] }
-
-  private_ip:
-    description: Private IP on tenant network
-    value: { get_attr: [ port, fixed_ips, 0, ip_address ] }
-
-  server_id:
-    description: Nova server ID
-    value: { get_resource: server }
-
-  pgadmin_url:
-    description: pgAdmin4 URL (if enabled)
-    value:
-      str_replace:
-        template: "http://__FIP__/pgadmin4/"
-        params:
-          "__FIP__": { get_attr: [ fip, floating_ip_address ] }
-
-  ssh_hint:
-    description: Admin SSH (key-based)
-    value:
-      str_replace:
-        template: "ssh -i ~/.ssh/heat-bastion-key.pem ubuntu@__FIP__"
-        params:
-          "__FIP__": { get_attr: [ fip, floating_ip_address ] }
-
-  ssh_tunnel_hint:
-    description: How to access Postgres securely via SSH tunnel
-    value:
-      str_replace:
-        template: "ssh -i ~/.ssh/heat-bastion-key.pem -L 5432:127.0.0.1:5432 ubuntu@__FIP__"
-        params:
-          "__FIP__": { get_attr: [ fip, floating_ip_address ] }
-
-  ready_marker:
-    description: Backend should wait until this marker appears in the Nova console log
-    value:
-      str_replace:
-        template: "DOZILAB_READY stack=__LABEL__"
-        params:
-          "__LABEL__": { get_param: stack_label }
-
-  root_volume_id:
-    description: Cinder root volume ID (debug/traceability)
-    value: { get_resource: root_volume }
-
-"""
-
-MULTISTUDENT_CLOUD_INIT = """
-#cloud-config
-package_update: true
-package_upgrade: false
-
-packages:
-  - libpam-pwquality
-  - python3
-  - cloud-guest-utils
-
-# Ensure root partition/filesystem grows when booting from larger volume
-growpart:
-  mode: auto
-  devices: ["/"]
-  ignore_growroot_disabled: false
-
-resize_rootfs: true
-
-write_files:
-  - path: /etc/dozilab/user.json.payload
-    owner: root:root
-    permissions: "0600"
-    content: |
-      __USER_JSON__
-  - path: /usr/local/bin/dozilab-multiuser-setup.sh
-    permissions: "0755"
-    content: |
-      #!/usr/bin/env bash
-      set -euo pipefail
-
-      LOG="/var/log/dozilab-multiuser.log"
-      MARK_DIR="/var/lib/dozilab"
-      READY_FILE="${MARK_DIR}/ready"
-      FAIL_FILE="${MARK_DIR}/failed"
-
-      STACK_LABEL="__STACK_LABEL__"
-
-      USER_JSON_PAYLOAD="/etc/dozilab/user.json.payload"
-      USER_JSON_PATH="/etc/dozilab/user.json"
-      FORCE="__FORCE_CHANGE__"
-      WORKDIR="__WORKDIR__"
-
-      PW_MIN_LENGTH="__PW_MIN_LENGTH__"
-      PW_REQUIRE_DIGIT="__PW_REQUIRE_DIGIT__"
-      PW_REQUIRE_UPPER="__PW_REQUIRE_UPPER__"
-      PW_REQUIRE_SPECIAL="__PW_REQUIRE_SPECIAL__"
-
-      mkdir -p "$MARK_DIR"
-      # Mirror logs to cloud-init output and our own logfile
-      exec > >(tee -a "$LOG" /var/log/cloud-init-output.log) 2>&1
-      echo "multiuser setup started $(date -Is)"
-
-      on_fail() {
-        rc=$?
-        msg="DOZILAB_FAILED stack=${STACK_LABEL} rc=${rc} time=$(date -Is)"
-        echo "$msg" | tee -a "$LOG" | tee /dev/console > "$FAIL_FILE"
-        chmod 644 "$FAIL_FILE" || true
-        exit "$rc"
-      }
-      trap on_fail ERR
-
-      to_bool() {
-        local v="${1:-}"
-        v="$(echo "$v" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
-        [[ "$v" == "1" || "$v" == "true" || "$v" == "yes" || "$v" == "on" ]]
-      }
-
-      # --- Build deterministic pwquality options from Heat params ---
-      DCREDIT=0
-      UCREDIT=0
-      OCREDIT=0
-      if to_bool "$PW_REQUIRE_DIGIT"; then DCREDIT=-1; fi
-      if to_bool "$PW_REQUIRE_UPPER"; then UCREDIT=-1; fi
-      if to_bool "$PW_REQUIRE_SPECIAL"; then OCREDIT=-1; fi
-      if ! [[ "$PW_MIN_LENGTH" =~ ^[0-9]+$ ]]; then PW_MIN_LENGTH=12; fi
-
-      # Enforce exactly what the UI exposes (no dict/diff surprise checks)
-      # NOTE: this affects password setting (chpasswd) AND interactive passwd.
-      PWQ_OPTS="retry=3 enforce_for_root minlen=${PW_MIN_LENGTH} dcredit=${DCREDIT} ucredit=${UCREDIT} ocredit=${OCREDIT} dictcheck=0 usercheck=0 gecoscheck=0 difok=0 maxrepeat=0 minclass=0"
-
-      # Keep pwquality.conf consistent for debugging/inspection (PAM line is the source of truth)
-      cat >/etc/security/pwquality.conf <<EOF
-      # Managed by DoziLab (cloud-init). NOTE: PAM options override this file.
-      minlen = ${PW_MIN_LENGTH}
-      dcredit = ${DCREDIT}
-      ucredit = ${UCREDIT}
-      ocredit = ${OCREDIT}
-      dictcheck = 0
-      usercheck = 0
-      gecoscheck = 0
-      difok = 0
-      maxrepeat = 0
-      minclass = 0
-      EOF
-
-      # --- Enforce our exact policy in PAM (source of truth) ---
-      PAM_FILE="/etc/pam.d/common-password"
-
-      if grep -qE '^\s*password\s+requisite\s+pam_pwquality\.so' "$PAM_FILE"; then
-        # Replace existing pwquality line
-        sed -i -E "s|^\s*password\s+requisite\s+pam_pwquality\.so.*$|password requisite pam_pwquality.so ${PWQ_OPTS}|" "$PAM_FILE"
-      else
-        # Insert before pam_unix
-        sed -i -E "/^\s*password\s+.*pam_unix\.so/ i password requisite pam_pwquality.so ${PWQ_OPTS}" "$PAM_FILE"
-      fi
-
-      # SSH: enable password login (users use passwords)
-      cat >/etc/ssh/sshd_config.d/99-dozilab-multiuser.conf <<'EOF'
-      PasswordAuthentication yes
-      KbdInteractiveAuthentication yes
-      ChallengeResponseAuthentication yes
-      UsePAM yes
-      PermitRootLogin no
-      EOF
-
-      export USER_JSON_PATH FORCE WORKDIR
-
-      if [[ ! -s "$USER_JSON_PAYLOAD" ]]; then
-        echo "ERROR: $USER_JSON_PAYLOAD missing/empty" >&2
-        exit 2
-      fi
-
-      # Decode base64 (or accept raw JSON) into /etc/dozilab/user.json
-      python3 - <<'PY'
-      import ast
-      import base64
-      import json
-      import sys
-      from pathlib import Path
-
-      payload_path = Path("/etc/dozilab/user.json.payload")
-      out_path = Path("/etc/dozilab/user.json")
-
-      raw = payload_path.read_text(encoding="utf-8").strip()
-      if not raw:
-          sys.exit("user_json payload missing/empty")
-
-      def parse_obj(txt: str):
-          try:
-              return json.loads(txt), "json"
-          except Exception:
-              pass
-          try:
-              return ast.literal_eval(txt), "python-literal"
-          except Exception:
-              return None, None
-
-      def decode_b64(s: str):
-          compact = "".join(s.split())
-          pad = (-len(compact)) % 4
-          compact += "=" * pad
-          try:
-              return base64.b64decode(compact, validate=True).decode("utf-8")
-          except Exception:
-              try:
-                  return base64.b64decode(compact).decode("utf-8")
-              except Exception:
-                  return None
-
-      obj, kind = parse_obj(raw)
-      source = "raw"
-      if obj is None:
-          decoded = decode_b64(raw)
-          if decoded is None:
-              sys.exit("user_json payload is neither JSON/literal nor base64-encoded JSON/literal")
-          obj, kind = parse_obj(decoded.strip())
-          if obj is None:
-              sys.exit("user_json base64 decoded, but not valid JSON or python literal")
-          source = "base64"
-
-      out_path.write_text(json.dumps(obj, ensure_ascii=True), encoding="utf-8")
-      print(f"user_json normalized ({source}, {kind}) -> {out_path}")
-      PY
-
-      if [[ ! -s "$USER_JSON_PATH" ]]; then
-        echo "ERROR: $USER_JSON_PATH missing/empty after decoding" >&2
-        exit 2
-      fi
-
-      # Create users from user_json (hard fail on invalid schema)
-      python3 - <<'PY'
-      import json, os, re, sys, subprocess
-
-      user_json_path = os.environ.get("USER_JSON_PATH", "/etc/dozilab/user.json")
-      try:
-          user_json = open(user_json_path, "r", encoding="utf-8").read().strip()
-      except FileNotFoundError:
-          user_json = ""
-      force = str(os.environ.get("FORCE", "true")).lower() in ("1","true","yes","on")
-      workdir = os.environ.get("WORKDIR","work")
-
-      def fail(msg):
-          print(msg, file=sys.stderr)
-          sys.exit(1)
-
-      if not re.match(r"^[A-Za-z0-9._-]{1,32}$", workdir or ""):
-          print(f"Invalid workdir {workdir!r}, using 'work'")
-          workdir = "work"
-
-      if not user_json:
-          fail("user_json is empty or missing")
-
-      try:
-          data = json.loads(user_json)
-      except Exception as e:
-          fail(f"user_json invalid: {e}. Must be JSON with double quotes.")
-
-      if not isinstance(data, dict):
-          fail("user_json must be a JSON object")
-
-      instance = data.get("instance") or {}
-      if not isinstance(instance, dict):
-          fail("instance must be an object")
-
-      credentials = instance.get("credentials") or []
-      admin = instance.get("admin_credentials")
-      apps = data.get("applications") or []
-
-      if not isinstance(credentials, list):
-          fail("instance.credentials must be a list")
-
-      if not isinstance(apps, list):
-          print("applications is not a list; ignoring")
-          apps = []
-
-      course_label = data.get("course_label") or ""
-      if course_label:
-          print(f"course_label={course_label}")
-
-      if not credentials:
-          print("WARNING: instance.credentials empty; no student users will be created")
-
-      rx = re.compile(r"^[a-z_][a-z0-9_-]{0,31}$")
-
-      def run(cmd, **kw):
-          subprocess.run(cmd, check=True, **kw)
-
-      NL = chr(10)
-
-      def ensure_user(u, p, is_admin=False):
-          if subprocess.run(["id", u], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode != 0:
-              run(["useradd", "-m", "-s", "/bin/bash", u])
-
-          # This MUST succeed, otherwise we fail the whole setup
-          run(["chpasswd"], input=f"{u}:{p}" + NL, text=True)
-
-          if is_admin:
-              subprocess.run(["usermod", "-aG", "sudo", u], check=False)
-
-          if force:
-              subprocess.run(["chage", "-d", "0", u], check=False)
-
-          run(["chmod", "700", f"/home/{u}"])
-          run(["mkdir", "-p", f"/home/{u}/{workdir}"])
-          run(["chown", "-R", f"{u}:{u}", f"/home/{u}/{workdir}"])
-          run(["chmod", "700", f"/home/{u}/{workdir}"])
-
-          profile = f"/home/{u}/.profile"
-          line = f'cd "$HOME/{workdir}"' + NL
-          try:
-              txt = open(profile, "r", encoding="utf-8", errors="ignore").read()
-          except FileNotFoundError:
-              txt = ""
-          if f'cd "$HOME/{workdir}"' not in txt:
-              with open(profile, "a", encoding="utf-8") as f:
-                  f.write(line)
-          run(["chown", f"{u}:{u}", profile])
-
-      created = []
-
-      # Validate credentials upfront so we don't half-configure
-      for idx, item in enumerate(credentials):
-          if not isinstance(item, dict):
-              fail(f"instance.credentials[{idx}] must be an object")
-          u = item.get("username")
-          p = item.get("password")
-          if not isinstance(u, str) or not rx.match(u):
-              fail(f"Invalid username: {u!r}")
-          if not isinstance(p, str) or len(p) == 0:
-              fail(f"Empty password for {u}")
-
-      for item in credentials:
-          u = item["username"]
-          p = item["password"]
-          ensure_user(u, p, is_admin=False)
-          created.append(u)
-
-      admin_user = None
-      if admin is not None:
-          if not isinstance(admin, dict):
-              fail("instance.admin_credentials must be an object")
-          au = admin.get("username")
-          ap = admin.get("password")
-          if not isinstance(au, str) or not rx.match(au):
-              fail(f"Invalid admin username: {au!r}")
-          if not isinstance(ap, str) or len(ap) == 0:
-              fail("Empty password for admin user")
-          ensure_user(au, ap, is_admin=True)
-          admin_user = au
-
-      # Restrict SSH users: ubuntu (admin key) + created users only
-      allow_users = sorted(set(created + ([admin_user] if admin_user else [])))
-      allow = "AllowUsers " + " ".join(["ubuntu"] + allow_users) + NL
-      with open("/etc/ssh/sshd_config.d/98-dozilab-allowusers.conf", "w", encoding="utf-8") as f:
-          f.write(allow)
-
-      if allow_users:
-          print("created users:", ", ".join(allow_users))
-
-      if not apps:
-          print("applications: none")
-      else:
-          for idx, app in enumerate(apps):
-              if isinstance(app, dict):
-                  name = app.get("name") or app.get("app") or f"index-{idx}"
-                  version = app.get("version") or app.get("ver") or ""
-                  if version:
-                      print(f"applications[{idx}]: {name} {version}")
-                  else:
-                      print(f"applications[{idx}]: {name}")
-              else:
-                  print(f"applications[{idx}]: {app!r}")
-      PY
-
-      # Restart sshd; if this fails, trap will mark FAILED
-      systemctl restart ssh || service ssh restart
-
-      echo "multiuser setup finished $(date -Is)"
-
-      # READY marker (ONLY here = success)
-      msg="DOZILAB_READY stack=${STACK_LABEL} time=$(date -Is)"
-      echo "$msg" | tee -a "$LOG" | tee /dev/console > "$READY_FILE"
-      chmod 644 "$READY_FILE"
-
-runcmd:
-  - [ bash, -lc, "/usr/local/bin/dozilab-multiuser-setup.sh" ]
-
-final_message: "DoziLab multi-user VM: cloud-init finished"
-
-"""
-
-POSTGRES_CLOUD_INIT = """
-#cloud-config
-package_update: true
-package_upgrade: false
-
-write_files:
-  - path: /etc/dozilab/user.json.payload
-    owner: root:root
-    permissions: "0600"
-    content: |
-      __USER_JSON__
-
-  - path: /usr/local/bin/dozilab-postgres-setup.sh
-    owner: root:root
-    permissions: "0755"
-    content: |
-      #!/usr/bin/env bash
-      set -euo pipefail
-      export DEBIAN_FRONTEND=noninteractive
-
-      LOG="/var/log/dozilab-postgres.log"
-      MARK_DIR="/var/lib/dozilab"
-      READY_FILE="${MARK_DIR}/ready"
-      FAIL_FILE="${MARK_DIR}/failed"
-
-      STACK_LABEL="__STACK_LABEL__"
-      USER_JSON_PAYLOAD="/etc/dozilab/user.json.payload"
-      USER_JSON_PATH="/etc/dozilab/user.json"
-
-      mkdir -p "$MARK_DIR"
-      exec > >(tee -a "$LOG") 2>&1
-
-      on_fail() {
-        rc=$?
-        msg="DOZILAB_FAILED stack=${STACK_LABEL} rc=${rc} time=$(date -Is)"
-        echo "$msg" | tee -a "$LOG" | tee /dev/console > "$FAIL_FILE"
-        chmod 644 "$FAIL_FILE" || true
-        exit "$rc"
-      }
-      trap on_fail ERR
-
-      echo "DoziLab setup started $(date -Is)"
-      echo "Stack label: ${STACK_LABEL}"
-      echo "Using user_json payload: ${USER_JSON_PAYLOAD}"
-
-      if [[ ! -s "$USER_JSON_PAYLOAD" ]]; then
-        echo "ERROR: $USER_JSON_PAYLOAD missing/empty" >&2
-        exit 2
-      fi
-
-      # ------------------------------------------------------------
-      # Decode wrapper (base64 or raw) into JSON file, then validate payload.
-      # Backend must send final db_user + database_name etc. (no sanitizing)
-      # ------------------------------------------------------------
-      python3 - <<'PY'
-      import ast
-      import base64
-      import json
-      import sys
-      from pathlib import Path
-
-      payload_path = Path("/etc/dozilab/user.json.payload")
-      out_path = Path("/etc/dozilab/user.json")
-
-      raw = payload_path.read_text(encoding="utf-8").strip()
-      if not raw:
-          sys.exit("user_json payload missing/empty")
-
-      def parse_obj(txt: str):
-          try:
-              return json.loads(txt), "json"
-          except Exception:
-              pass
-          try:
-              return ast.literal_eval(txt), "python-literal"
-          except Exception:
-              return None, None
-
-      def decode_b64(s: str):
-          compact = "".join(s.split())
-          pad = (-len(compact)) % 4
-          compact += "=" * pad
-          try:
-              return base64.b64decode(compact, validate=True).decode("utf-8")
-          except Exception:
-              try:
-                  return base64.b64decode(compact).decode("utf-8")
-              except Exception:
-                  return None
-
-      obj, kind = parse_obj(raw)
-      source = "raw"
-      if obj is None:
-          decoded = decode_b64(raw)
-          if decoded is None:
-              sys.exit("user_json payload is neither JSON/literal nor base64-encoded JSON/literal")
-          obj, kind = parse_obj(decoded.strip())
-          if obj is None:
-              sys.exit("user_json base64 decoded, but not valid JSON or python literal")
-          source = "base64"
-
-      out_path.write_text(json.dumps(obj, ensure_ascii=True), encoding="utf-8")
-      print(f"user_json normalized ({source}, {kind}) -> {out_path}")
-      PY
-
-      if [[ ! -s "$USER_JSON_PATH" ]]; then
-        echo "ERROR: $USER_JSON_PATH missing/empty after decoding" >&2
-        exit 2
-      fi
-
-      echo "Validating user_json schema (direct) ..."
-      python3 - <<'PY'
-      import json, re, sys
-
-      p = "/etc/dozilab/user.json"
-      data = json.load(open(p, "r", encoding="utf-8"))
-      if not isinstance(data, dict):
-          sys.exit("user_json must be an object")
-
-      apps = data.get("applications")
-      if not isinstance(apps, list):
-          sys.exit("user_json.applications must be a list")
-
-      def find_app(name: str):
-          for a in apps:
-              if isinstance(a, dict) and str(a.get("name","")).lower() == name:
-                  return a
-          return None
-
-      pg = find_app("postgres") or find_app("postgresql")
-      if not pg:
-          sys.exit("Missing applications[name=postgres]")
-
-      pg_creds = pg.get("credentials")
-      if not isinstance(pg_creds, list) or not pg_creds:
-          sys.exit("postgres.credentials must be a non-empty list")
-
-      # strict identifiers to avoid surprises
-      ident = re.compile(r"^[a-z_][a-z0-9_]{0,62}$")
-      group_token = re.compile(r"^[A-Za-z0-9_]{1,32}$")
-
-      used_db_users = set()
-
-      for c in pg_creds:
-          if not isinstance(c, dict):
-              sys.exit("postgres.credentials entries must be objects")
-
-          gid = c.get("group")
-          if gid is None:
-              sys.exit("postgres credential missing group")
-          gid_s = str(gid).strip()
-          if not gid_s or not group_token.match(gid_s):
-              sys.exit(f"postgres credential group must be [A-Za-z0-9_], 1..32 chars, got: {gid!r}")
-
-          dbn = c.get("database_name") or c.get("db_name")
-          if not isinstance(dbn, str) or not ident.match(dbn):
-              sys.exit(f"postgres credential database_name invalid (must match {ident.pattern}): {dbn!r}")
-
-          db_user = c.get("db_user")
-          if not isinstance(db_user, str) or not ident.match(db_user):
-              sys.exit(f"postgres credential db_user invalid (must match {ident.pattern}): {db_user!r}")
-
-          if db_user in used_db_users:
-              sys.exit(f"duplicate postgres db_user not allowed: {db_user!r}")
-          used_db_users.add(db_user)
-
-          pw = c.get("password")
-          if not isinstance(pw, str) or len(pw) < 6:
-              sys.exit(f"postgres credential password too short for {db_user!r} (min 6)")
-
-      admin = pg.get("admin_credentials") or {}
-      if admin:
-          if not isinstance(admin, dict):
-              sys.exit("postgres.admin_credentials must be an object")
-          a_user = admin.get("db_user")
-          a_pw = admin.get("password")
-          if not isinstance(a_user, str) or not ident.match(a_user):
-              sys.exit(f"postgres admin db_user invalid (must match {ident.pattern}): {a_user!r}")
-          if a_user in used_db_users:
-              sys.exit(f"postgres admin db_user collides with group user: {a_user!r}")
-          if not isinstance(a_pw, str) or len(a_pw) < 6:
-              sys.exit("postgres admin password too short (min 6)")
-
-      # pgadmin is optional; if present we validate only what it explicitly sends (no fallback)
-      pga = find_app("pgadmin")
-      if pga:
-          pga_admin = pga.get("admin_credentials") or {}
-          if not isinstance(pga_admin, dict) or not pga_admin.get("email") or not pga_admin.get("password"):
-              sys.exit("pgadmin.admin_credentials must contain email+password when pgadmin app is present")
-
-          pga_creds = pga.get("credentials")
-          if not isinstance(pga_creds, list) or not pga_creds:
-              sys.exit("pgadmin.credentials must be a non-empty list when pgadmin app is present")
-
-          seen_emails = set()
-          for c in pga_creds:
-              if not isinstance(c, dict):
-                  sys.exit("pgadmin.credentials entries must be objects")
-              gid = c.get("group")
-              if gid is None:
-                  sys.exit("pgadmin credential missing group")
-              gid_s = str(gid).strip()
-              if not gid_s or not group_token.match(gid_s):
-                  sys.exit(f"pgadmin credential group must be [A-Za-z0-9_], got: {gid!r}")
-
-              email = c.get("email")
-              pw = c.get("password")
-              if not isinstance(email, str) or "@" not in email:
-                  sys.exit(f"pgadmin credential email invalid: {email!r}")
-              if not isinstance(pw, str) or len(pw) < 6:
-                  sys.exit(f"pgadmin credential password too short for {email!r} (min 6)")
-              if email in seen_emails:
-                  sys.exit(f"duplicate pgadmin email not allowed: {email!r}")
-              seen_emails.add(email)
-
-      print("user_json validated OK (direct mode)")
-      PY
-
-      # ------------------------------------------------------------
-      # Install PostgreSQL
-      # - If user_json contains postgres_version -> install that major
-      # - else install distro default (postgresql meta)
-      # ------------------------------------------------------------
-      PGVER="$(python3 - <<'PY'
-      import json
-      data = json.load(open("/etc/dozilab/user.json"))
-      pgver = data.get("postgres_version")
-      if pgver is None:
-          pgver = data.get("postgresVersion")
-      apps = data.get("applications") or []
-      for a in apps:
-          if isinstance(a, dict) and str(a.get("name","")).lower() in ("postgres","postgresql"):
-              if a.get("postgres_version") is not None:
-                  pgver = a.get("postgres_version")
-              if a.get("postgresVersion") is not None:
-                  pgver = a.get("postgresVersion")
-      if pgver is None:
-          print("")
-      else:
-          print(int(pgver))
-      PY
-      )"
-
-      apt-get update -y
-      if [[ -n "${PGVER}" ]]; then
-        echo "Installing PostgreSQL ${PGVER} ..."
-        apt-get install -y "postgresql-${PGVER}" postgresql-client
-      else
-        echo "Installing distro default PostgreSQL ..."
-        apt-get install -y postgresql postgresql-client
-      fi
-
-      # Detect installed major version
-      DETECTED_PGVER="$(pg_lsclusters --no-header 2>/dev/null | awk 'NR==1{print $1}')"
-      if [[ -z "${DETECTED_PGVER:-}" ]]; then
-        echo "ERROR: Could not detect Postgres version (pg_lsclusters empty)" >&2
-        exit 3
-      fi
-      PGVER="${DETECTED_PGVER}"
-      echo "Detected PostgreSQL major version: ${PGVER}"
-
-      echo "Configuring Postgres to listen on localhost only ..."
-      CONF="/etc/postgresql/${PGVER}/main/postgresql.conf"
-      HBA="/etc/postgresql/${PGVER}/main/pg_hba.conf"
-
-      sed -i "s/^#\\?listen_addresses\\s*=.*/listen_addresses = '127.0.0.1'/" "$CONF"
-
-      grep -qE "^[[:space:]]*host[[:space:]]+all[[:space:]]+all[[:space:]]+127\\.0\\.0\\.1/32" "$HBA" \
-        || echo "host all all 127.0.0.1/32 scram-sha-256" >> "$HBA"
-      grep -qE "^[[:space:]]*host[[:space:]]+all[[:space:]]+all[[:space:]]+::1/128" "$HBA" \
-        || echo "host all all ::1/128 scram-sha-256" >> "$HBA"
-
-      systemctl enable --now postgresql
-      systemctl restart postgresql
-
-      for i in {1..60}; do
-        if sudo -u postgres psql -d postgres -Atc "SELECT 1" >/dev/null 2>&1; then
-          break
-        fi
-        sleep 1
-      done
-
-      # ------------------------------------------------------------
-      # Provision DB roles & databases from user_json DIRECTLY
-      # (robust quoting; no psql :var substitution)
-      # ------------------------------------------------------------
-      echo "Provisioning roles & databases (direct from user_json) ..."
-      python3 - <<'PY'
-      import json, subprocess, sys, re
-
-      spec = json.load(open("/etc/dozilab/user.json"))
-      apps = spec.get("applications") or []
-
-      def find_app(name: str):
-          for a in apps:
-              if isinstance(a, dict) and str(a.get("name","")).lower() == name:
-                  return a
-          return None
-
-      pg = find_app("postgres") or find_app("postgresql")
-      pg_creds = pg.get("credentials") or []
-      pg_admin = pg.get("admin_credentials") or {}
-
-      ident = re.compile(r"^[a-z_][a-z0-9_]{0,62}$")
-      group_token = re.compile(r"^[A-Za-z0-9_]{1,32}$")
-
-      def run(sql: str, db: str = "postgres", capture: bool = True) -> str:
-          cmd = ["sudo", "-u", "postgres", "psql", "-d", db, "-v", "ON_ERROR_STOP=1", "-Atc", sql]
-          if capture:
-              return subprocess.check_output(cmd, text=True, cwd="/").strip()
-          subprocess.check_call(cmd, cwd="/")
-          return ""
-
-      def q_ident(s: str) -> str:
-          return '"' + s.replace('"', '""') + '"'
-
-      def q_lit(s: str) -> str:
-          return "'" + s.replace("'", "''") + "'"
-
-      def role_exists(name: str) -> bool:
-          return run(f"SELECT 1 FROM pg_roles WHERE rolname={q_lit(name)};") == "1"
-
-      def db_exists(name: str) -> bool:
-          return run(f"SELECT 1 FROM pg_database WHERE datname={q_lit(name)};") == "1"
-
-      def ensure_group_role(role: str) -> None:
-          if not role_exists(role):
-              run(f"CREATE ROLE {q_ident(role)} NOLOGIN;", capture=False)
-
-      def ensure_login_role(role: str, password: str) -> None:
-          if not role_exists(role):
-              run(f"CREATE ROLE {q_ident(role)} LOGIN PASSWORD {q_lit(password)};", capture=False)
-          else:
-              run(f"ALTER ROLE {q_ident(role)} LOGIN PASSWORD {q_lit(password)};", capture=False)
-
-      def ensure_db(dbname: str, owner: str) -> None:
-          if not db_exists(dbname):
-              run(f"CREATE DATABASE {q_ident(dbname)} OWNER {q_ident(owner)};", capture=False)
-          run(f"ALTER DATABASE {q_ident(dbname)} OWNER TO {q_ident(owner)};", capture=False)
-
-      def lock_down_db(dbname: str, grp_role: str) -> None:
-          run(f"REVOKE ALL ON DATABASE {q_ident(dbname)} FROM PUBLIC;", capture=False)
-          run(f"GRANT CONNECT, TEMPORARY ON DATABASE {q_ident(dbname)} TO {q_ident(grp_role)};", capture=False)
-          run("REVOKE CREATE ON SCHEMA public FROM PUBLIC;", db=dbname, capture=False)
-          run("REVOKE USAGE ON SCHEMA public FROM PUBLIC;", db=dbname, capture=False)
-          run(f"GRANT USAGE, CREATE ON SCHEMA public TO {q_ident(grp_role)};", db=dbname, capture=False)
-
-      def grant_group_defaults(dbname: str, creator_role: str, grp_role: str) -> None:
-          run(
-              f"ALTER DEFAULT PRIVILEGES FOR ROLE {q_ident(creator_role)} IN SCHEMA public "
-              f"GRANT ALL PRIVILEGES ON TABLES TO {q_ident(grp_role)};",
-              db=dbname,
-              capture=False,
-          )
-          run(
-              f"ALTER DEFAULT PRIVILEGES FOR ROLE {q_ident(creator_role)} IN SCHEMA public "
-              f"GRANT ALL PRIVILEGES ON SEQUENCES TO {q_ident(grp_role)};",
-              db=dbname,
-              capture=False,
-          )
-
-      def grant_role(grp_role: str, user: str) -> None:
-          run(f"GRANT {q_ident(grp_role)} TO {q_ident(user)};", capture=False)
-
-      # Build group map (DIRECT): group -> {dbname, db_user, password}
-      groups = {}
-      for c in pg_creds:
-          gid = str(c.get("group")).strip()
-          if not gid or not group_token.match(gid):
-              sys.exit(f"Invalid group token: {gid!r}")
-
-          dbname = c.get("database_name") or c.get("db_name")
-          db_user = c.get("db_user")
-          pw = c.get("password")
-
-          if not isinstance(dbname, str) or not ident.match(dbname):
-              sys.exit(f"Invalid database_name for group {gid}: {dbname!r}")
-          if not isinstance(db_user, str) or not ident.match(db_user):
-              sys.exit(f"Invalid db_user for group {gid}: {db_user!r}")
-          if not isinstance(pw, str) or len(pw) < 6:
-              sys.exit(f"Invalid password for db_user {db_user!r} (min 6)")
-
-          if gid in groups:
-              sys.exit(f"Duplicate group in postgres.credentials: {gid!r}")
-          groups[gid] = {"dbname": dbname, "db_user": db_user, "password": pw}
-
-      # 1) group roles + dbs
-      for gid, info in groups.items():
-          grp_role = f"grp_{gid}"
-          ensure_group_role(grp_role)
-          ensure_db(info["dbname"], grp_role)
-          lock_down_db(info["dbname"], grp_role)
-
-      # 2) group login users
-      for gid, info in groups.items():
-          grp_role = f"grp_{gid}"
-          db_user = info["db_user"]
-          ensure_login_role(db_user, info["password"])
-          grant_role(grp_role, db_user)
-          grant_group_defaults(info["dbname"], db_user, grp_role)
-
-      # 3) optional admin (teacher)
-      if isinstance(pg_admin, dict) and pg_admin:
-          a_user = pg_admin.get("db_user")
-          a_pw = pg_admin.get("password")
-          if a_user and a_pw:
-              if not isinstance(a_user, str) or not ident.match(a_user):
-                  sys.exit(f"Invalid postgres admin db_user: {a_user!r}")
-              if not isinstance(a_pw, str) or len(a_pw) < 6:
-                  sys.exit("Invalid postgres admin password (min 6)")
-              ensure_login_role(a_user, a_pw)
-              for gid, info in groups.items():
-                  grp_role = f"grp_{gid}"
-                  grant_role(grp_role, a_user)
-                  grant_group_defaults(info["dbname"], a_user, grp_role)
-
-      print(f"Provisioned groups: {len(groups)}")
-      PY
-
-      # ------------------------------------------------------------
-      # pgAdmin (optional; only if applications includes pgadmin)
-      # NO fallback, NO deriving from postgres.
-      # ------------------------------------------------------------
-      PGADMIN_PRESENT="$(python3 - <<'PY'
-      import json
-      spec = json.load(open("/etc/dozilab/user.json"))
-      apps = spec.get("applications") or []
-      def find(name):
-          for a in apps:
-              if isinstance(a, dict) and str(a.get("name","")).lower() == name:
-                  return True
-          return False
-      print("true" if find("pgadmin") else "false")
-      PY
-      )"
-
-      if [[ "$PGADMIN_PRESENT" == "true" ]]; then
-        echo "Installing pgAdmin4 ..."
-        apt-get install -y curl ca-certificates gnupg apache2 libapache2-mod-wsgi-py3
-        install -d -m 0755 /etc/apt/keyrings
-        curl -fsS https://www.pgadmin.org/static/packages_pgadmin_org.pub | gpg --dearmor -o /etc/apt/keyrings/pgadmin.gpg
-        echo "deb [signed-by=/etc/apt/keyrings/pgadmin.gpg] https://ftp.postgresql.org/pub/pgadmin/pgadmin4/apt/jammy pgadmin4 main" > /etc/apt/sources.list.d/pgadmin4.list
-        apt-get update -y
-        apt-get install -y pgadmin4-web
-
-        echo "Configuring pgAdmin admin account (direct) ..."
-        python3 - <<'PY'
-      import json, shlex, sys
-
-      spec = json.load(open("/etc/dozilab/user.json"))
-      apps = spec.get("applications") or []
-
-      def get_app(name):
-          for a in apps:
-              if isinstance(a, dict) and str(a.get("name","")).lower() == name:
-                  return a
-          return None
-
-      pga = get_app("pgadmin") or {}
-      admin = pga.get("admin_credentials") or {}
-      email = admin.get("email")
-      pw = admin.get("password")
-
-      if not email or not pw:
-          sys.exit("pgadmin.admin_credentials missing email/password")
-      if "@" not in email:
-          sys.exit(f"pgAdmin admin email invalid: {email!r}")
-      if len(pw) < 6:
-          sys.exit("pgAdmin admin password too short (min 6)")
-
-      with open("/etc/default/pgadmin4", "w") as f:
-          print(f"PGADMIN_SETUP_EMAIL={shlex.quote(email)}", file=f)
-          print(f"PGADMIN_SETUP_PASSWORD={shlex.quote(pw)}", file=f)
-      print("pgAdmin admin email:", email)
-      PY
-
-        chmod 600 /etc/default/pgadmin4
-        rm -f /var/lib/pgadmin/pgadmin4.db
-        rm -rf /var/lib/pgadmin/sessions /var/lib/pgadmin/storage
-        install -d -m 0750 -o www-data -g www-data /var/lib/pgadmin
-
-        set -a
-        source /etc/default/pgadmin4
-        set +a
-        PGADMIN_SETUP_EMAIL="$PGADMIN_SETUP_EMAIL" \
-        PGADMIN_SETUP_PASSWORD="$PGADMIN_SETUP_PASSWORD" \
-          /usr/pgadmin4/bin/setup-web.sh --yes
-
-        a2enconf pgadmin4 || true
-        systemctl reload apache2 || true
-
-        echo "Creating pgAdmin users (direct from pgadmin.credentials) ..."
-        python3 - <<'PY'
-      import json, subprocess, sys
-
-      spec = json.load(open("/etc/dozilab/user.json"))
-      apps = spec.get("applications") or []
-
-      def get_app(name):
-          for a in apps:
-              if isinstance(a, dict) and str(a.get("name","")).lower() == name:
-                  return a
-          return None
-
-      pga = get_app("pgadmin") or {}
-      creds = pga.get("credentials") or []
-      if not isinstance(creds, list):
-          sys.exit("pgadmin.credentials must be a list")
-
-      accounts = []
-      seen = set()
-      for c in creds:
-          if not isinstance(c, dict):
-              continue
-          email = c.get("email")
-          pw = c.get("password")
-          if not email or not pw:
-              continue
-          if email in seen:
-              continue
-          seen.add(email)
-          accounts.append((email, pw))
-
-      created = 0
-      for email, pw in accounts:
-          cmd = [
-              "sudo",
-              "-u",
-              "www-data",
-              "/usr/pgadmin4/venv/bin/python",
-              "/usr/pgadmin4/web/setup.py",
-              "add-user",
-              email,
-              pw,
-              "--role",
-              "User",
-              "--active",
-          ]
-          res = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
-          out = (res.stdout or "").strip()
-          if res.returncode == 0:
-              created += 1
-              print(f"created pgAdmin user: {email}")
-          elif "already exists" in out.lower():
-              print(f"pgAdmin user already exists: {email}")
-          else:
-              print(f"WARNING: failed to create pgAdmin user {email} rc={res.returncode} {out}")
-
-      print(f"pgAdmin accounts processed: {len(accounts)}, created: {created}")
-      PY
-      fi
-
-      msg="DOZILAB_READY stack=${STACK_LABEL} time=$(date -Is)"
-      echo "$msg" | tee /dev/console > "$READY_FILE"
-      chmod 644 "$READY_FILE"
-
-      echo "DoziLab setup finished successfully"
-
-runcmd:
-  - [ bash, -lc, "/usr/local/bin/dozilab-postgres-setup.sh" ]
-
-final_message: "DoziLab Postgres + pgAdmin VM: cloud-init finished"
-
-
-"""
-
-
-def create_lecturer_user(db: Session) -> User:
-    """Create or get mock development user."""
-    existing_user = db.query(User).filter(User.external_id == "b2767751-c2d0-4d09-9400-ad520edbfe3c").first()
-    if existing_user:
-        return existing_user
-    
-    user = User(
-        external_id="b2767751-c2d0-4d09-9400-ad520edbfe3c"
-    )
-    db.add(user)
-    db.commit()
-    db.refresh(user)
-    logger.info(f"Created mock user with external_id: {user.external_id}")
-    return user
-
-
-ANSIBLE_MULTIUSER_APP_YAML = """
-app:
-  name: ansible-multiuser
-  label: Ansible Multi-User Ubuntu
-  version: 2.0.0
-  description: >
-    Ubuntu VM mit mehreren Benutzerkonten, verwaltet durch Ansible.
-    Pro Gruppe wird ein Linux-Account mit eigenem Arbeitsverzeichnis erstellt.
-  owner_team: dozilab-app-team
-
-  allow_user_files: true
-
-parameters:
-
-  - name: stack_label
-    label: Stack-Label
-    step: template
-    type: string
-    default: ansible
-    required: true
-    description: "Kurzes Label für diesen Stack (z.B. kurs-ws2026)."
-
-  - name: image
-    label: Betriebssystem-Image
-    step: konfiguration
-    type: string
-    default: "Ubuntu 22.04 2025-01"
-    required: true
-    enum:
-      - "Ubuntu 22.04 2025-01"
-      - "Ubuntu 24.04 2025-01"
-      - "Ubuntu 24.04 2026-01"
-
-  - name: flavor
-    label: VM-Größe (Flavor)
-    step: konfiguration
-    type: string
-    default: "gp1.small"
-    required: true
-    enum:
-      - "gp1.small"
-      - "gp1.medium"
-
-  - name: ssh_cidr
-    label: SSH-Zugriff (CIDR)
-    step: netzwerk
-    type: string
-    default: "141.72.0.0/16"
-    required: true
-    description: "Nur dieses Netz darf per SSH zugreifen. Standard: DHBW/VPN."
-
-  - name: force_password_change
-    label: Passwort-Änderung beim ersten Login erzwingen
-    step: zugriff
-    type: boolean
-    default: true
-    required: true
 
 credentials:
-
   per_group:
     - linux:
         username: "{{ username }}"
         password: generate
+        ssh_key: generate
 
   teacher:
+    # teacher.linux automatisch vorhanden — kein Eintrag nötig
 
 user_files:
   - name:        aufgabe_pdf
@@ -1708,15 +215,24 @@ outputs:
   - name: server_id
     label: Server ID
     from_heat_output: server_id
-"""
 
-ANSIBLE_MULTIUSER_HEAT_TEMPLATE = """
+  - name: ssh_hint
+    label: SSH Hinweis
+    from_heat_output: ssh_hint
+
+  - name: root_volume_id
+    label: Root Volume ID
+    from_heat_output: root_volume_id
+'''
+
+MULTIUSER_HEAT_TEMPLATE = r'''
 heat_template_version: 2018-08-31
 
 description: >
   DoziLab Ansible Multi-User VM.
   Nur Infrastruktur — keine user_data, keine cloud-init.
   Konfiguration übernimmt Ansible vom Backend aus per SSH.
+  Root disk is provisioned as a Cinder volume (Boot from Volume) so "Speicher" can be configured.
 
 parameters:
   image:
@@ -1727,24 +243,37 @@ parameters:
           - "Ubuntu 22.04 2025-01"
           - "Ubuntu 24.04 2025-01"
           - "Ubuntu 24.04 2026-01"
+    description: "Base image for the VM."
 
   flavor:
     type: string
     default: "gp1.small"
     constraints:
-      - allowed_values: ["gp1.small", "gp1.medium"]
+      - allowed_values:
+          - "gp1.small"
+          - "gp1.medium"
+    description: "VM size. Keep small/medium for student workloads."
+
+  volume_size:
+    type: number
+    default: 8
+    constraints:
+      - range: { min: 8, max: 200 }
+    description: "Root volume size in GB."
 
   ssh_cidr:
     type: string
     default: "141.72.0.0/16"
     constraints:
-      - allowed_pattern: '^(\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2}$'
+      - allowed_pattern: '^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$'
+    description: "IPv4 CIDR allowed to SSH and ICMP."
 
   stack_label:
     type: string
     default: "ansible"
     constraints:
       - allowed_pattern: '^[a-z0-9][a-z0-9-]{0,30}$'
+    description: "Internal label used for resource names/metadata."
 
   network:
     type: string
@@ -1760,6 +289,7 @@ parameters:
 
   key_name:
     type: string
+    description: "Admin/support SSH keypair. Backend should set this from ANSIBLE_SSH_KEY_NAME."
 
 resources:
   secgroup:
@@ -1768,11 +298,14 @@ resources:
       description: SSH + ICMP aus erlaubtem CIDR
       rules:
         - direction: ingress
+          ethertype: IPv4
           protocol: tcp
           port_range_min: 22
           port_range_max: 22
           remote_ip_prefix: { get_param: ssh_cidr }
+
         - direction: ingress
+          ethertype: IPv4
           protocol: icmp
           remote_ip_prefix: { get_param: ssh_cidr }
 
@@ -1783,19 +316,42 @@ resources:
       security_groups:
         - { get_resource: secgroup }
 
+  root_volume:
+    type: OS::Cinder::Volume
+    properties:
+      name:
+        str_replace:
+          template: "dozilab-STACK-root"
+          params:
+            STACK: { get_param: stack_label }
+      size: { get_param: volume_size }
+      image: { get_param: image }
+      metadata:
+        dozilab_stack_label: { get_param: stack_label }
+
   server:
     type: OS::Nova::Server
     properties:
       name:
         str_replace:
-          template: "dozilab-LABEL"
+          template: "dozilab-STACK"
           params:
-            LABEL: { get_param: stack_label }
-      image:    { get_param: image }
-      flavor:   { get_param: flavor }
+            STACK: { get_param: stack_label }
+
+      flavor: { get_param: flavor }
       key_name: { get_param: key_name }
+
+      block_device_mapping_v2:
+        - boot_index: 0
+          volume_id: { get_resource: root_volume }
+          delete_on_termination: true
+
       networks:
         - port: { get_resource: port }
+
+      metadata:
+        dozilab_stack_label: { get_param: stack_label }
+        dozilab_config_method: "ansible"
 
   fip:
     type: OS::Neutron::FloatingIP
@@ -1806,159 +362,322 @@ resources:
     type: OS::Neutron::FloatingIPAssociation
     properties:
       floatingip_id: { get_resource: fip }
-      port_id:       { get_resource: port }
+      port_id: { get_resource: port }
 
 outputs:
   floating_ip:
+    description: "Public floating IP address."
     value: { get_attr: [fip, floating_ip_address] }
 
   server_id:
+    description: "Nova server ID."
     value: { get_resource: server }
-"""
 
-ANSIBLE_MULTIUSER_PLAYBOOK = """
+  ssh_hint:
+    description: "Students login like: ssh <username>@<floating_ip>"
+    value:
+      str_replace:
+        template: "ssh <username>@FIP"
+        params:
+          FIP: { get_attr: [fip, floating_ip_address] }
+
+  root_volume_id:
+    description: "Cinder root volume ID."
+    value: { get_resource: root_volume }'''
+
+MULTIUSER_PLAYBOOK = r'''
 ---
+# DoziLab Ansible Playbook: Multi-User Ubuntu
+#
+# Variablen (vom Backend):
+#   deployment_groups[].username                         # sanitized Linux-User pro Gruppe
+#   deployment_groups[].linux.password
+#   deployment_groups[].linux.ssh_key.public_key         # optional (nur wenn app.yaml: ssh_key: generate)
+#   deployment_groups[].linux.ssh_key.private_key        # optional, nur informativ — wird NICHT auf die VM kopiert
+#   deployment_groups[].group_name                       # Original-Gruppenname (für user_files-Lookup)
+#   stack_label
+#   force_password_change
+#   workdir
+#   pw_min_length
+#   pw_require_digit
+#   pw_require_upper
+#   pw_require_special
+#   user_files.aufgabe_pdf.exists
+#   user_files.material_gruppe[group_name].exists
+#
+# Hinweis: ``deployment_groups`` heißt NICHT ``groups`` — letzteres ist eine
+# reservierte Ansible-Magic-Variable (Inventory-Dict). Würden wir unsere
+# Group-Liste so nennen, würde Ansible sie mit dem Inventory-Dict
+# überschreiben und alle loop-Tasks unten würden über etwas ganz anderes
+# iterieren.
+
 - name: DoziLab Multi-User Setup
   hosts: all
   remote_user: ubuntu
   become: true
 
+  vars:
+    dozilab_workdir: "{{ workdir | default('work') }}"
+    dozilab_pw_min_length: "{{ pw_min_length | default(12) }}"
+    dozilab_pw_require_digit: "{{ pw_require_digit | default(true) }}"
+    dozilab_pw_require_upper: "{{ pw_require_upper | default(true) }}"
+    dozilab_pw_require_special: "{{ pw_require_special | default(true) }}"
+
   tasks:
+    - name: Arbeitsordner-Parameter validieren
+      assert:
+        that:
+          - dozilab_workdir is match('^[A-Za-z0-9._-]{1,32}$')
+        fail_msg: "Invalid workdir. Allowed pattern: ^[A-Za-z0-9._-]{1,32}$"
+
+    - name: Passwort-Mindestlänge validieren
+      assert:
+        that:
+          - (dozilab_pw_min_length | int) >= 4
+          - (dozilab_pw_min_length | int) <= 128
+        fail_msg: "pw_min_length must be between 4 and 128."
+
+    - name: Benötigte Pakete installieren
+      apt:
+        name:
+          - libpam-pwquality
+          - python3
+          - cloud-guest-utils
+        state: present
+        update_cache: true
+
+    - name: Passwort-Policy Variablen berechnen
+      set_fact:
+        pw_dcredit: "{{ '-1' if (dozilab_pw_require_digit | bool) else '0' }}"
+        pw_ucredit: "{{ '-1' if (dozilab_pw_require_upper | bool) else '0' }}"
+        pw_ocredit: "{{ '-1' if (dozilab_pw_require_special | bool) else '0' }}"
+
+    - name: pwquality.conf schreiben
+      copy:
+        dest: /etc/security/pwquality.conf
+        owner: root
+        group: root
+        mode: "0644"
+        content: |
+          # Managed by DoziLab (Ansible). NOTE: PAM options override this file.
+          minlen = {{ dozilab_pw_min_length | int }}
+          dcredit = {{ pw_dcredit }}
+          ucredit = {{ pw_ucredit }}
+          ocredit = {{ pw_ocredit }}
+          dictcheck = 0
+          usercheck = 0
+          gecoscheck = 0
+          difok = 0
+          maxrepeat = 0
+          minclass = 0
+
+    - name: Prüfen ob pam_pwquality bereits konfiguriert ist
+      command: grep -qE '^\s*password\s+requisite\s+pam_pwquality\.so' /etc/pam.d/common-password
+      register: pam_pwquality_check
+      changed_when: false
+      failed_when: false
+
+    - name: Bestehende pam_pwquality Zeile ersetzen
+      replace:
+        path: /etc/pam.d/common-password
+        regexp: '^\s*password\s+requisite\s+pam_pwquality\.so.*$'
+        replace: "password requisite pam_pwquality.so retry=3 enforce_for_root minlen={{ dozilab_pw_min_length | int }} dcredit={{ pw_dcredit }} ucredit={{ pw_ucredit }} ocredit={{ pw_ocredit }} dictcheck=0 usercheck=0 gecoscheck=0 difok=0 maxrepeat=0 minclass=0"
+      when: pam_pwquality_check.rc == 0
+
+    - name: pam_pwquality vor pam_unix einfügen
+      lineinfile:
+        path: /etc/pam.d/common-password
+        insertbefore: '^\s*password\s+.*pam_unix\.so'
+        line: "password requisite pam_pwquality.so retry=3 enforce_for_root minlen={{ dozilab_pw_min_length | int }} dcredit={{ pw_dcredit }} ucredit={{ pw_ucredit }} ocredit={{ pw_ocredit }} dictcheck=0 usercheck=0 gecoscheck=0 difok=0 maxrepeat=0 minclass=0"
+      when: pam_pwquality_check.rc != 0
 
     - name: /opt/dozilab nur für root zugänglich machen
       file:
-        path:  /opt/dozilab
+        path: /opt/dozilab
         state: directory
         owner: root
         group: root
-        mode:  "0700"
+        mode: "0700"
 
-    - name: Student Accounts erstellen
+    - name: Gruppen-Linux-Accounts erstellen
       user:
-        name:        "{{ item.username }}"
-        shell:       /bin/bash
+        name: "{{ item.username }}"
+        shell: /bin/bash
         create_home: true
-        state:       present
-      loop: "{{ students }}"
+        state: present
+      loop: "{{ deployment_groups }}"
       no_log: true
 
     - name: Passwörter setzen
       user:
-        name:     "{{ item.username }}"
+        name: "{{ item.username }}"
         password: "{{ item.linux.password | password_hash('sha512') }}"
         update_password: always
-      loop: "{{ students }}"
+      loop: "{{ deployment_groups }}"
+      no_log: true
+
+    - name: Gruppen-SSH-Public-Key in authorized_keys installieren
+      # Backend generiert per app.yaml `ssh_key: generate` ein Ed25519-Keypair
+      # pro Gruppe. Der Public-Key landet hier in ~/.ssh/authorized_keys des
+      # Gruppen-Linux-Users, der Private-Key bleibt in der Backend-DB und wird
+      # via /student-API zum Download bereitgestellt. Task ist no-op für
+      # Gruppen ohne Keypair (z.B. Apps die `ssh_key: generate` nicht setzen).
+      ansible.posix.authorized_key:
+        user:  "{{ item.username }}"
+        key:   "{{ item.linux.ssh_key.public_key }}"
+        state: present
+      loop: "{{ deployment_groups }}"
+      when: item.linux.ssh_key is defined and item.linux.ssh_key.public_key is defined
       no_log: true
 
     - name: Passwort-Änderung beim ersten Login erzwingen
       command: chage -d 0 {{ item.username }}
-      loop: "{{ students }}"
+      loop: "{{ deployment_groups }}"
       no_log: true
       when: force_password_change | bool
 
+    - name: Home-Verzeichnis absichern
+      file:
+        path: "/home/{{ item.username }}"
+        owner: "{{ item.username }}"
+        group: "{{ item.username }}"
+        mode: "0700"
+      loop: "{{ deployment_groups }}"
+      no_log: true
+
     - name: Arbeitsverzeichnis erstellen
       file:
-        path:  "/home/{{ item.username }}/work"
+        path: "/home/{{ item.username }}/{{ dozilab_workdir }}"
         state: directory
         owner: "{{ item.username }}"
         group: "{{ item.username }}"
-        mode:  "0700"
-      loop: "{{ students }}"
+        mode: "0700"
+      loop: "{{ deployment_groups }}"
       no_log: true
 
-    - name: .bashrc für jeden Student setzen
-      copy:
-        src:   /opt/dozilab/files/bashrc
-        dest:  "/home/{{ item.username }}/.bashrc"
+    - name: Standard-Login-Verzeichnis in .profile setzen
+      lineinfile:
+        path: "/home/{{ item.username }}/.profile"
+        line: 'cd "$HOME/{{ dozilab_workdir }}"'
+        create: true
         owner: "{{ item.username }}"
         group: "{{ item.username }}"
-        mode:  "0644"
+        mode: "0644"
+      loop: "{{ deployment_groups }}"
+      no_log: true
+
+    - name: .bashrc für jeden Gruppen-User setzen
+      copy:
+        src: /opt/dozilab/files/bashrc
+        dest: "/home/{{ item.username }}/.bashrc"
+        owner: "{{ item.username }}"
+        group: "{{ item.username }}"
+        mode: "0644"
         remote_src: true
-      loop: "{{ students }}"
+      loop: "{{ deployment_groups }}"
+      no_log: true
+
+    - name: Arbeitsordner in .bashrc ersetzen
+      replace:
+        path: "/home/{{ item.username }}/.bashrc"
+        regexp: "__WORKDIR__"
+        replace: "{{ dozilab_workdir }}"
+      loop: "{{ deployment_groups }}"
       no_log: true
 
     - name: MOTD setzen
       shell: |
-        sed 's/__STACK_LABEL__/{{ stack_label }}/g' \\
+        sed 's/__STACK_LABEL__/{{ stack_label }}/g' \
           /opt/dozilab/files/motd > /etc/update-motd.d/99-dozilab
         chmod +x /etc/update-motd.d/99-dozilab
 
     - name: Scripts ausführbar machen
       file:
-        path:  "{{ item }}"
-        mode:  "0755"
+        path: "{{ item }}"
+        mode: "0755"
       loop:
         - /opt/dozilab/scripts/check_student_setup.sh
         - /opt/dozilab/scripts/reset_password.sh
 
-    - name: Student-Setup verifizieren
-      command: /opt/dozilab/scripts/check_student_setup.sh {{ item.username }}
-      loop: "{{ students }}"
+    - name: Gruppen-Setup verifizieren
+      command: /opt/dozilab/scripts/check_student_setup.sh {{ item.username }} {{ dozilab_workdir }}
+      loop: "{{ deployment_groups }}"
       register: check_result
       changed_when: false
       no_log: true
 
     - name: Aufgabenstellung in Arbeitsverzeichnis kopieren
       copy:
-        src:   /opt/dozilab/user-files/aufgabe.pdf
-        dest:  "/home/{{ item.username }}/work/aufgabe.pdf"
+        src: /opt/dozilab/user-files/aufgabe.pdf
+        dest: "/home/{{ item.username }}/{{ dozilab_workdir }}/aufgabe.pdf"
         owner: "{{ item.username }}"
-        mode:  "0644"
+        group: "{{ item.username }}"
+        mode: "0644"
         remote_src: true
-      loop: "{{ students }}"
+      loop: "{{ deployment_groups }}"
       no_log: true
       when: user_files.aufgabe_pdf.exists | default(false)
 
     - name: Gruppenverzeichnis für Material erstellen
       file:
-        path:  "/home/{{ item.username }}/work/material"
+        path: "/home/{{ item.username }}/{{ dozilab_workdir }}/material"
         state: directory
         owner: "{{ item.username }}"
-        mode:  "0700"
-      loop: "{{ students }}"
+        group: "{{ item.username }}"
+        mode: "0700"
+      loop: "{{ deployment_groups }}"
       no_log: true
       when: user_files.material_gruppe[item.group_name].exists | default(false)
 
     - name: Gruppenmaterial in Arbeitsverzeichnis kopieren
       copy:
-        src:   "/opt/dozilab/user-files/{{ item.group_name }}/material"
-        dest:  "/home/{{ item.username }}/work/material/"
+        src: "/opt/dozilab/user-files/{{ item.group_name }}/material"
+        dest: "/home/{{ item.username }}/{{ dozilab_workdir }}/material/"
         owner: "{{ item.username }}"
-        mode:  "0600"
+        group: "{{ item.username }}"
+        mode: "0600"
         remote_src: true
-      loop: "{{ students }}"
+      loop: "{{ deployment_groups }}"
       no_log: true
       when: user_files.material_gruppe[item.group_name].exists | default(false)
-"""
+'''
 
-
-ANSIBLE_MULTIUSER_BASHRC = """# ==============================================================================
-# DoziLab: .bashrc für Student-Accounts
+MULTIUSER_BASHRC = r'''
 # ==============================================================================
+# DoziLab: .bashrc für Student-Accounts
+# Wird von Ansible in jeden Home-Ordner kopiert.
+# ==============================================================================
+
+# Basis
 export HISTSIZE=1000
 export HISTFILESIZE=2000
 export EDITOR=nano
 
+# Farben im Terminal
 force_color_prompt=yes
-PS1='\\[\\033[01;32m\\]\\u@\\h\\[\\033[00m\\]:\\[\\033[01;34m\\]\\w\\[\\033[00m\\]\\$ '
+PS1='\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
 
+# Praktische Aliase
 alias ll='ls -alF'
 alias la='ls -A'
 alias l='ls -CF'
 alias ..='cd ..'
-alias work='cd ~/work'
+alias work='cd ~/__WORKDIR__'
 
+# Begrüßung beim Login
 echo ""
 echo "  Willkommen, $(whoami)!"
-echo "  Dein Arbeitsverzeichnis: ~/work"
+echo "  Dein Arbeitsverzeichnis: ~/__WORKDIR__"
 echo ""
-"""
+'''
 
-ANSIBLE_MULTIUSER_MOTD = """#!/usr/bin/env bash
+MULTIUSER_MOTD = r'''
+#!/usr/bin/env bash
 # ==============================================================================
-# DoziLab: Message of the Day
+# DoziLab: Message of the Day — wird beim SSH-Login angezeigt.
 # Platzhalter __STACK_LABEL__ wird vom Playbook ersetzt.
 # ==============================================================================
+
 echo ""
 echo "  ██████╗  ██████╗ ███████╗██╗██╗      █████╗ ██████╗ "
 echo "  ██╔══██╗██╔═══██╗╚══███╔╝██║██║     ██╔══██╗██╔══██╗"
@@ -1970,288 +689,1523 @@ echo ""
 echo "  Kurs:    __STACK_LABEL__"
 echo "  Support: Wende dich an deinen Dozenten"
 echo ""
-"""
+'''
 
-ANSIBLE_MULTIUSER_CHECK_SCRIPT = """#!/usr/bin/env bash
+MULTIUSER_CHECK_SCRIPT = r'''
+#!/usr/bin/env bash
+# ==============================================================================
+# DoziLab: Check ob ein Student-Account korrekt eingerichtet ist.
+# Wird vom Playbook nach dem Setup aufgerufen.
+#
+# Usage: check_student_setup.sh <username> [workdir]
+# Gibt 0 zurück wenn alles OK, 1 wenn etwas fehlt.
+# ==============================================================================
 set -euo pipefail
-USERNAME="${1:?Usage: check_student_setup.sh <username>}"
+
+USERNAME="${1:?Usage: check_student_setup.sh <username> [workdir]}"
+WORKDIR="${2:-work}"
 ERRORS=0
 
 check() {
-    local desc="$1"; local result="$2"
-    if [[ "$result" == "ok" ]]; then echo "  ✓ $desc"
-    else echo "  ✗ $desc → $result"; ERRORS=$((ERRORS + 1)); fi
+    local desc="$1"
+    local result="$2"
+    if [[ "$result" == "ok" ]]; then
+        echo "  ✓ $desc"
+    else
+        echo "  ✗ $desc → $result"
+        ERRORS=$((ERRORS + 1))
+    fi
 }
 
 echo "Checking setup for: $USERNAME"
-id "$USERNAME" &>/dev/null && check "Account existiert" "ok" || check "Account existiert" "nicht gefunden"
-[[ -d "/home/$USERNAME" ]] && check "Home-Verzeichnis" "ok" || check "Home-Verzeichnis" "fehlt"
-[[ -d "/home/$USERNAME/work" ]] && check "Arbeitsverzeichnis" "ok" || check "Arbeitsverzeichnis" "fehlt"
-passwd -S "$USERNAME" 2>/dev/null | grep -qv " L " && check "Passwort gesetzt" "ok" || check "Passwort gesetzt" "gesperrt"
-SHELL=$(getent passwd "$USERNAME" | cut -d: -f7)
-[[ "$SHELL" == "/bin/bash" ]] && check "Shell ist /bin/bash" "ok" || check "Shell ist /bin/bash" "ist $SHELL"
+echo "Expected workdir: $WORKDIR"
+
+id "$USERNAME" &>/dev/null \
+    && check "Account existiert" "ok" \
+    || check "Account existiert" "nicht gefunden"
+
+[[ -d "/home/$USERNAME" ]] \
+    && check "Home-Verzeichnis /home/$USERNAME" "ok" \
+    || check "Home-Verzeichnis /home/$USERNAME" "fehlt"
+
+[[ -d "/home/$USERNAME/$WORKDIR" ]] \
+    && check "Arbeitsverzeichnis /home/$USERNAME/$WORKDIR" "ok" \
+    || check "Arbeitsverzeichnis /home/$USERNAME/$WORKDIR" "fehlt"
+
+passwd -S "$USERNAME" 2>/dev/null | grep -qv " L " \
+    && check "Passwort gesetzt" "ok" \
+    || check "Passwort gesetzt" "Account gesperrt oder kein Passwort"
+
+USER_SHELL=$(getent passwd "$USERNAME" | cut -d: -f7)
+[[ "$USER_SHELL" == "/bin/bash" ]] \
+    && check "Shell ist /bin/bash" "ok" \
+    || check "Shell ist /bin/bash" "ist $USER_SHELL"
 
 echo ""
-if [[ $ERRORS -eq 0 ]]; then echo "✓ Setup OK für $USERNAME"; exit 0
-else echo "✗ $ERRORS Fehler für $USERNAME"; exit 1; fi
-"""
+if [[ $ERRORS -eq 0 ]]; then
+    echo "✓ Setup OK für $USERNAME"
+    exit 0
+else
+    echo "✗ $ERRORS Fehler gefunden für $USERNAME"
+    exit 1
+fi
+'''
 
-ANSIBLE_MULTIUSER_RESET_SCRIPT = """#!/usr/bin/env bash
+MULTIUSER_RESET_SCRIPT = r'''
+#!/usr/bin/env bash
+# ==============================================================================
+# DoziLab: Passwort eines Student-Accounts zurücksetzen.
+# Kann vom Lehrer manuell aufgerufen werden.
+#
+# Usage: reset_password.sh <username> <new_password>
+# ==============================================================================
 set -euo pipefail
+
 USERNAME="${1:?Usage: reset_password.sh <username> <new_password>}"
 NEW_PASSWORD="${2:?Usage: reset_password.sh <username> <new_password>}"
-if ! id "$USERNAME" &>/dev/null; then echo "ERROR: Account '$USERNAME' nicht gefunden" >&2; exit 1; fi
+
+# Prüfen ob Account existiert
+if ! id "$USERNAME" &>/dev/null; then
+    echo "ERROR: Account '$USERNAME' nicht gefunden" >&2
+    exit 1
+fi
+
+# Passwort setzen
 echo "${USERNAME}:${NEW_PASSWORD}" | chpasswd
 echo "✓ Passwort für '$USERNAME' zurückgesetzt"
+
+# Passwort-Änderung beim nächsten Login erzwingen
 chage -d 0 "$USERNAME"
 echo "✓ Passwort-Änderung beim nächsten Login erzwungen"
-"""
+'''
+
+POSTGRES_APP_YAML = r'''
+app:
+  name: ansible-postgres-group-db
+  label: Ansible PostgreSQL Group DB
+  version: 2.0.0
+  description: >
+    Ubuntu VM mit PostgreSQL, Gruppen-Datenbanken, Teacher-Zugriff und optionalem pgAdmin.
+    Infrastruktur wird per Heat erstellt, Konfiguration läuft per Ansible.
+  owner_team: dozilab-app-team
+
+artifacts:
+  heat_template: heat/main.yaml
+  ansible_playbook: playbooks/main.yml
+
+# ------------------------------------------------------------------------------
+# Parameter
+# ------------------------------------------------------------------------------
+parameters:
+
+  # --- Schritt 1: Template ---
+
+  - name: stack_label
+    label: Stack-Label
+    step: template
+    type: string
+    default: sql
+    required: true
+    description: "Kurzes Label für diesen Stack, z.B. sql-2026-01."
+
+  # --- Schritt 2: Konfiguration ---
+
+  - name: image
+    label: Betriebssystem-Image
+    step: konfiguration
+    type: string
+    default: "Ubuntu 22.04 2025-01"
+    required: true
+    enum:
+      - "Ubuntu 22.04 2025-01"
+      - "Ubuntu 24.04 2025-01"
+      - "Ubuntu 24.04 2026-01"
+
+  - name: flavor
+    label: VM-Größe (Flavor)
+    step: konfiguration
+    type: string
+    default: "gp1.small"
+    required: true
+    enum:
+      - "gp1.small"
+      - "gp1.medium"
+      - "gp1.large"
+      - "mb1.small"
+      - "mb1.medium"
+      - "mb1.large"
+    description: >
+      VM-Größe für PostgreSQL und optional pgAdmin.
+      gp1.small reicht für kleine Kurse und Tests.
+      Für größere Kurse oder pgAdmin-Nutzung sind gp1.medium, gp1.large oder mb1.* sinnvoll.
+
+  - name: volume_size
+    label: Speicher (GB)
+    step: konfiguration
+    type: number
+    default: 8
+    required: true
+    enum:
+      - 8
+      - 16
+      - 32
+      - 64
+      - 128
+    description: "Größe der Root-Disk als Cinder-Volume."
+
+  # --- Schritt 3: Netzwerk ---
+
+  - name: ssh_cidr
+    label: SSH-Zugriff (CIDR)
+    step: netzwerk
+    type: string
+    default: "141.72.0.0/16"
+    required: true
+    description: "Nur dieses Netz darf per SSH zugreifen. Standard: DHBW/VPN."
+
+  - name: web_cidr
+    label: pgAdmin-Zugriff (CIDR)
+    step: netzwerk
+    type: string
+    default: "141.72.0.0/16"
+    required: true
+    description: "Nur dieses Netz darf pgAdmin über HTTP Port 80 erreichen."
+
+  # --- Plattform-fest / hidden ---
+
+  - name: network
+    label: Internes Netzwerk
+    step: netzwerk
+    type: string
+    default: "NAT"
+    hidden: true
+    description: "Internes OpenStack-Netzwerk."
+
+  - name: external_network
+    label: Externes Netzwerk
+    step: netzwerk
+    type: string
+    default: "DHBW"
+    hidden: true
+    description: "Floating-IP-Netzwerk."
 
 
-def create_mock_templates(db: Session, owner_id: str) -> list[Template]:
-    """Create mock templates."""
-    templates_data = [
-        {
-            "name": "Ansible Multi-User Ubuntu",
-            "description": "Ubuntu VM mit mehreren Benutzerkonten, verwaltet durch Ansible. Pro Gruppe wird ein Linux-Account mit eigenem Arbeitsverzeichnis erstellt.",
-            "repo_url": "https://github.com/dozilab/appstore-templates",
-            "icon_url": "mdi:server-network",
-            "visibility": TemplateVisibility.PUBLIC,
-        },
-        {
-            "name": "PostgreSQL Group Database",
-            "description": "Deploy a PostgreSQL database server where each student group gets its own database and role. Optional pgAdmin4 web interface for database management",
-            "repo_url": "https://github.com/dozilab/appstore-templates",
-            "icon_url": "mdi:database",
-            "visibility": TemplateVisibility.PUBLIC,
-        }
-    ]
-    
-    templates = []
-    for data in templates_data:
-        # Check if template already exists
-        existing = db.query(Template).filter(Template.name == data["name"]).first()
-        if existing:
-            logger.info(f"Template '{data['name']}' already exists, skipping creation (ID: {existing.id})")
-            templates.append(existing)
-            continue
-        
-        try:
-            template = Template(
-                owner_id=owner_id,
-                **data
-            )
-            db.add(template)
-            db.commit()
-            db.refresh(template)
-            templates.append(template)
-            logger.info(f"Created template: {template.name} (ID: {template.id})")
-        except Exception as e:
-            logger.error(f"Failed to create template '{data['name']}': {e}")
-            db.rollback()
-            raise
-    
-    logger.info(f"Total templates: {len(templates)} (created or existing)")
-    return templates
+# ------------------------------------------------------------------------------
+# Credentials
+# ------------------------------------------------------------------------------
+credentials:
+  per_group:
+    - postgres:
+        database_name: "db_{{ username }}"
+        db_user: "{{ username }}"
+        password: generate
 
+    - pgadmin:
+        email: "{{ email }}"
+        password: generate
 
-def create_mock_template_versions(db: Session, templates: list[Template]) -> list[TemplateVersion]:
-    """Create mock template versions."""
-    versions = []
-    
-    for template in templates:
-        # Check if version already exists
-        existing = db.query(TemplateVersion).filter(
-            TemplateVersion.template_id == template.id
-        ).first()
-        
-        if existing:
-            logger.info(f"Template version already exists for '{template.name}', skipping creation (Version ID: {existing.id})")
-            versions.append(existing)
-            continue
-        
-        try:
-            version = TemplateVersion(
-                template_id=template.id,
-                version="1.0.0",
-                git_commit_sha=f"v1.0.0-{template.name.lower().replace(' ', '-')}",
-                is_active=True
-            )
-            db.add(version)
-            db.commit()
-            db.refresh(version)
-            versions.append(version)
-            logger.info(f"Created version for template: {template.name} (Version ID: {version.id})")
-        except Exception as e:
-            logger.error(f"Failed to create version for template '{template.name}': {e}")
-            db.rollback()
-            raise
-    
-    return versions
+  teacher:
+    - postgres:
+        db_user: teacher
+        password: generate
 
+    - pgadmin:
+        email: "{{ email }}"
+        password: generate
 
-def create_mock_template_files(db: Session, versions: list[TemplateVersion]) -> None:
-    """Create mock template version files."""
-    files_created = 0
-    files_skipped = 0
-    files_failed = 0
-    
-    for version in versions:
-        try:
-            # Check if files already exist
-            existing_files = db.query(TemplateVersionFile).filter(
-                TemplateVersionFile.template_version_id == version.id
-            ).count()
-            
-            if existing_files > 0:
-                logger.info(f"Files already exist for version {version.id}, skipping (count: {existing_files})")
-                files_skipped += 1
-                continue
-            
-            # Get template to determine which files to create
-            template = db.query(Template).filter(Template.id == version.template_id).first()
-            if not template:
-                logger.warning(f"Template not found for version {version.id} (template_id: {version.template_id})")
-                files_failed += 1
-                continue
-            
-            logger.info(f"Creating files for version {version.id} (template: {template.name})")
-            
-            # Determine which template files to use based on template name
-            if template.name == "Ansible Multi-User Ubuntu":
-                app_yaml_content = ANSIBLE_MULTIUSER_APP_YAML
-                heat_template_content = ANSIBLE_MULTIUSER_HEAT_TEMPLATE
-                cloud_init_content = None
-                heat_file_name = "main.yaml"
-                heat_file_path = "heat/main.yaml"
+# ------------------------------------------------------------------------------
+# Outputs
+# ------------------------------------------------------------------------------
+outputs:
+  - name: ssh_user
+    label: SSH User
+    from_heat_output: ssh_user
+
+  - name: floating_ip
+    label: Floating IP
+    from_heat_output: floating_ip
+
+  - name: pgadmin_url
+    label: pgAdmin URL
+    from_heat_output: pgadmin_url'''
+
+POSTGRES_HEAT_TEMPLATE = r'''
+heat_template_version: 2018-08-31
+
+description: >
+  DoziLab Ansible PostgreSQL Group DB VM.
+  Nur Infrastruktur — keine user_data, keine cloud-init.
+  Konfiguration übernimmt Ansible vom Backend aus per SSH.
+  Root disk is a Cinder volume (Boot from Volume) so "Speicher" can be configured.
+
+parameters:
+  image:
+    type: string
+    default: "Ubuntu 22.04 2025-01"
+    constraints:
+      - allowed_values:
+          - "Ubuntu 22.04 2025-01"
+          - "Ubuntu 24.04 2025-01"
+          - "Ubuntu 24.04 2026-01"
+    description: "Base image for the VM."
+
+  flavor:
+    type: string
+    default: "gp1.small"
+    constraints:
+      - allowed_values:
+          - "gp1.small"
+          - "gp1.medium"
+          - "gp1.large"
+          - "mb1.small"
+          - "mb1.medium"
+          - "mb1.large"
+    description: "VM size for PostgreSQL and optional pgAdmin."
+
+  volume_size:
+    type: number
+    default: 8
+    constraints:
+      - range: { min: 8, max: 200 }
+    description: "Root volume size in GB."
+
+  ssh_cidr:
+    type: string
+    default: "141.72.0.0/16"
+    constraints:
+      - allowed_pattern: '^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$'
+    description: "IPv4 CIDR allowed to SSH and ICMP."
+
+  web_cidr:
+    type: string
+    default: "141.72.0.0/16"
+    constraints:
+      - allowed_pattern: '^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$'
+    description: "IPv4 CIDR allowed to reach pgAdmin over HTTP."
+
+  stack_label:
+    type: string
+    default: "sql"
+    constraints:
+      - allowed_pattern: '^[a-z0-9][a-z0-9-]{0,30}$'
+    description: "Internal label used for resource names/metadata."
+
+  network:
+    type: string
+    default: "NAT"
+    constraints:
+      - allowed_values: ["NAT"]
+
+  external_network:
+    type: string
+    default: "DHBW"
+    constraints:
+      - allowed_values: ["DHBW"]
+
+  key_name:
+    type: string
+    description: "Admin/support SSH keypair. Backend should set this from ANSIBLE_SSH_KEY_NAME."
+
+resources:
+  secgroup:
+    type: OS::Neutron::SecurityGroup
+    properties:
+      description: SSH, ICMP und pgAdmin HTTP aus erlaubten CIDRs
+      rules:
+        - direction: ingress
+          ethertype: IPv4
+          protocol: tcp
+          port_range_min: 22
+          port_range_max: 22
+          remote_ip_prefix: { get_param: ssh_cidr }
+
+        - direction: ingress
+          ethertype: IPv4
+          protocol: icmp
+          remote_ip_prefix: { get_param: ssh_cidr }
+
+        - direction: ingress
+          ethertype: IPv4
+          protocol: tcp
+          port_range_min: 80
+          port_range_max: 80
+          remote_ip_prefix: { get_param: web_cidr }
+
+        - direction: egress
+          ethertype: IPv4
+
+  port:
+    type: OS::Neutron::Port
+    properties:
+      network: { get_param: network }
+      security_groups:
+        - { get_resource: secgroup }
+
+  root_volume:
+    type: OS::Cinder::Volume
+    properties:
+      name:
+        str_replace:
+          template: "dozilab-pg-STACK-root"
+          params:
+            STACK: { get_param: stack_label }
+      size: { get_param: volume_size }
+      image: { get_param: image }
+      metadata:
+        dozilab_stack_label: { get_param: stack_label }
+        dozilab_app: "ansible-postgres-group-db"
+
+  server:
+    type: OS::Nova::Server
+    properties:
+      name:
+        str_replace:
+          template: "dozilab-pg-STACK"
+          params:
+            STACK: { get_param: stack_label }
+
+      flavor: { get_param: flavor }
+      key_name: { get_param: key_name }
+
+      block_device_mapping_v2:
+        - boot_index: 0
+          volume_id: { get_resource: root_volume }
+          delete_on_termination: true
+
+      networks:
+        - port: { get_resource: port }
+
+      metadata:
+        dozilab_stack_label: { get_param: stack_label }
+        dozilab_config_method: "ansible"
+        dozilab_app: "ansible-postgres-group-db"
+
+  fip:
+    type: OS::Neutron::FloatingIP
+    properties:
+      floating_network: { get_param: external_network }
+
+  fip_assoc:
+    type: OS::Neutron::FloatingIPAssociation
+    properties:
+      floatingip_id: { get_resource: fip }
+      port_id: { get_resource: port }
+
+outputs:
+  ssh_user:
+    description: "SSH username."
+    value: ubuntu
+
+  floating_ip:
+    description: "Public floating IP address."
+    value: { get_attr: [fip, floating_ip_address] }
+
+  private_ip:
+    description: "Private IP on tenant network."
+    value: { get_attr: [port, fixed_ips, 0, ip_address] }
+
+  server_id:
+    description: "Nova server ID."
+    value: { get_resource: server }
+
+  pgadmin_url:
+    description: "pgAdmin4 URL."
+    value:
+      str_replace:
+        template: "http://FIP/pgadmin4/"
+        params:
+          FIP: { get_attr: [fip, floating_ip_address] }
+
+  ssh_hint:
+    description: "Admin SSH command."
+    value:
+      str_replace:
+        template: "ssh -i ~/.ssh/heat-bastion-key.pem ubuntu@FIP"
+        params:
+          FIP: { get_attr: [fip, floating_ip_address] }
+
+  ssh_tunnel_hint:
+    description: "PostgreSQL SSH tunnel command."
+    value:
+      str_replace:
+        template: "ssh -i ~/.ssh/heat-bastion-key.pem -L 5432:127.0.0.1:5432 ubuntu@FIP"
+        params:
+          FIP: { get_attr: [fip, floating_ip_address] }
+
+  root_volume_id:
+    description: "Cinder root volume ID."
+    value: { get_resource: root_volume }'''
+
+POSTGRES_PLAYBOOK = r'''
+---
+- name: DoziLab Ansible PostgreSQL Group DB Setup
+  hosts: all
+  remote_user: ubuntu
+  become: true
+
+  vars:
+    dozilab_stack_label: "{{ stack_label | default('sql') }}"
+    dozilab_mark_dir: /var/lib/dozilab
+    dozilab_user_json_path: /etc/dozilab/user.json
+    dozilab_postgres_log: /var/log/dozilab-postgres-ansible.log
+
+  tasks:
+    - name: Stack-Label validieren
+      assert:
+        that:
+          - dozilab_stack_label is match('^[a-z0-9][a-z0-9-]{0,30}$')
+        fail_msg: "stack_label muss ^[a-z0-9][a-z0-9-]{0,30}$ erfüllen."
+
+    - name: DoziLab Verzeichnisse erstellen
+      file:
+        path: "{{ item.path }}"
+        state: directory
+        owner: root
+        group: root
+        mode: "{{ item.mode }}"
+      loop:
+        - { path: "/etc/dozilab", mode: "0700" }
+        - { path: "{{ dozilab_mark_dir }}", mode: "0755" }
+
+    - name: Backend-Credentials validieren
+      assert:
+        that:
+          - deployment_groups is defined
+          - deployment_groups | length > 0
+          - teacher is defined
+          - teacher.postgres is defined
+          - teacher.postgres.db_user is defined
+          - teacher.postgres.password is defined
+          - teacher.pgadmin is defined
+          - teacher.pgadmin.email is defined
+          - teacher.pgadmin.password is defined
+        fail_msg: "Backend-Credentials fehlen. Erwartet werden deployment_groups[].postgres/pgadmin und teacher.postgres/pgadmin."
+      no_log: true
+
+    - name: Gruppen-Credentials validieren
+      assert:
+        that:
+          - item.username is defined
+          - item.username is match('^[a-z_][a-z0-9_]{0,62}$')
+          - item.postgres is defined
+          - item.postgres.database_name is defined
+          - item.postgres.database_name is match('^[a-z_][a-z0-9_]{0,62}$')
+          - item.postgres.db_user is defined
+          - item.postgres.db_user is match('^[a-z_][a-z0-9_]{0,62}$')
+          - item.postgres.password is defined
+          - item.postgres.password | length >= 6
+          - item.pgadmin is defined
+          - item.pgadmin.email is defined
+          - "'@' in item.pgadmin.email"
+          - item.pgadmin.password is defined
+          - item.pgadmin.password | length >= 6
+        fail_msg: "Ungültige Gruppen-Credentials für PostgreSQL/pgAdmin."
+      loop: "{{ deployment_groups }}"
+      no_log: true
+
+    - name: user_json aus Backend-Credentials erzeugen
+      copy:
+        dest: "{{ dozilab_user_json_path }}"
+        owner: root
+        group: root
+        mode: "0600"
+        content: |
+          {
+            "course_label": {{ dozilab_stack_label | to_json }},
+            "instance": {},
+            "applications": [
+              {
+                "name": "postgres",
+                "credentials": [
+          {% for g in deployment_groups %}
+                  {
+                    "group": {{ g.username | to_json }},
+                    "database_name": {{ g.postgres.database_name | to_json }},
+                    "db_user": {{ g.postgres.db_user | to_json }},
+                    "password": {{ g.postgres.password | to_json }}
+                  }{% if not loop.last %},{% endif %}
+          {% endfor %}
+                ],
+                "admin_credentials": {
+                  "db_user": {{ teacher.postgres.db_user | to_json }},
+                  "password": {{ teacher.postgres.password | to_json }}
+                }
+              },
+              {
+                "name": "pgadmin",
+                "credentials": [
+          {% for g in deployment_groups %}
+                  {
+                    "group": {{ g.username | to_json }},
+                    "email": {{ g.pgadmin.email | to_json }},
+                    "password": {{ g.pgadmin.password | to_json }}
+                  }{% if not loop.last %},{% endif %}
+          {% endfor %}
+                ],
+                "admin_credentials": {
+                  "email": {{ teacher.pgadmin.email | to_json }},
+                  "password": {{ teacher.pgadmin.password | to_json }}
+                }
+              }
+            ]
+          }
+      no_log: true
+
+    - name: Erzeugtes user_json validieren
+      shell: |
+        set -euo pipefail
+
+        python3 - <<'PY'
+        import json
+        import re
+        import sys
+        from pathlib import Path
+
+        out_path = Path("/etc/dozilab/user.json")
+
+        if not out_path.exists() or out_path.stat().st_size == 0:
+            sys.exit("generated user_json missing/empty")
+
+        obj = json.loads(out_path.read_text(encoding="utf-8"))
+
+        if not isinstance(obj, dict):
+            sys.exit("user_json must be an object")
+
+        apps = obj.get("applications")
+        if not isinstance(apps, list):
+            sys.exit("user_json.applications must be a list")
+
+        def find_app(name: str):
+            for a in apps:
+                if isinstance(a, dict) and str(a.get("name", "")).lower() == name:
+                    return a
+            return None
+
+        pg = find_app("postgres") or find_app("postgresql")
+        if not pg:
+            sys.exit("Missing applications[name=postgres]")
+
+        pg_creds = pg.get("credentials")
+        if not isinstance(pg_creds, list) or not pg_creds:
+            sys.exit("postgres.credentials must be a non-empty list")
+
+        ident = re.compile(r"^[a-z_][a-z0-9_]{0,62}$")
+        group_token = re.compile(r"^[A-Za-z0-9_]{1,32}$")
+
+        used_db_users = set()
+        used_groups = set()
+
+        for c in pg_creds:
+            if not isinstance(c, dict):
+                sys.exit("postgres.credentials entries must be objects")
+
+            gid = c.get("group")
+            if gid is None:
+                sys.exit("postgres credential missing group")
+
+            gid_s = str(gid).strip()
+            if not gid_s or not group_token.match(gid_s):
+                sys.exit(f"postgres credential group invalid: {gid!r}")
+
+            if gid_s in used_groups:
+                sys.exit(f"duplicate postgres group not allowed: {gid_s!r}")
+            used_groups.add(gid_s)
+
+            dbn = c.get("database_name") or c.get("db_name")
+            if not isinstance(dbn, str) or not ident.match(dbn):
+                sys.exit(f"postgres credential database_name invalid: {dbn!r}")
+
+            db_user = c.get("db_user")
+            if not isinstance(db_user, str) or not ident.match(db_user):
+                sys.exit(f"postgres credential db_user invalid: {db_user!r}")
+
+            if db_user in used_db_users:
+                sys.exit(f"duplicate postgres db_user not allowed: {db_user!r}")
+            used_db_users.add(db_user)
+
+            pw = c.get("password")
+            if not isinstance(pw, str) or len(pw) < 6:
+                sys.exit(f"postgres credential password too short for {db_user!r} (min 6)")
+
+        admin = pg.get("admin_credentials") or {}
+        if admin:
+            if not isinstance(admin, dict):
+                sys.exit("postgres.admin_credentials must be an object")
+
+            a_user = admin.get("db_user")
+            a_pw = admin.get("password")
+
+            if not isinstance(a_user, str) or not ident.match(a_user):
+                sys.exit(f"postgres admin db_user invalid: {a_user!r}")
+
+            if a_user in used_db_users:
+                sys.exit(f"postgres admin db_user collides with group user: {a_user!r}")
+
+            if not isinstance(a_pw, str) or len(a_pw) < 6:
+                sys.exit("postgres admin password too short (min 6)")
+
+        pga = find_app("pgadmin")
+        if pga:
+            pga_admin = pga.get("admin_credentials") or {}
+            if not isinstance(pga_admin, dict) or not pga_admin.get("email") or not pga_admin.get("password"):
+                sys.exit("pgadmin.admin_credentials must contain email+password when pgadmin app is present")
+
+            if "@" not in str(pga_admin.get("email")):
+                sys.exit("pgadmin admin email invalid")
+
+            if len(str(pga_admin.get("password"))) < 6:
+                sys.exit("pgadmin admin password too short (min 6)")
+
+            pga_creds = pga.get("credentials")
+            if not isinstance(pga_creds, list) or not pga_creds:
+                sys.exit("pgadmin.credentials must be a non-empty list when pgadmin app is present")
+
+            seen_emails = set()
+            for c in pga_creds:
+                if not isinstance(c, dict):
+                    sys.exit("pgadmin.credentials entries must be objects")
+
+                gid = c.get("group")
+                if gid is None:
+                    sys.exit("pgadmin credential missing group")
+
+                gid_s = str(gid).strip()
+                if not gid_s or not group_token.match(gid_s):
+                    sys.exit(f"pgadmin credential group invalid: {gid!r}")
+
+                email = c.get("email")
+                pw = c.get("password")
+
+                if not isinstance(email, str) or "@" not in email:
+                    sys.exit(f"pgadmin credential email invalid: {email!r}")
+
+                if not isinstance(pw, str) or len(pw) < 6:
+                    sys.exit(f"pgadmin credential password too short for {email!r} (min 6)")
+
+                if email in seen_emails:
+                    sys.exit(f"duplicate pgadmin email not allowed: {email!r}")
+
+                seen_emails.add(email)
+
+        print("generated user_json validated OK")
+        PY
+      args:
+        executable: /bin/bash
+      no_log: true
+
+    - name: PostgreSQL Version aus user_json lesen
+      shell: |
+        set -euo pipefail
+        python3 - <<'PY'
+        import json
+
+        data = json.load(open("/etc/dozilab/user.json", "r", encoding="utf-8"))
+        pgver = data.get("postgres_version")
+        if pgver is None:
+            pgver = data.get("postgresVersion")
+
+        apps = data.get("applications") or []
+        for a in apps:
+            if isinstance(a, dict) and str(a.get("name", "")).lower() in ("postgres", "postgresql"):
+                if a.get("postgres_version") is not None:
+                    pgver = a.get("postgres_version")
+                if a.get("postgresVersion") is not None:
+                    pgver = a.get("postgresVersion")
+
+        if pgver is None or str(pgver).strip() == "":
+            print("")
+        else:
+            print(int(pgver))
+        PY
+      args:
+        executable: /bin/bash
+      register: postgres_version_result
+      changed_when: false
+
+    - name: APT Cache aktualisieren
+      apt:
+        update_cache: true
+        cache_valid_time: 3600
+
+    - name: PostgreSQL distro default installieren
+      apt:
+        name:
+          - postgresql
+          - postgresql-client
+          - python3
+        state: present
+      when: postgres_version_result.stdout | trim == ""
+
+    - name: PostgreSQL gewünschte Major-Version installieren
+      apt:
+        name:
+          - "postgresql-{{ postgres_version_result.stdout | trim }}"
+          - postgresql-client
+          - python3
+        state: present
+      when: postgres_version_result.stdout | trim != ""
+
+    - name: Installierte PostgreSQL Major-Version erkennen
+      shell: |
+        set -euo pipefail
+        pg_lsclusters --no-header | awk 'NR==1{print $1}'
+      args:
+        executable: /bin/bash
+      register: detected_pgver
+      changed_when: false
+
+    - name: PostgreSQL Version validieren
+      assert:
+        that:
+          - detected_pgver.stdout | trim | length > 0
+        fail_msg: "Konnte installierte PostgreSQL-Version nicht erkennen."
+
+    - name: PostgreSQL nur auf localhost binden
+      lineinfile:
+        path: "/etc/postgresql/{{ detected_pgver.stdout | trim }}/main/postgresql.conf"
+        regexp: "^#?listen_addresses\\s*="
+        line: "listen_addresses = '127.0.0.1'"
+        backup: true
+
+    - name: pg_hba IPv4 localhost scram sicherstellen
+      lineinfile:
+        path: "/etc/postgresql/{{ detected_pgver.stdout | trim }}/main/pg_hba.conf"
+        line: "host all all 127.0.0.1/32 scram-sha-256"
+        state: present
+
+    - name: pg_hba IPv6 localhost scram sicherstellen
+      lineinfile:
+        path: "/etc/postgresql/{{ detected_pgver.stdout | trim }}/main/pg_hba.conf"
+        line: "host all all ::1/128 scram-sha-256"
+        state: present
+
+    - name: PostgreSQL aktivieren und starten
+      service:
+        name: postgresql
+        enabled: true
+        state: restarted
+
+    - name: Auf PostgreSQL warten
+      shell: |
+        set -euo pipefail
+        for i in $(seq 1 60); do
+          if sudo -u postgres psql -d postgres -Atc "SELECT 1" >/dev/null 2>&1; then
+            exit 0
+          fi
+          sleep 1
+        done
+        exit 1
+      args:
+        executable: /bin/bash
+      changed_when: false
+
+    - name: PostgreSQL Rollen, Datenbanken und Rechte provisionieren
+      shell: |
+        set -euo pipefail
+
+        python3 - <<'PY'
+        import json
+        import re
+        import subprocess
+        import sys
+
+        spec = json.load(open("/etc/dozilab/user.json", "r", encoding="utf-8"))
+        apps = spec.get("applications") or []
+
+        def find_app(name: str):
+            for a in apps:
+                if isinstance(a, dict) and str(a.get("name", "")).lower() == name:
+                    return a
+            return None
+
+        pg = find_app("postgres") or find_app("postgresql")
+        pg_creds = pg.get("credentials") or []
+        pg_admin = pg.get("admin_credentials") or {}
+
+        ident = re.compile(r"^[a-z_][a-z0-9_]{0,62}$")
+        group_token = re.compile(r"^[A-Za-z0-9_]{1,32}$")
+
+        def run(sql: str, db: str = "postgres", capture: bool = True) -> str:
+            cmd = ["sudo", "-u", "postgres", "psql", "-d", db, "-v", "ON_ERROR_STOP=1", "-Atc", sql]
+            if capture:
+                return subprocess.check_output(cmd, text=True, cwd="/").strip()
+            subprocess.check_call(cmd, cwd="/")
+            return ""
+
+        def q_ident(s: str) -> str:
+            return '"' + s.replace('"', '""') + '"'
+
+        def q_lit(s: str) -> str:
+            return "'" + s.replace("'", "''") + "'"
+
+        def role_exists(name: str) -> bool:
+            return run(f"SELECT 1 FROM pg_roles WHERE rolname={q_lit(name)};") == "1"
+
+        def db_exists(name: str) -> bool:
+            return run(f"SELECT 1 FROM pg_database WHERE datname={q_lit(name)};") == "1"
+
+        def ensure_group_role(role: str) -> None:
+            if not role_exists(role):
+                run(f"CREATE ROLE {q_ident(role)} NOLOGIN;", capture=False)
+
+        def ensure_login_role(role: str, password: str) -> None:
+            if not role_exists(role):
+                run(f"CREATE ROLE {q_ident(role)} LOGIN PASSWORD {q_lit(password)};", capture=False)
             else:
-                logger.warning(f"Unknown template name '{template.name}' for version {version.id}, skipping file creation")
-                files_failed += 1
+                run(f"ALTER ROLE {q_ident(role)} LOGIN PASSWORD {q_lit(password)};", capture=False)
+
+        def ensure_db(dbname: str, owner: str) -> None:
+            if not db_exists(dbname):
+                run(f"CREATE DATABASE {q_ident(dbname)} OWNER {q_ident(owner)};", capture=False)
+            run(f"ALTER DATABASE {q_ident(dbname)} OWNER TO {q_ident(owner)};", capture=False)
+
+        def lock_down_db(dbname: str, grp_role: str) -> None:
+            run(f"REVOKE ALL ON DATABASE {q_ident(dbname)} FROM PUBLIC;", capture=False)
+            run(f"GRANT CONNECT, TEMPORARY ON DATABASE {q_ident(dbname)} TO {q_ident(grp_role)};", capture=False)
+            run("REVOKE CREATE ON SCHEMA public FROM PUBLIC;", db=dbname, capture=False)
+            run("REVOKE USAGE ON SCHEMA public FROM PUBLIC;", db=dbname, capture=False)
+            run(f"GRANT USAGE, CREATE ON SCHEMA public TO {q_ident(grp_role)};", db=dbname, capture=False)
+
+        def grant_group_defaults(dbname: str, creator_role: str, grp_role: str) -> None:
+            run(
+                f"ALTER DEFAULT PRIVILEGES FOR ROLE {q_ident(creator_role)} IN SCHEMA public "
+                f"GRANT ALL PRIVILEGES ON TABLES TO {q_ident(grp_role)};",
+                db=dbname,
+                capture=False,
+            )
+            run(
+                f"ALTER DEFAULT PRIVILEGES FOR ROLE {q_ident(creator_role)} IN SCHEMA public "
+                f"GRANT ALL PRIVILEGES ON SEQUENCES TO {q_ident(grp_role)};",
+                db=dbname,
+                capture=False,
+            )
+
+        def grant_role(grp_role: str, user: str) -> None:
+            run(f"GRANT {q_ident(grp_role)} TO {q_ident(user)};", capture=False)
+
+        groups = {}
+        for c in pg_creds:
+            gid = str(c.get("group")).strip()
+            if not gid or not group_token.match(gid):
+                sys.exit(f"Invalid group token: {gid!r}")
+
+            dbname = c.get("database_name") or c.get("db_name")
+            db_user = c.get("db_user")
+            pw = c.get("password")
+
+            if not isinstance(dbname, str) or not ident.match(dbname):
+                sys.exit(f"Invalid database_name for group {gid}: {dbname!r}")
+            if not isinstance(db_user, str) or not ident.match(db_user):
+                sys.exit(f"Invalid db_user for group {gid}: {db_user!r}")
+            if not isinstance(pw, str) or len(pw) < 6:
+                sys.exit(f"Invalid password for db_user {db_user!r} (min 6)")
+            if gid in groups:
+                sys.exit(f"Duplicate group in postgres.credentials: {gid!r}")
+
+            groups[gid] = {
+                "dbname": dbname,
+                "db_user": db_user,
+                "password": pw,
+            }
+
+        for gid, info in groups.items():
+            grp_role = f"grp_{gid}"
+            ensure_group_role(grp_role)
+            ensure_db(info["dbname"], grp_role)
+            lock_down_db(info["dbname"], grp_role)
+
+        for gid, info in groups.items():
+            grp_role = f"grp_{gid}"
+            db_user = info["db_user"]
+            ensure_login_role(db_user, info["password"])
+            grant_role(grp_role, db_user)
+            grant_group_defaults(info["dbname"], db_user, grp_role)
+
+        if isinstance(pg_admin, dict) and pg_admin:
+            a_user = pg_admin.get("db_user")
+            a_pw = pg_admin.get("password")
+            if a_user and a_pw:
+                if not isinstance(a_user, str) or not ident.match(a_user):
+                    sys.exit(f"Invalid postgres admin db_user: {a_user!r}")
+                if not isinstance(a_pw, str) or len(a_pw) < 6:
+                    sys.exit("Invalid postgres admin password (min 6)")
+
+                ensure_login_role(a_user, a_pw)
+                for gid, info in groups.items():
+                    grp_role = f"grp_{gid}"
+                    grant_role(grp_role, a_user)
+                    grant_group_defaults(info["dbname"], a_user, grp_role)
+
+        print(f"Provisioned postgres groups: {len(groups)}")
+        PY
+      args:
+        executable: /bin/bash
+      no_log: true
+
+    - name: Prüfen ob pgAdmin in user_json vorhanden ist
+      shell: |
+        set -euo pipefail
+        python3 - <<'PY'
+        import json
+
+        spec = json.load(open("/etc/dozilab/user.json", "r", encoding="utf-8"))
+        apps = spec.get("applications") or []
+
+        present = any(
+            isinstance(a, dict) and str(a.get("name", "")).lower() == "pgadmin"
+            for a in apps
+        )
+
+        print("true" if present else "false")
+        PY
+      args:
+        executable: /bin/bash
+      register: pgadmin_present_result
+      changed_when: false
+
+    - name: pgAdmin Basis-Pakete installieren
+      apt:
+        name:
+          - curl
+          - ca-certificates
+          - gnupg
+          - apache2
+          - libapache2-mod-wsgi-py3
+          - lsb-release
+        state: present
+      when: pgadmin_present_result.stdout | trim == "true"
+
+    - name: Ubuntu Codename ermitteln
+      command: lsb_release -cs
+      register: ubuntu_codename
+      changed_when: false
+      when: pgadmin_present_result.stdout | trim == "true"
+
+    - name: pgAdmin APT Key und Repository konfigurieren
+      shell: |
+        set -euo pipefail
+
+        install -d -m 0755 /etc/apt/keyrings
+
+        if [ ! -f /etc/apt/keyrings/pgadmin.gpg ]; then
+          curl -fsS https://www.pgadmin.org/static/packages_pgadmin_org.pub \
+            | gpg --dearmor -o /etc/apt/keyrings/pgadmin.gpg
+        fi
+
+        echo "deb [signed-by=/etc/apt/keyrings/pgadmin.gpg] https://ftp.postgresql.org/pub/pgadmin/pgadmin4/apt/{{ ubuntu_codename.stdout | trim }} pgadmin4 main" \
+          > /etc/apt/sources.list.d/pgadmin4.list
+      args:
+        executable: /bin/bash
+      when: pgadmin_present_result.stdout | trim == "true"
+
+    - name: APT Cache nach pgAdmin Repository aktualisieren
+      apt:
+        update_cache: true
+      when: pgadmin_present_result.stdout | trim == "true"
+
+    - name: pgAdmin Web installieren
+      apt:
+        name: pgadmin4-web
+        state: present
+      when: pgadmin_present_result.stdout | trim == "true"
+
+    - name: pgAdmin Admin Credentials schreiben
+      shell: |
+        set -euo pipefail
+
+        python3 - <<'PY'
+        import json
+        import shlex
+        import sys
+
+        spec = json.load(open("/etc/dozilab/user.json", "r", encoding="utf-8"))
+        apps = spec.get("applications") or []
+
+        def get_app(name):
+            for a in apps:
+                if isinstance(a, dict) and str(a.get("name", "")).lower() == name:
+                    return a
+            return None
+
+        pga = get_app("pgadmin") or {}
+        admin = pga.get("admin_credentials") or {}
+
+        email = admin.get("email")
+        pw = admin.get("password")
+
+        if not email or not pw:
+            sys.exit("pgadmin.admin_credentials missing email/password")
+        if "@" not in email:
+            sys.exit(f"pgAdmin admin email invalid: {email!r}")
+        if len(pw) < 6:
+            sys.exit("pgAdmin admin password too short (min 6)")
+
+        with open("/etc/default/pgadmin4", "w", encoding="utf-8") as f:
+            print(f"PGADMIN_SETUP_EMAIL={shlex.quote(email)}", file=f)
+            print(f"PGADMIN_SETUP_PASSWORD={shlex.quote(pw)}", file=f)
+
+        print("pgAdmin admin email:", email)
+        PY
+
+        chmod 600 /etc/default/pgadmin4
+      args:
+        executable: /bin/bash
+      no_log: true
+      when: pgadmin_present_result.stdout | trim == "true"
+
+    - name: pgAdmin Web Setup ausführen
+      shell: |
+        set -euo pipefail
+
+        rm -f /var/lib/pgadmin/pgadmin4.db
+        rm -rf /var/lib/pgadmin/sessions /var/lib/pgadmin/storage
+        install -d -m 0750 -o www-data -g www-data /var/lib/pgadmin
+
+        set -a
+        . /etc/default/pgadmin4
+        set +a
+
+        PGADMIN_SETUP_EMAIL="$PGADMIN_SETUP_EMAIL" \
+        PGADMIN_SETUP_PASSWORD="$PGADMIN_SETUP_PASSWORD" \
+          /usr/pgadmin4/bin/setup-web.sh --yes
+
+        a2enconf pgadmin4 || true
+        systemctl reload apache2 || true
+      args:
+        executable: /bin/bash
+      no_log: true
+      when: pgadmin_present_result.stdout | trim == "true"
+
+    - name: pgAdmin User aus user_json anlegen
+      shell: |
+        set -euo pipefail
+
+        python3 - <<'PY'
+        import json
+        import subprocess
+        import sys
+
+        spec = json.load(open("/etc/dozilab/user.json", "r", encoding="utf-8"))
+        apps = spec.get("applications") or []
+
+        def get_app(name):
+            for a in apps:
+                if isinstance(a, dict) and str(a.get("name", "")).lower() == name:
+                    return a
+            return None
+
+        pga = get_app("pgadmin") or {}
+        creds = pga.get("credentials") or []
+
+        if not isinstance(creds, list):
+            sys.exit("pgadmin.credentials must be a list")
+
+        accounts = []
+        seen = set()
+
+        for c in creds:
+            if not isinstance(c, dict):
                 continue
-            
-            # Create app.yaml
-            app_yaml = TemplateVersionFile(
-                template_version_id=version.id,
-                file_name="app.yaml",
-                file_type=FileType.APP_MANIFEST,
-                file_path="app.yaml",
-                content=app_yaml_content,
-                is_primary=False
+            email = c.get("email")
+            pw = c.get("password")
+            if not email or not pw:
+                continue
+            if email in seen:
+                continue
+            seen.add(email)
+            accounts.append((email, pw))
+
+        created = 0
+
+        for email, pw in accounts:
+            cmd = [
+                "sudo",
+                "-u",
+                "www-data",
+                "/usr/pgadmin4/venv/bin/python",
+                "/usr/pgadmin4/web/setup.py",
+                "add-user",
+                email,
+                pw,
+                "--role",
+                "User",
+                "--active",
+            ]
+
+            res = subprocess.run(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
             )
-            db.add(app_yaml)
-            logger.debug(f"Added app.yaml for version {version.id}")
 
-            # Create heat template
-            heat_template = TemplateVersionFile(
-                template_version_id=version.id,
-                file_name=heat_file_name,
-                file_type=FileType.HEAT_TEMPLATE,
-                file_path=heat_file_path,
-                content=heat_template_content,
-                is_primary=True
-            )
-            db.add(heat_template)
-            logger.debug(f"Added heat template for version {version.id}")
+            out = (res.stdout or "").strip()
+            if res.returncode == 0:
+                created += 1
+                print(f"created pgAdmin user: {email}")
+            elif "already exists" in out.lower():
+                print(f"pgAdmin user already exists: {email}")
+            else:
+                print(f"WARNING: failed to create pgAdmin user {email} rc={res.returncode} out={out}")
 
-            files_in_version = 2
+        print(f"pgAdmin accounts processed: {len(accounts)}, created: {created}")
+        PY
+      args:
+        executable: /bin/bash
+      no_log: true
+      when: pgadmin_present_result.stdout | trim == "true"
 
-            # Create cloud-init user-data (only for templates that use it)
-            if cloud_init_content is not None:
-                cloud_init = TemplateVersionFile(
-                    template_version_id=version.id,
-                    file_name="user-data.yaml",
-                    file_type=FileType.CLOUD_INIT,
-                    file_path="cloud-init/user-data.yaml",
-                    content=cloud_init_content,
-                    is_primary=False
+    - name: pgAdmin Server-Eintraege pro User registrieren
+      # load-servers importiert eine JSON-Datei mit Server-Definitionen
+      # in den Pgadmin-Account eines Users. Passwoerter werden bewusst NICHT
+      # mitimportiert — pgAdmin lehnt das aus Sicherheitsgruenden ab.
+      # Studenten geben das Postgres-Passwort beim ersten Connect ein.
+      # Teacher sieht alle Gruppen-DBs als separate Eintraege.
+      shell: |
+        set -euo pipefail
+
+        python3 - <<'PY'
+        import json
+        import subprocess
+        import sys
+        import tempfile
+        from pathlib import Path
+
+        spec = json.load(open("/etc/dozilab/user.json", "r", encoding="utf-8"))
+        apps = spec.get("applications") or []
+
+        def get_app(name):
+            for a in apps:
+                if isinstance(a, dict) and str(a.get("name", "")).lower() == name:
+                    return a
+            return None
+
+        pg = get_app("postgres") or get_app("postgresql") or {}
+        pga = get_app("pgadmin") or {}
+
+        pg_creds = pg.get("credentials") or []
+        pga_creds = pga.get("credentials") or []
+        pga_admin = pga.get("admin_credentials") or {}
+
+        # Build group_index -> {db_user, database_name} from postgres creds
+        groups_by_gid = {}
+        for c in pg_creds:
+            gid = str(c.get("group") or "").strip()
+            if not gid:
+                continue
+            groups_by_gid[gid] = {
+                "db_user": c.get("db_user"),
+                "database_name": c.get("database_name") or c.get("db_name"),
+            }
+
+        def load_servers_for_user(email: str, servers: dict) -> None:
+            """Run pgAdmin's load-servers CLI for a single user."""
+            payload = {"Servers": servers}
+            with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+                json.dump(payload, f)
+                tmp_path = f.name
+            try:
+                # Make sure www-data can read it
+                Path(tmp_path).chmod(0o644)
+                cmd = [
+                    "sudo", "-u", "www-data",
+                    "/usr/pgadmin4/venv/bin/python",
+                    "/usr/pgadmin4/web/setup.py",
+                    "load-servers", tmp_path,
+                    "--user", email,
+                ]
+                res = subprocess.run(
+                    cmd,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
                 )
-                db.add(cloud_init)
-                logger.debug(f"Added cloud-init for version {version.id}")
-                files_in_version += 1
+                out = (res.stdout or "").strip()
+                if res.returncode == 0:
+                    print(f"loaded {len(servers)} server(s) for {email}")
+                else:
+                    print(f"WARNING: load-servers failed for {email} rc={res.returncode} out={out}")
+            finally:
+                Path(tmp_path).unlink(missing_ok=True)
 
-            # Create ansible playbook (only for ansible-based templates)
-            if template.name == "Ansible Multi-User Ubuntu":
-                playbook = TemplateVersionFile(
-                    template_version_id=version.id,
-                    file_name="main.yml",
-                    file_type=FileType.ANSIBLE_PLAYBOOK,
-                    file_path="playbooks/main.yml",
-                    content=ANSIBLE_MULTIUSER_PLAYBOOK,
-                    is_primary=False
+        # --- Student / group accounts: one server entry per pgAdmin user ---
+        for c in pga_creds:
+            email = c.get("email")
+            gid = str(c.get("group") or "").strip()
+            if not email or not gid:
+                continue
+            group_info = groups_by_gid.get(gid)
+            if not group_info:
+                print(f"WARNING: no postgres credential for group {gid} — skipping {email}")
+                continue
+            servers = {
+                "1": {
+                    "Name": f"Gruppe {gid} DB",
+                    "Group": "Servers",
+                    "Host": "127.0.0.1",
+                    "Port": 5432,
+                    "MaintenanceDB": group_info["database_name"],
+                    "Username": group_info["db_user"],
+                    "SSLMode": "prefer",
+                },
+            }
+            load_servers_for_user(email, servers)
+
+        # --- Teacher: one server entry per group, all with teacher db_user ---
+        teacher_email = pga_admin.get("email")
+        pg_admin = pg.get("admin_credentials") or {}
+        teacher_db_user = pg_admin.get("db_user")
+        if teacher_email and teacher_db_user and groups_by_gid:
+            teacher_servers = {}
+            for i, (gid, info) in enumerate(sorted(groups_by_gid.items()), start=1):
+                teacher_servers[str(i)] = {
+                    "Name": f"Gruppe {gid} DB (teacher)",
+                    "Group": "Gruppen",
+                    "Host": "127.0.0.1",
+                    "Port": 5432,
+                    "MaintenanceDB": info["database_name"],
+                    "Username": teacher_db_user,
+                    "SSLMode": "prefer",
+                }
+            load_servers_for_user(teacher_email, teacher_servers)
+        PY
+      args:
+        executable: /bin/bash
+      no_log: true
+      when: pgadmin_present_result.stdout | trim == "true"
+
+    - name: Apache aktivieren und starten
+      service:
+        name: apache2
+        enabled: true
+        state: started
+      when: pgadmin_present_result.stdout | trim == "true"
+
+    - name: Auf pgAdmin Login-Seite warten
+      # Pollt die pgAdmin-Login-Seite ueber Apache.
+      # Erst wenn HTTP 200 zurueck kommt, gilt pgAdmin als wirklich bereit —
+      # vorher wuerde der Ready-Marker den Frontend-Status faelschlich auf
+      # "bereit" setzen, obwohl Apache noch 503/404 wirft.
+      uri:
+        url: "http://127.0.0.1/pgadmin4/login"
+        method: GET
+        status_code: 200
+        return_content: false
+      register: pgadmin_ready_check
+      retries: 120
+      delay: 5
+      until: pgadmin_ready_check.status == 200
+      when: pgadmin_present_result.stdout | trim == "true"
+
+    - name: Ready Marker schreiben
+      copy:
+        dest: "{{ dozilab_mark_dir }}/ready"
+        owner: root
+        group: root
+        mode: "0644"
+        content: "DOZILAB_READY stack={{ dozilab_stack_label }} time={{ ansible_facts.date_time.iso8601 }}\n"
+
+    - name: Fail Marker entfernen falls vorhanden
+      file:
+        path: "{{ dozilab_mark_dir }}/failed"
+        state: absent
+
+    - name: Abschluss anzeigen
+      debug:
+        msg:
+          - "DoziLab PostgreSQL Setup OK"
+          - "Stack: {{ dozilab_stack_label }}"
+          - "PostgreSQL Version: {{ detected_pgver.stdout | trim }}"
+          - "pgAdmin enabled: {{ pgadmin_present_result.stdout | trim }}"'''
+
+
+# ============================================================================
+# Template definitions
+# ============================================================================
+
+# Each app describes a template + its version files. Files are loaded in
+# the order listed (only matters for the 'order' column in the DB).
+APPS = [
+    {
+        "name": "Multi-User Ubuntu",
+        "description": (
+            "Ubuntu VM mit mehreren Benutzerkonten, verwaltet durch Ansible. "
+            "Pro Gruppe wird ein Linux-Account mit eigenem Arbeitsverzeichnis erstellt."
+        ),
+        "icon_url": "mdi:server-network",
+        "version": "2.1.0",
+        "files": [
+            {"name": "app.yaml",                "type": FileType.APP_MANIFEST,    "path": "app.yaml",                       "content": MULTIUSER_APP_YAML,         "primary": False},
+            {"name": "main.yaml",               "type": FileType.HEAT_TEMPLATE,   "path": "heat/main.yaml",                 "content": MULTIUSER_HEAT_TEMPLATE,    "primary": True},
+            {"name": "main.yml",                "type": FileType.ANSIBLE_PLAYBOOK,"path": "playbooks/main.yml",             "content": MULTIUSER_PLAYBOOK,         "primary": False},
+            {"name": "bashrc",                  "type": FileType.CONFIG_FILE,     "path": "files/bashrc",                   "content": MULTIUSER_BASHRC,           "primary": False},
+            {"name": "motd",                    "type": FileType.CONFIG_FILE,     "path": "files/motd",                     "content": MULTIUSER_MOTD,             "primary": False},
+            {"name": "check_student_setup.sh", "type": FileType.SHELL_SCRIPT,    "path": "scripts/check_student_setup.sh", "content": MULTIUSER_CHECK_SCRIPT,     "primary": False},
+            {"name": "reset_password.sh",       "type": FileType.SHELL_SCRIPT,    "path": "scripts/reset_password.sh",      "content": MULTIUSER_RESET_SCRIPT,     "primary": False},
+        ],
+    },
+    {
+        "name": "PostgreSQL Group DB",
+        "description": (
+            "Ubuntu VM mit PostgreSQL und optionalem pgAdmin. Jede Gruppe bekommt "
+            "eine eigene Datenbank und einen eigenen DB-Rollen-Account. Der Dozent "
+            "hat lesenden/schreibenden Zugriff auf alle Gruppen-DBs."
+        ),
+        "icon_url": "mdi:database",
+        "version": "2.0.0",
+        "files": [
+            {"name": "app.yaml",   "type": FileType.APP_MANIFEST,    "path": "app.yaml",            "content": POSTGRES_APP_YAML,     "primary": False},
+            {"name": "main.yaml",  "type": FileType.HEAT_TEMPLATE,   "path": "heat/main.yaml",      "content": POSTGRES_HEAT_TEMPLATE,"primary": True},
+            {"name": "main.yml",   "type": FileType.ANSIBLE_PLAYBOOK,"path": "playbooks/main.yml",  "content": POSTGRES_PLAYBOOK,     "primary": False},
+        ],
+    },
+]
+
+
+# Old template names from earlier iterations. Removed by the seeder so the
+# UI doesn't show stale entries. Add new entries here if you rename a template.
+_LEGACY_TEMPLATE_NAMES = [
+    "Ansible Multi-User Ubuntu",
+    "Ansible PostgreSQL Group DB",
+    "PostgreSQL Group Database",
+]
+
+
+def create_lecturer_user(db: Session) -> User:
+    """Create or get mock development user."""
+    existing_user = db.query(User).filter(User.external_id == "40a38818-552d-4ee0-a3fd-a2a1c434a862").first()
+    if existing_user:
+        return existing_user
+
+    user = User(
+        id="5c1c8363-ff6a-4d7f-946a-0221aaf21fb5",
+        external_id="40a38818-552d-4ee0-a3fd-a2a1c434a862",
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    logger.info(f"Created mock user with external_id: {user.external_id}")
+    return user
+
+
+def _delete_legacy_templates(db: Session) -> None:
+    """Delete templates from earlier iterations whose names we've since changed.
+
+    Cascades via the ORM relationships: template -> versions -> files. If a
+    legacy template has deployments hanging off it the DELETE will fail with
+    a FK violation — that's intentional, you'll need to remove those first.
+    """
+    removed = 0
+    for name in _LEGACY_TEMPLATE_NAMES:
+        existing = db.query(Template).filter(Template.name == name).all()
+        for t in existing:
+            try:
+                db.delete(t)
+                db.commit()
+                removed += 1
+                logger.info(f"Removed legacy template: {name} (id={t.id})")
+            except Exception as e:
+                db.rollback()
+                logger.warning(
+                    f"Could not remove legacy template {name!r} (id={t.id}): {e}. "
+                    "Likely has deployments referencing it — delete those first."
                 )
-                db.add(playbook)
-                files_in_version += 1
+    if removed:
+        logger.info(f"Removed {removed} legacy template(s).")
 
-                for name, content in [("bashrc", ANSIBLE_MULTIUSER_BASHRC), ("motd", ANSIBLE_MULTIUSER_MOTD)]:
-                    db.add(TemplateVersionFile(
-                        template_version_id=version.id,
-                        file_name=name,
-                        file_type=FileType.CONFIG_FILE,
-                        file_path=f"files/{name}",
-                        content=content,
-                        is_primary=False
-                    ))
-                    files_in_version += 1
 
-                for name, content in [
-                    ("check_student_setup.sh", ANSIBLE_MULTIUSER_CHECK_SCRIPT),
-                    ("reset_password.sh", ANSIBLE_MULTIUSER_RESET_SCRIPT),
-                ]:
-                    db.add(TemplateVersionFile(
-                        template_version_id=version.id,
-                        file_name=name,
-                        file_type=FileType.SHELL_SCRIPT,
-                        file_path=f"scripts/{name}",
-                        content=content,
-                        is_primary=False
-                    ))
-                    files_in_version += 1
+def _seed_one_app(db: Session, owner_id: str, app: dict) -> None:
+    """Create or update a single app (template + version + files).
 
-            db.commit()
-            files_created += 1
-            logger.info(f"✅ Created {files_in_version} files for version: {version.id} (template: {template.name})")
-            
-        except Exception as e:
-            logger.error(f"❌ Failed to create files for version {version.id}: {e}", exc_info=True)
-            db.rollback()
-            files_failed += 1
-    
-    logger.info(f"Template files summary: {files_created} created, {files_skipped} skipped, {files_failed} failed")
+    Idempotent: existing template/version is reused; files are upserted
+    by file_path so re-running picks up content changes.
+    """
+    template = db.query(Template).filter(Template.name == app["name"]).first()
+    if not template:
+        template = Template(
+            owner_id=owner_id,
+            name=app["name"],
+            description=app["description"],
+            repo_url="https://github.com/dozilab/appstore-templates",
+            icon_url=app["icon_url"],
+            visibility=TemplateVisibility.PUBLIC,
+        )
+        db.add(template)
+        db.commit()
+        db.refresh(template)
+        logger.info(f"Created template: {template.name} (id={template.id})")
+    else:
+        logger.info(f"Template exists: {template.name} (id={template.id})")
+
+    version = (
+        db.query(TemplateVersion)
+        .filter(TemplateVersion.template_id == template.id)
+        .order_by(TemplateVersion.created_at.desc())
+        .first()
+    )
+    if not version:
+        version = TemplateVersion(
+            template_id=template.id,
+            version=app["version"],
+            git_commit_sha=f"v{app['version']}-{template.name.lower().replace(' ', '-')}",
+            is_active=True,
+        )
+        db.add(version)
+        db.commit()
+        db.refresh(version)
+        logger.info(f"  Created version {version.version} (id={version.id})")
+    else:
+        logger.info(f"  Version exists: {version.version} (id={version.id})")
+
+    # Upsert files by file_path within the version.
+    existing_files = {
+        f.file_path: f
+        for f in db.query(TemplateVersionFile)
+        .filter(TemplateVersionFile.template_version_id == version.id)
+        .all()
+    }
+
+    for order, file_spec in enumerate(app["files"]):
+        content = file_spec["content"].lstrip("\n")  # strip leading newline from our r''' indentation
+        existing = existing_files.get(file_spec["path"])
+        if existing:
+            if existing.content != content:
+                existing.content = content
+                existing.file_size = len(content.encode())
+                logger.info(f"    Updated {file_spec['path']} ({existing.file_size} bytes)")
+            continue
+
+        f = TemplateVersionFile(
+            template_version_id=version.id,
+            file_name=file_spec["name"],
+            file_type=file_spec["type"],
+            file_path=file_spec["path"],
+            content=content,
+            file_size=len(content.encode()),
+            is_primary=file_spec["primary"],
+            order=order,
+        )
+        db.add(f)
+        logger.info(f"    Added   {file_spec['path']} ({f.file_size} bytes)")
+
+    db.commit()
 
 
 def seed_mock_data(db: Session) -> None:
-    """Seed all mock data for development.
-    
-    Args:
-        db: Database session
-    """
+    """Seed all mock data for development. Idempotent."""
     try:
         logger.info("Starting mock data seeding...")
-        
-        # Create mock user
+
         user = create_lecturer_user(db)
         logger.info(f"User ready: {user.id} (external_id: {user.external_id})")
-        
-        # Create templates
-        templates = create_mock_templates(db, user.id)
-        if not templates:
-            logger.warning("No templates were created or found!")
-            return
-        logger.info(f"Templates ready: {len(templates)} templates")
-        
-        # Create versions
-        versions = create_mock_template_versions(db, templates)
-        if not versions:
-            logger.warning("No template versions were created or found!")
-            return
-        logger.info(f"Template versions ready: {len(versions)} versions")
-        
-        # Create files
-        create_mock_template_files(db, versions)
-        logger.info(f"Template files created for {len(versions)} versions")
-        
+
+        _delete_legacy_templates(db)
+
+        for app in APPS:
+            _seed_one_app(db, user.id, app)
+
         logger.info("Mock data seeding completed successfully!")
-        
+
     except Exception as e:
         logger.error(f"Failed to seed mock data: {e}", exc_info=True)
         db.rollback()

--- a/src/schemas/deployment.py
+++ b/src/schemas/deployment.py
@@ -268,6 +268,19 @@ class DeploymentCredentialEntry(BaseModel):
     )
     connection_url: Optional[str] = Field(None, description="Connection URL if applicable")
     port: Optional[int] = Field(None, description="Port number if applicable")
+    group_id: Optional[str] = Field(
+        None,
+        description=(
+            "course_groups.id this credential belongs to. NULL = lecturer/admin "
+            "credential (not tied to a student group). Drives the Dozent/Gruppen "
+            "split in the UI."
+        ),
+    )
+    group_name: Optional[str] = Field(
+        None,
+        description="Display name of the course group (joined from course_groups.name). "
+                    "NULL when group_id is NULL.",
+    )
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/src/services/credential_generator_service.py
+++ b/src/services/credential_generator_service.py
@@ -26,9 +26,16 @@ def _generate_password(length: int = 16) -> str:
 
 
 def _sanitize_username(name: str) -> str:
-    """Convert any string to a valid Unix username (max 32 chars)."""
-    username = name.lower().replace(" ", "-").replace(".", "-")
-    username = re.sub(r"[^a-z0-9\-_]", "", username)
+    """Convert any string to a valid Unix username (max 32 chars).
+
+    Hyphens are mapped to underscores so the result also satisfies stricter
+    identifier rules (e.g. PostgreSQL role / database names: ``[a-z_][a-z0-9_]*``)
+    without quoting. The previous behavior used hyphens, which broke
+    ``ansible_postgres_group_db`` for group names containing spaces / dots
+    (``"Gruppe 1"`` → ``"gruppe-1"`` → rejected by Postgres-identifier asserts).
+    """
+    username = name.lower().replace(" ", "_").replace(".", "_").replace("-", "_")
+    username = re.sub(r"[^a-z0-9_]", "", username)
     if username and username[0].isdigit():
         username = "u" + username
     return (username or "user")[:32]

--- a/src/utils/app_manifest_parser.py
+++ b/src/utils/app_manifest_parser.py
@@ -103,6 +103,12 @@ class AppManifestParser:
                 "teacher": credentials_raw.get("teacher") or [],
             }
 
+            # Ansible configuration (vars mapping for extra_vars)
+            ansible_raw = data.get("ansible") or {}
+            ansible = {
+                "vars": ansible_raw.get("vars") or {},
+            }
+
             # User files
             user_files = data.get("user_files") or []
 
@@ -123,6 +129,7 @@ class AppManifestParser:
                 "parameters": parameters,
                 "outputs": outputs,
                 "credentials": credentials,
+                "ansible": ansible,
                 "user_files": user_files,
                 "artifacts": artifacts,
             }

--- a/tests/api/test_deployment_credentials_routes.py
+++ b/tests/api/test_deployment_credentials_routes.py
@@ -71,6 +71,8 @@ def _build_access(
     username="gruppe-1",
     ssh_private_key=_SAMPLE_PEM,
     password="P@ssw0rd-1234567",
+    group_id=None,
+    group_name=None,
 ):
     """Mirror of a DeploymentInstanceAccess row (post-decryption)."""
     access = MagicMock()
@@ -82,6 +84,15 @@ def _build_access(
     access.port = 22
     access.access_type = MagicMock()
     access.access_type.value = "ssh"
+    # group_id / group.name drive the Dozent/Gruppen split in the response
+    # schema. Pydantic rejects bare MagicMock here (must be str | None), so
+    # the test must explicitly choose. Default: lecturer/admin row.
+    access.group_id = group_id
+    if group_id is None:
+        access.group = None
+    else:
+        access.group = MagicMock()
+        access.group.name = group_name
     return access
 
 

--- a/tests/unit/test_backfill_access_group_id.py
+++ b/tests/unit/test_backfill_access_group_id.py
@@ -153,7 +153,7 @@ def test_backfill_stamps_group_access_row(session):
         course_id="c-1",
         group_name="Gruppe 1",
         course_group_id="cg-1",
-        sanitized_username="gruppe-1",
+        sanitized_username="gruppe_1",
     )
 
     _run_backfill(session)
@@ -174,7 +174,7 @@ def test_backfill_is_idempotent(session):
         course_id="c-1",
         group_name="Gruppe 1",
         course_group_id="cg-1",
-        sanitized_username="gruppe-1",
+        sanitized_username="gruppe_1",
     )
 
     _run_backfill(session)
@@ -247,7 +247,7 @@ def test_backfill_uses_explicit_course_group_id_when_present(session):
     session.add(_DeploymentInstanceAccess(
         id="access-1",
         deployment_instance_id="inst-1",
-        username="gruppe-1",
+        username="gruppe_1",
         group_id=None,
     ))
     session.commit()


### PR DESCRIPTION
## Was sich aendert

### `api/deployments.py`

#### `GET /credentials` — Owner-Info fuer Frontend

Response-Entries enthalten jetzt `group_id` und `group_name` (per JOIN auf `course_groups.name`). Damit kann das Frontend die Credentials nach Owner gruppieren:

* `group_id = NULL` → Lehrer/Admin-Credentials → "Dozent"-Tab
* `group_id = <uuid>` → Gruppen-Credentials → "Gruppen"-Tab, Akkordeon nach `group_name`

Frontend-PR: https://github.com/DoziLab/appstore-frontend/pull/130 (rendert mit diesen Feldern Tabs + Akkordeon).

#### `GET /logs/stream` — funktioniert wirklich live

Mehrere Fixes:

* **Frische SessionLocal pro Polling-Tick.** Die Request-Session sieht Commits vom Celery-Worker nicht, weil SQLAlchemy in derselben Transaktion die Identity-Map cached. Vorher kamen Logs erst nach Reload — neu jeder Tick liest mit eigener Connection.
* **`run_in_threadpool`** um die sync DB-Aufrufe. Vorher blockierte ein langer SSE-Stream den Event-Loop.
* **15s-Heartbeat** (`: ping\n\n` SSE-Comment). Verhindert dass Browser/Proxies waehrend langer Ansible-Phasen die Connection als tot betrachten.
* `Connection: keep-alive` Header.

### `schemas/deployment.py`

`DeploymentCredentialEntry` um optional `group_id` + `group_name` erweitert. Schon im Model vorhanden (PR #167 hat `group_id` eingefuehrt), aber bisher nicht im API-Schema durchgereicht.

### `services/credential_generator_service.py`

`_sanitize_username` mappt jetzt auch Bindestriche auf Underscores. Konkret:

```py
# alt: "Gruppe 1"  → "gruppe-1"
# neu: "Gruppe 1"  → "gruppe_1"
```

Hintergrund: `ansible_postgres_group_db/playbooks/main.yml` validiert `item.username` gegen `^[a-z_][a-z0-9_]{0,62}$` (striktes Postgres-Identifier-Pattern, weil DB-Name und DB-User direkt aus dem Username gebildet werden). Jeder Gruppenname mit Space/Punkt/Strich liess das alte Sanitize-Verhalten einen Bindestrich produzieren und der Deploy starb mit `Ungueltige Gruppen-Credentials fuer PostgreSQL/pgAdmin`. Multi-User-Templates akzeptierten den Bindestrich, akzeptieren aber auch den Underscore — keine Regression.

### `utils/app_manifest_parser.py`

Parser zieht jetzt eine `ansible:` Sektion (mit `vars:` Mapping) aus der app.yaml und liefert sie unter dem `ansible`-Key zurueck. Schon vom Code in `deploy_tasks.py` vorgesehen, im Parser aber nicht durchgereicht.

### `core/seed_data.py` — komplett neu geschrieben

Bisher 2200 Zeilen mit `MULTISTUDENT_*`, `POSTGRES_*` und einem dritten `ANSIBLE_MULTIUSER_*`-Set inkonsistenter String-Konstanten (Playbook nutzte z.B. `{{ students }}`, das Backend liefert aber `{{ deployment_groups }}`).

Nach dem Rewrite:

* **10 Datei-Inhalte byte-identisch aus appstore-apps/ eingebettet** — `ansible_multiuser/` (app.yaml, heat, playbook, files/, scripts/) und `ansible_postgres_group_db/` (app.yaml, heat, playbook). Raw triple-single-quote strings, kein Escaping.
* **Zwei Templates** mit sauberen Namen ohne "Ansible "-Praefix: `Multi-User Ubuntu` und `PostgreSQL Group DB`.
* **Legacy-Cleanup**: Templates mit alten Namen (`Ansible Multi-User Ubuntu`, `PostgreSQL Group Database`, `Ansible PostgreSQL Group DB`) werden beim Seeder-Lauf geloescht — saubere DB nach Restart. Falls noch Deployments daran haengen, scheitert das DELETE und es wird nur eine Warning geloggt.
* **Idempotente Upsert-Logic** statt der bisherigen "skip if exists"-Logik: Files werden per `file_path` upserted, sodass beim naechsten Backend-Start aktualisierte Inhalte aus den eingebetteten Strings durchgereicht werden.

### `scripts/sync_app_files_to_db.py` (neu)

Helfer-Skript fuer den Dev-Workflow:

```bash
uv run python scripts/sync_app_files_to_db.py "Multi-User Ubuntu" ../appstore-apps/ansible_multiuser
```

Liest die Files vom Disk und upserted sie in die DB der bereits gesseededten App-Version. Nuetzlich wenn du am Playbook bastelst und nicht jedes Mal das Backend neu starten willst (Templates kommen ja aus der DB, nicht von Disk).

## Wie testen

1. Backend neu starten — im Log siehst du:
   ```
   Removed legacy template: Ansible Multi-User Ubuntu
   Removed legacy template: PostgreSQL Group Database
   Created template: Multi-User Ubuntu
   Created template: PostgreSQL Group DB
   ```
2. Frontend zeigt die zwei Templates ohne "Ansible "-Praefix.
3. Deploy mit Postgres-Template, Gruppe mit Spaces im Namen (z.B. "Gruppe 1") → kein "Ungueltige Gruppen-Credentials"-Error mehr.
4. Network-Tab → `/logs/stream` zeigt Events live, alle 15s ein `: ping`-Comment.
5. Credentials-Sektion: Frontend (PR #130) zeigt Tabs Dozent/Gruppen, im Gruppen-Tab Akkordeon pro Gruppe.