### PR TITLE
feat(deployments): auto-resolve course groups on deployment create

### DIFF
--- a/src/services/deployment_service.py
+++ b/src/services/deployment_service.py
@@ -138,6 +138,7 @@ class DeploymentService:
         # Get or create Course entry based on keycloak_course_id
         # The course_id from frontend is the Keycloak group ID
         from src.models.course import Course
+        from src.models.course_group import CourseGroup
         keycloak_course_id = deployment_data.course_id
 
         course = self.db.query(Course).filter(
@@ -145,13 +146,37 @@ class DeploymentService:
         ).first()
 
         if not course:
-            # Auto-create course entry with deployment name as course name
             course = Course(
                 name=deployment_data.name,
                 keycloak_course_id=keycloak_course_id
             )
             self.db.add(course)
-            self.db.flush()  # Get the ID without committing
+            self.db.flush()
+
+        # Get or create CourseGroup rows for every group in the stack assignments.
+        # This ensures group_id is always stamped onto credential rows so students
+        # can see their credentials via /api/v1/student/, regardless of whether the
+        # wizard already passed course_group_id (first deployment = no pre-existing rows).
+        group_name_to_id: dict[str, str] = {
+            g.name: g.id
+            for g in self.db.query(CourseGroup).filter(
+                CourseGroup.course_id == str(course.id)
+            ).all()
+        }
+        for sa in deployment_data.stack_assignments:
+            for group in sa.groups:
+                if group.group_name not in group_name_to_id:
+                    new_group = CourseGroup(
+                        course_id=str(course.id),
+                        name=group.group_name,
+                    )
+                    self.db.add(new_group)
+                    self.db.flush()
+                    group_name_to_id[group.group_name] = new_group.id
+                # Backfill course_group_id so deploy_tasks stamps the FK onto
+                # DeploymentInstanceAccess rows — even on the first deployment.
+                if not group.course_group_id:
+                    group.course_group_id = group_name_to_id[group.group_name]
 
         # Validate the target OpenStack project: must belong to the teacher
         # submitting this request. ``teacher_user`` was already resolved


### PR DESCRIPTION
## Summary

Moves `course_groups` get-or-create out of the frontend wizard and into `DeploymentService.create_deployment`. For every group referenced by the incoming `stack_assignments`, the service now:

1. Looks up an existing `CourseGroup` row by `(course_id, name)`, or creates one if missing.
2. Backfills `course_group_id` on the request payload when the client passed `null`, so `deploy_tasks` can stamp the FK onto `DeploymentInstanceAccess` rows.

## Motivation

Previously, the wizard had to:

- resolve the internal `courses.id` for the selected Keycloak group via `GET /courses`,
- pre-create `course_groups` rows via `POST /courses/{id}/groups` before submitting the deployment.

That flow had two failure modes:

1. On the very first deployment of a course (no `courses` row yet, no `course_groups` rows yet), the wizard couldn't resolve the internal course id and submitted `course_group_id: null`. Credential rows then had `group_id = NULL` and students lost visibility via `/api/v1/student/`.
2. If the wizard's `course_groups` bootstrapping hit an HTTP error, it aborted the deployment with a user-facing toast — even though the backend already had `Course` get-or-create logic and was capable of doing the same for groups.

Doing this server-side guarantees that `course_group_id` is always populated, regardless of which client submits the deployment.

## Changes

- `src/services/deployment_service.py`: after the existing `Course` get-or-create, build a `{group_name: course_group_id}` map for the course; create missing `CourseGroup` rows; backfill `course_group_id` on any `stack_assignments[].groups[]` entry that arrived with `None`.

## Companion PR

- Frontend: `DoziLab/appstore-frontend` — `refactor/move-course-group-resolution-to-backend` → `staging`

## Test plan

- [ ] Deploy a brand-new course (no prior `courses` or `course_groups` rows) — confirm `course_groups` rows are auto-created and `DeploymentInstanceAccess.group_id` is non-null.
- [ ] Deploy into an existing course — confirm existing `course_groups` are reused (no duplicates), names are matched case-sensitively as before.
- [ ] Deploy with a client that still sends a populated `course_group_id` (older frontend build) — confirm the value is honoured, not overwritten.