### PR TITLE
feat(overleaf): persist activation links via post-Ansible SSH fetch

### DIFF
--- a/alembic/versions/034d40e1dad3_add_activation_link_to_access_type.py
+++ b/alembic/versions/034d40e1dad3_add_activation_link_to_access_type.py
@@ -1,0 +1,53 @@
+"""add ACTIVATION_LINK to accesstype enum
+
+Revision ID: 034d40e1dad3
+Revises: c8e9d3b7f1a2
+Create Date: 2026-06-29 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = '034d40e1dad3'
+down_revision: Union[str, Sequence[str], None] = 'c8e9d3b7f1a2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    Adds a new ``ACTIVATION_LINK`` value to the ``accesstype`` Postgres enum
+    that backs ``deployment_instance_access.access_type``. Required for the
+    Overleaf LaTeX Lab app (and any future app that produces one-time
+    activation links during the Ansible run rather than passwords/keys
+    before it): the post-Ansible SSH fetch in ``deploy_tasks`` writes such
+    rows via ``DeploymentCredentialService.persist_activation_links``.
+
+    ``IF NOT EXISTS`` keeps the migration idempotent — safe to re-run if a
+    manual ALTER got there first.
+
+    Note: ``ALTER TYPE ... ADD VALUE`` is allowed inside a transaction since
+    PG 12, but the newly-added label is only usable after commit. The
+    backfill of any rows using this value happens at deploy time, never in
+    this migration, so the default Alembic transaction wrap is fine.
+    """
+    op.execute(
+        "ALTER TYPE accesstype "
+        "ADD VALUE IF NOT EXISTS 'ACTIVATION_LINK'"
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Postgres does not support removing values from an enum type without
+    rebuilding the type and all dependent columns. Rolling back the
+    application code is the correct response; the unused enum label is
+    harmless. Left intentionally empty (same approach as
+    ``a1c5e8d2f307_add_expiry_enum_values_to_deployment_log``).
+    """
+    pass

--- a/src/models/deployment_instance_access.py
+++ b/src/models/deployment_instance_access.py
@@ -18,6 +18,11 @@ class AccessType(str, Enum):
     RDP = "rdp"
     VNC = "vnc"
     DATABASE = "database"
+    # One-time activation/setup link the playbook generates on the VM
+    # (e.g. Overleaf account setup). Carried in connection_url; no
+    # password / SSH key. Stored as a Postgres enum value of the same
+    # name — see the Alembic migration that adds it.
+    ACTIVATION_LINK = "activation_link"
 
 
 class DeploymentInstanceAccess(Base):

--- a/src/services/ansible_service.py
+++ b/src/services/ansible_service.py
@@ -215,6 +215,108 @@ class AnsibleService:
                     details={"playbook": playbook_name},
                 )
 
+    def fetch_remote_file(self, remote_path: str) -> str | None:
+        """SCP-style fetch of a remote file via `ssh sudo cat`.
+
+        Used to read root-owned post-deployment artifacts the playbook writes
+        to /opt/dozilab/ (e.g. activation-link JSON). Direct ssh+sudo cat
+        beats scp here because target files are mode 0600 root:root and the
+        Ansible-managed login user is unprivileged.
+
+        Returns the file content as UTF-8 text on success, None on any
+        failure (missing file, unreachable host, timeout, permission denied,
+        non-UTF8 bytes). Never raises — callers should treat absence as a
+        no-op so unrelated apps that never write such files keep working.
+        """
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".pem", delete=False, prefix="dozilab_ssh_"
+        ) as key_file:
+            key_file.write(self.ssh_private_key)
+            key_path = key_file.name
+
+        try:
+            Path(key_path).chmod(0o600)
+
+            cmd = [
+                "ssh",
+                "-i", key_path,
+                "-o", "StrictHostKeyChecking=no",
+                "-o", "ConnectTimeout=10",
+                "-o", "BatchMode=yes",
+                f"{self.ssh_user}@{self.floating_ip}",
+                "--",
+                "sudo", "cat", remote_path,
+            ]
+
+            try:
+                result = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
+            except subprocess.TimeoutExpired:
+                self._log(
+                    DeploymentLogEventType.ANSIBLE_TASK,
+                    f"Remote fetch timed out: {remote_path}",
+                    level=DeploymentLogLevel.WARNING,
+                )
+                return None
+
+            if result.returncode != 0:
+                stderr = (result.stderr or "").strip()
+                # File-absent is the expected path for apps that don't write
+                # such artifacts — log as INFO, not WARNING.
+                if "No such file" in stderr or "cannot open" in stderr.lower():
+                    self._log(
+                        DeploymentLogEventType.ANSIBLE_TASK,
+                        f"Remote file not present, skipping: {remote_path}",
+                        level=DeploymentLogLevel.INFO,
+                    )
+                else:
+                    self._log(
+                        DeploymentLogEventType.ANSIBLE_TASK,
+                        f"Remote fetch failed ({result.returncode}) for {remote_path}: {sanitize_message(stderr)[:200]}",
+                        level=DeploymentLogLevel.WARNING,
+                    )
+                return None
+
+            content = result.stdout
+            self._log(
+                DeploymentLogEventType.ANSIBLE_TASK,
+                f"Fetched {len(content)} bytes from {remote_path}",
+            )
+            return content
+        finally:
+            Path(key_path).unlink(missing_ok=True)
+
+    def fetch_remote_json(self, remote_path: str) -> dict | None:
+        """Thin wrapper over fetch_remote_file that parses JSON.
+
+        Returns None for missing files, unreachable hosts, and malformed
+        JSON. Malformed JSON is logged at WARNING level; absence is silent.
+        """
+        content = self.fetch_remote_file(remote_path)
+        if content is None:
+            return None
+        try:
+            data = json.loads(content)
+        except (ValueError, json.JSONDecodeError) as err:
+            self._log(
+                DeploymentLogEventType.ANSIBLE_TASK,
+                f"Remote file {remote_path} is not valid JSON: {err}",
+                level=DeploymentLogLevel.WARNING,
+            )
+            return None
+        if not isinstance(data, dict):
+            self._log(
+                DeploymentLogEventType.ANSIBLE_TASK,
+                f"Remote file {remote_path} JSON root is not an object",
+                level=DeploymentLogLevel.WARNING,
+            )
+            return None
+        return data
+
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------

--- a/src/services/deployment_credential_service.py
+++ b/src/services/deployment_credential_service.py
@@ -1,11 +1,14 @@
 """Persist deployment credentials produced by the per-stack ``user_json``."""
 from __future__ import annotations
 
+import logging
 from typing import Any
 from sqlalchemy.orm import Session
 
 from src.models.deployment_instance import DeploymentInstance, DeploymentInstanceStatus
 from src.models.deployment_instance_access import AccessType, DeploymentInstanceAccess
+
+logger = logging.getLogger(__name__)
 
 
 class DeploymentCredentialService:
@@ -121,3 +124,109 @@ class DeploymentCredentialService:
                 })
 
         return [e for e in entries if e.get("password") or e.get("ssh_private_key")]
+
+    def persist_activation_links(
+        self,
+        instance_id: str,
+        overleaf_users_json: dict[str, Any],
+        username_to_group_id: dict[str, str | None],
+    ) -> int:
+        """Append ACTIVATION_LINK access rows to an existing DeploymentInstance.
+
+        Used for apps that generate one-time activation/setup links inside the
+        playbook (no password, no SSH key) and write them to a JSON file on
+        the VM that ``AnsibleService.fetch_remote_json`` then reads back.
+        Currently driven by ``ansible_overleaf_latex_lab``; the input shape
+        below is the contract any future app must follow to opt in.
+
+        Expected input shape::
+
+            {
+              "admin":  {"email": str, "activation_url": str},
+              "groups": [{"username": str, "email": str,
+                          "activation_url": str}, ...]
+            }
+
+        ``username_to_group_id`` maps each playbook-side group ``username``
+        (e.g. ``"gruppe01"``) to the corresponding ``course_groups.id``. The
+        caller builds it from ``generated["deployment_groups"]``. An entry
+        whose username is **not** in the map is skipped with a warning rather
+        than written with ``group_id=NULL`` (that would leak the link to no
+        student via the self-service filter — safer to omit it and surface
+        the discrepancy in logs).
+
+        Bypasses the ``_extract_access_entries`` password/key filter on
+        purpose: that filter encodes the pre-Ansible "no password ⇒ nothing
+        to store" invariant, which we don't want to weaken just for this
+        post-Ansible path.
+
+        Args:
+            instance_id: ID of the already-persisted ``DeploymentInstance``
+                this stack belongs to.
+            overleaf_users_json: Parsed JSON read back from the VM.
+            username_to_group_id: ``{playbook_username: course_groups.id}``.
+                Use ``None`` as the value to deliberately produce an admin /
+                lecturer-only row (currently unused — admin uses the
+                separate ``admin`` block in the JSON).
+
+        Returns:
+            Number of access rows written.
+        """
+        instance = self.db.get(DeploymentInstance, instance_id)
+        if instance is None:
+            raise ValueError(
+                f"persist_activation_links: DeploymentInstance {instance_id} not found"
+            )
+
+        written = 0
+
+        # Admin entry — always group_id=None so only lecturers see it.
+        admin = overleaf_users_json.get("admin") or {}
+        admin_url = (admin.get("activation_url") or "").strip()
+        if admin_url:
+            self.db.add(
+                DeploymentInstanceAccess(
+                    deployment_instance_id=instance_id,
+                    access_type=AccessType.ACTIVATION_LINK,
+                    # Show the admin email as the "username" column in the UI
+                    # — reads better than NULL.
+                    username=admin.get("email"),
+                    connection_url=admin_url,
+                    group_id=None,
+                )
+            )
+            written += 1
+
+        # Per-group entries — must resolve to a known course_groups.id.
+        for entry in overleaf_users_json.get("groups") or []:
+            url = (entry.get("activation_url") or "").strip()
+            if not url:
+                continue
+            username = entry.get("username")
+            if not username:
+                logger.warning(
+                    "persist_activation_links: group entry missing 'username', skipping: %r",
+                    entry,
+                )
+                continue
+            if username not in username_to_group_id:
+                logger.warning(
+                    "persist_activation_links: no course_group mapping for username '%s'; "
+                    "skipping rather than writing a NULL group_id row",
+                    username,
+                )
+                continue
+            gid = username_to_group_id[username]
+            self.db.add(
+                DeploymentInstanceAccess(
+                    deployment_instance_id=instance_id,
+                    access_type=AccessType.ACTIVATION_LINK,
+                    username=entry.get("email") or username,
+                    connection_url=url,
+                    group_id=gid,
+                )
+            )
+            written += 1
+
+        self.db.commit()
+        return written

--- a/src/tasks/deploy_tasks.py
+++ b/src/tasks/deploy_tasks.py
@@ -277,7 +277,11 @@ def deploy_stack(self, deployment_id: str) -> dict:
                             } if generated.get("teacher", {}).get("linux", {}).get("password") else None,
                         },
                     }
-                    DeploymentCredentialService(db).persist_credentials_for_stack(
+                    # Bind the returned DeploymentInstance so the post-Ansible
+                    # activation-link fetch below can append rows to it. None
+                    # if persistence failed (see except clause); the post-
+                    # Ansible block guards against that.
+                    instance = DeploymentCredentialService(db).persist_credentials_for_stack(
                         deployment_id=deployment_id,
                         stack_name=stack_name,
                         openstack_stack_id=stack_id,
@@ -287,6 +291,7 @@ def deploy_stack(self, deployment_id: str) -> dict:
                         flavor=stack_params.get("flavor"),
                     )
                 except Exception as cred_error:
+                    instance = None
                     logger.error(f"Failed to persist credentials for stack {idx}: {cred_error}", exc_info=True)
                     log_service.log(
                         deployment_id=deployment_id,
@@ -345,6 +350,73 @@ def deploy_stack(self, deployment_id: str) -> dict:
                                 ],
                             }
                             ansible.run_playbooks(playbooks=playbooks, extra_vars=extra_vars)
+
+                            # --- 5. Post-Ansible: collect any per-stack
+                            #     output JSON the playbook wrote into
+                            #     /opt/dozilab/. Currently only Overleaf
+                            #     uses this — it writes activation links
+                            #     there because the Overleaf CLI generates
+                            #     one-time setup URLs at provisioning time
+                            #     (we have no password/SSH key to persist
+                            #     pre-Ansible). Any future app may opt in
+                            #     by writing the same shape; the fetch is
+                            #     a no-op when the file is absent.
+                            # TODO: when a second app needs this, replace
+                            #     the hardcoded path with a list declared
+                            #     in app.yaml (e.g. ``post_ansible_outputs``).
+                            try:
+                                users_json = ansible.fetch_remote_json(
+                                    "/opt/dozilab/OVERLEAF_USERS.json"
+                                )
+                                if users_json and instance is not None:
+                                    # Map the playbook's per-group ``username``
+                                    # (e.g. "gruppe01") to the matching
+                                    # course_groups.id stamped onto the
+                                    # generated deployment_groups entries.
+                                    username_to_group_id: dict[str, str | None] = {}
+                                    for s in generated.get("deployment_groups", []):
+                                        course_group_id = s.get("course_group_id")
+                                        linux_username = s.get("linux", {}).get("username")
+                                        if linux_username:
+                                            username_to_group_id[linux_username] = course_group_id
+                                        # Fallback for credential specs that
+                                        # set a top-level username but no
+                                        # linux block.
+                                        top_username = s.get("username")
+                                        if top_username:
+                                            username_to_group_id.setdefault(
+                                                top_username, course_group_id
+                                            )
+
+                                    written = DeploymentCredentialService(db).persist_activation_links(
+                                        instance_id=instance.id,
+                                        overleaf_users_json=users_json,
+                                        username_to_group_id=username_to_group_id,
+                                    )
+                                    log_service.log(
+                                        deployment_id=deployment_id,
+                                        event_type=DeploymentLogEventType.ANSIBLE_COMPLETED,
+                                        message=f"Persisted {written} activation-link credential(s) for stack {idx}",
+                                        level=DeploymentLogLevel.INFO,
+                                        details={"stack_index": idx, "count": written},
+                                    )
+                            except Exception as fetch_err:
+                                # Never fail the deployment because of a
+                                # post-fetch issue — the file still lives on
+                                # the VM at /opt/dozilab/OVERLEAF_USERS.{json,txt}
+                                # for manual recovery.
+                                logger.warning(
+                                    "Post-Ansible activation-link fetch failed for "
+                                    f"deployment {deployment_id} stack {idx}: {fetch_err}",
+                                    exc_info=True,
+                                )
+                                log_service.log(
+                                    deployment_id=deployment_id,
+                                    event_type=DeploymentLogEventType.ANSIBLE_COMPLETED,
+                                    message=f"Stack {idx} done; activation-link fetch skipped: {fetch_err}",
+                                    level=DeploymentLogLevel.WARNING,
+                                    details={"stack_index": idx, "error": str(fetch_err)},
+                                )
                         except CancelledException as cancel_err:
                             # Cancel was observed mid-SSH-wait or mid-playbook.
                             # Don't escalate to FAILED — log and exit cleanly.


### PR DESCRIPTION
## Was und warum

Overleaf ist die erste App, bei der **Credentials nicht vor Ansible generiert werden** (keine Passwörter, keine SSH-Keys pro User). Stattdessen erzeugt der Overleaf-CLI während des Playbook-Runs einmalige **Aktivierungslinks** (`/user/activate?token=...`) und das Playbook schreibt sie auf der VM nach `/opt/dozilab/OVERLEAF_USERS.json` (mode `0600` root:root). Vor diesem PR landen die Links nirgends außerhalb der VM — Lehrkraft müsste SSH-en und die Datei manuell auslesen.

## Datenfluss nach dem PR

```
Heat Stack → SSH-Creds wie bisher in DB (vor Ansible)
        ↓
Ansible Playbook → schreibt /opt/dozilab/OVERLEAF_USERS.json
        ↓
[NEU] AnsibleService.fetch_remote_json(...)
        ↓
[NEU] DeploymentCredentialService.persist_activation_links(...)
        → DeploymentInstanceAccess rows mit access_type=ACTIVATION_LINK
        → connection_url = die URL, group_id = course_groups.id (NULL für Admin)
        ↓
GET /deployments/{id}/credentials  (unverändert)
        ↓
Frontend rendert als klickbaren Link  (separater Frontend-PR)
```

## Änderungen

### Generisch (für jede zukünftige App nachnutzbar)
- **`AnsibleService.fetch_remote_file` / `fetch_remote_json`** — neuer SSH-Read-Back-Helper. `ssh sudo cat <path>` weil die Datei `0600 root:root` ist (plain `scp` als unprivilegierter Login-User scheitert). **Niemals raisend** — fehlende Datei → INFO-Log + `None` zurück, sodass andere Apps die diese Datei nicht schreiben unverändert laufen.
- **`AccessType.ACTIVATION_LINK`** + Alembic-Migration `ALTER TYPE accesstype ADD VALUE IF NOT EXISTS 'ACTIVATION_LINK'`. Idempotent (`IF NOT EXISTS`), `downgrade()` leer mit Kommentar zu PG-Enum-Removal.

### Overleaf-spezifisch
- **`DeploymentCredentialService.persist_activation_links(instance_id, overleaf_users_json, username_to_group_id)`** — neue Methode, **bypassed** den `password or ssh_private_key`-Filter in `_extract_access_entries` bewusst. Strippt Trailing-Whitespace. Wenn die Username-Zuordnung scheitert: **Warning loggen statt mit `group_id=NULL` schreiben** (sonst würde der Link via Student-Self-Service-Filter an niemanden gehen — sicherer als an alle).
- **`deploy_tasks.py`** — Rückgabewert von `persist_credentials_for_stack` wird auf `instance` gebunden. Nach erfolgreichem `run_playbooks` (Zeile ~347): Fetch + Persist in eigenem `try/except`. **Failed niemals das Deployment** — die JSON liegt weiterhin auf der VM in `/opt/dozilab/OVERLEAF_USERS.{json,txt}` für manuelle Recovery.
- `TODO`-Kommentar im deploy_tasks für den generischen `app.yaml: post_ansible_outputs`-Pattern, sobald eine zweite App das braucht. Helper-Methode auf `AnsibleService` ist aber bereits generisch.

### Bewusst NICHT geändert
- API-Endpoints (`/deployments/{id}/credentials`, Student-Self-Service): `access_type` wird über `.value` als String serialisiert → neue Enum-Werte laufen durch.
- Schemas (`DeploymentCredentialEntry.access_type: str`): permissiv, keine Whitelist.
- Student-Filter: arbeitet nur über `group_id` → Studenten sehen automatisch ihren Gruppen-Link, **nie** den Admin-Link (group_id=NULL).
- `_extract_access_entries`-Filter (Zeile 123): bleibt strikt. Pre-Ansible-Persistenz-Semantik bleibt unverändert.

## Migration ausführen

```bash
alembic upgrade head
```

Pflicht **vor** dem ersten Overleaf-Deployment, sonst schlägt der erste Schreibversuch in eine `ACTIVATION_LINK`-Zeile fehl.

## Testplan

**Unit-Tests** (kein VM nötig):
- `AnsibleService.fetch_remote_json`: success → dict, `"No such file"` stderr → None+INFO, malformed JSON → None+WARNING, Timeout → None+WARNING.
- `DeploymentCredentialService.persist_activation_links`: Admin-Eintrag → 1 Zeile mit `group_id IS NULL`; 2 Gruppen-Einträge mit Mapping → 2 Zeilen mit korrekter `group_id`; unbekannter Username → 0 Zeilen + Warning; URL mit Trailing-`\n` → gespeichert ohne.
- Migration: `alembic upgrade head` gegen Dev-PG → `SELECT enum_range(NULL::accesstype);` enthält `ACTIVATION_LINK`.

**End-to-End:**
1. Overleaf-Deployment mit ≥1 Gruppe via Wizard starten.
2. Im Deployment-Log nach `Persisted N activation-link credential(s) for stack 1` suchen.
3. Dozenten-Credentials-View: zusätzliche „Aktivierungslink"-Zeile (Admin) + eine pro Gruppe (separater Frontend-PR).
4. Als Student in „Gruppe 1" → `/api/v1/student/.../credentials` zeigt nur den eigenen Gruppen-Link.
5. Negativ-Fall: `create_overleaf_users=false` → Playbook schreibt keine JSON → Deployment-Log enthält INFO `Remote file not present, skipping: /opt/dozilab/OVERLEAF_USERS.json`. Deployment erfolgreich.

## Verbundene PRs

- Frontend-PR (folgt) — rendert die neuen `activation_link`-Zeilen als klickbaren Link, Password-Block ausgeblendet.
- AppStore-Apps `main`: Playbook-`trim`-Filter für die Activation-URL-Extraktion (Trailing-`\n` aus Overleaf-CLI-Output entfernen).