### PR TITLE
feat: publish-request flow + semver version validation

### DIFF
--- a/alembic/versions/e3a91d7b5c42_add_publish_requested_to_templates.py
+++ b/alembic/versions/e3a91d7b5c42_add_publish_requested_to_templates.py
@@ -1,0 +1,98 @@
+"""add publish_requested to templates
+
+Revision ID: e3a91d7b5c42
+Revises: d5e8c2a91b34
+Create Date: 2026-06-29 12:00:00.000000
+
+Owner-Wunsch „bei Erstellung öffentlich" soll das Template NICHT sofort auf
+`visibility=PUBLIC` flippen, sondern als PRIVATE + `publish_requested=TRUE`
+anlegen. Sobald ein Admin die erste Version genehmigt, übernimmt die
+Service-Logik den Flip auf PUBLIC. Bei Rejection wird der Wunsch verworfen.
+
+Data-Migration:
+- Bestehende PUBLIC-Templates OHNE eine APPROVED Version werden auf
+  PRIVATE + publish_requested=TRUE zurückgesetzt — sie entsprechen dem neuen
+  Erwartungs-Zustand „wartet noch auf die Erst-Freigabe". Templates mit
+  mindestens einer APPROVED Version bleiben unangetastet.
+- Logging via `op.execute` mit RAISE NOTICE in einem DO-Block, damit die
+  Anzahl der betroffenen Templates im Migrations-Output erscheint.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'e3a91d7b5c42'
+down_revision: Union[str, Sequence[str], None] = 'd5e8c2a91b34'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add publish_requested column + backfill stale PUBLIC templates."""
+    op.add_column(
+        'templates',
+        sa.Column(
+            'publish_requested',
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+
+    # Backfill: PUBLIC-Templates ohne approved Version → PRIVATE + publish_requested.
+    # Wir machen das atomar mit einem CTE, damit das gleichzeitige UPDATE auf
+    # visibility und publish_requested auf derselben Treffermenge läuft.
+    op.execute(
+        """
+        WITH stale_public AS (
+            SELECT t.id
+            FROM templates t
+            WHERE t.visibility = 'PUBLIC'
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM template_versions tv
+                  WHERE tv.template_id = t.id
+                    AND tv.approval_status = 'APPROVED'
+              )
+        )
+        UPDATE templates
+        SET visibility = 'PRIVATE',
+            publish_requested = TRUE
+        WHERE id IN (SELECT id FROM stale_public);
+        """
+    )
+
+    # Optional: kurze Notice für Operator-Sichtbarkeit. Postgres-spezifisch;
+    # auf SQLite (Tests) ist das ein No-Op via try/except.
+    op.execute(
+        """
+        DO $$
+        DECLARE
+            affected_count INTEGER;
+        BEGIN
+            SELECT COUNT(*) INTO affected_count
+            FROM templates WHERE publish_requested = TRUE;
+            RAISE NOTICE '[migration e3a91d7b5c42] Backfilled % template(s) to PRIVATE+publish_requested', affected_count;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    """Drop publish_requested.
+
+    Vor dem Drop flippen wir publish_requested=TRUE-Templates wieder zu PUBLIC,
+    damit deren Owner sie nicht „verlieren" — verlustbehaftet, aber näher am
+    pre-Migration-Zustand als „still privat ohne Erinnerung". Beide Pfade
+    haben Trade-offs; das ist die explizite Wahl.
+    """
+    op.execute(
+        """
+        UPDATE templates
+        SET visibility = 'PUBLIC'
+        WHERE publish_requested = TRUE;
+        """
+    )
+    op.drop_column('templates', 'publish_requested')

--- a/alembic/versions/ebc91d7b5d43_unique_template_version_string.py
+++ b/alembic/versions/ebc91d7b5d43_unique_template_version_string.py
@@ -1,0 +1,98 @@
+"""unique (template_id, version) on template_versions
+
+Revision ID: ebc91d7b5d43
+Revises: e3a91d7b5c42
+Create Date: 2026-06-29 12:05:00.000000
+
+Vor dieser Migration konnten innerhalb eines Templates beliebig viele Rows
+mit identischem ``version``-String existieren — nur ``(template_id, commit_sha)``
+war unique. Praxis-Effekt: jedes Repo, das `app.yaml.app.version` nicht bumpte,
+landete bei „v2.0.0, v2.0.0, v2.0.0, …".
+
+Daten-Migration:
+- Schritt 1: bestehende Duplikate von ``(template_id, version)`` deduplizieren.
+  Wir behalten die NEUESTE Row (höchste ``created_at``, Tie-Break per ``id``)
+  unverändert und hängen an die übrigen ``+dedupe-<short_sha>`` an. Die
+  Build-Metadata-Komponente (alles nach ``+``) ist laut Semver-Spec gültig
+  UND sortier-neutral — der Owner sieht im UI „2.0.0+dedupe-abc12345" und
+  kann das Item bei Bedarf umbenennen.
+- Schritt 2: ``UniqueConstraint`` auf ``(template_id, version)`` setzen.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'ebc91d7b5d43'
+down_revision: Union[str, Sequence[str], None] = 'e3a91d7b5c42'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Dedupe + unique constraint."""
+    # Schritt 1: alle Duplikate außer der jeweils neuesten umbenennen.
+    # Wir nutzen eine CTE mit ROW_NUMBER, partitioniert auf (template_id, version),
+    # sortiert auf created_at DESC, id DESC. rn=1 ist die zu behaltende Row,
+    # rn>=2 wird umbenannt zu „<version>+dedupe-<first8(commit_sha)>".
+    op.execute(
+        """
+        WITH ranked AS (
+            SELECT
+                id,
+                template_id,
+                version,
+                git_commit_sha,
+                ROW_NUMBER() OVER (
+                    PARTITION BY template_id, version
+                    ORDER BY created_at DESC, id DESC
+                ) AS rn
+            FROM template_versions
+        )
+        UPDATE template_versions tv
+        SET version = ranked.version || '+dedupe-' || SUBSTRING(ranked.git_commit_sha FROM 1 FOR 8)
+        FROM ranked
+        WHERE tv.id = ranked.id
+          AND ranked.rn > 1;
+        """
+    )
+
+    # Edge-Case: nach Schritt 1 könnte das umbenannte Suffix theoretisch erneut
+    # mit etwas existing kollidieren („1.0.0+dedupe-abc12345" war schon da).
+    # Praktisch unwahrscheinlich (commit_sha-Prefix), aber wir loggen die
+    # Gesamtzahl der renames für den Operator.
+    op.execute(
+        """
+        DO $$
+        DECLARE
+            renamed_count INTEGER;
+        BEGIN
+            SELECT COUNT(*) INTO renamed_count
+            FROM template_versions
+            WHERE version LIKE '%+dedupe-%';
+            RAISE NOTICE '[migration ebc91d7b5d43] Renamed % duplicate version row(s) to ''<version>+dedupe-<sha>''', renamed_count;
+        END $$;
+        """
+    )
+
+    # Schritt 2: jetzt darf die Constraint angelegt werden.
+    op.create_unique_constraint(
+        'uq_template_versions_template_id_version',
+        'template_versions',
+        ['template_id', 'version'],
+    )
+
+
+def downgrade() -> None:
+    """Drop the unique constraint.
+
+    Die ``+dedupe-…``-Suffixe werden bewusst NICHT entfernt — sie sind valider
+    Semver-Build-Metadata-Anteil und liefern Rückverfolgbarkeit. Wer einen
+    sauberen Rollback will, muss die Suffixe per SQL gezielt rückbauen.
+    """
+    op.drop_constraint(
+        'uq_template_versions_template_id_version',
+        'template_versions',
+        type_='unique',
+    )

--- a/src/api/template_versions.py
+++ b/src/api/template_versions.py
@@ -113,6 +113,14 @@ async def list_approval_queue(
         None,
         description="Optional: filter by parent template visibility (private/public)",
     ),
+    include_publish_requested: bool = Query(
+        True,
+        description=(
+            "When visibility=public, also include PRIVATE templates that have "
+            "publish_requested=true (templates waiting for their first approval "
+            "before being promoted to PUBLIC). Default True."
+        ),
+    ),
     sort: Literal[
         "created_at_desc",
         "created_at_asc",
@@ -130,8 +138,8 @@ async def list_approval_queue(
     - The parent template's metadata (`template.{name, owner_id, visibility}`)
     - The parsed `parameters` from app.yaml (resource requirements)
 
-    Filters: `status`, `template_id`, `visibility`. Sortable via `sort`.
-    Admin-only.
+    Filters: `status`, `template_id`, `visibility`, `include_publish_requested`.
+    Sortable via `sort`. Admin-only.
     """
     service = TemplateVersionService(db)
 
@@ -142,6 +150,7 @@ async def list_approval_queue(
         template_id=str(template_id) if template_id else None,
         visibility=visibility,
         sort=sort,
+        include_publish_requested=include_publish_requested,
     )
 
     items = []

--- a/src/api/templates.py
+++ b/src/api/templates.py
@@ -213,15 +213,19 @@ async def import_template_from_github(
 ):
     """Create a new template plus its first version from a GitHub repository.
 
-    The template is always created with `visibility=private` (matching
-    `POST /templates`); admins can promote to public later via PATCH. The first
-    version follows the standard per-version approval rules.
+    Sichtbarkeitsregel:
+    - ``visibility=private`` (Default) → Template ist sofort owner-only nutzbar,
+      kein Approval-Flow.
+    - ``visibility=public`` → Template wird ALS PRIVATE + ``publish_requested=True``
+      persistiert; die erste Version geht durch den Admin-Approval-Flow. Erst
+      beim ersten approve_version() flippt das Template atomar auf PUBLIC.
+      So sieht der Owner sofort „wartet auf Erst-Freigabe" statt eines
+      fälschlich-öffentlichen Templates ohne approved Version. Admin-Caller
+      umgehen den Flow (Auto-Approval + Direkt-Promotion).
 
-    For private repos the calling user must have linked our GitHub App via
-    `POST /auth/github/install`. Public repos work without an installation
-    (subject to GitHub's 60/h unauthenticated rate limit). The endpoint
-    resolves the repo's commit SHA, fetches `app.yaml`, and persists every
-    file in the same folder as a new Template + TemplateVersion + files.
+    Für private Repos muss der Caller unsere GitHub App via
+    ``POST /auth/github/install`` verbunden haben. Public Repos funktionieren
+    auch ohne Installation (GitHub-API 60/h-Rate-Limit).
     """
     service = GithubImportService(db)
     template = service.import_to_new_template(
@@ -273,6 +277,7 @@ async def import_new_version_from_github(
         is_active=payload.is_active,
         user_id=current_user["user_id"],
         user_roles=current_user.get("roles", []),
+        replace_existing=payload.replace_existing,
     )
 
     version_response = TemplateVersionResponse.model_validate(version)

--- a/src/core/exceptions.py
+++ b/src/core/exceptions.py
@@ -4,6 +4,7 @@ This module provides custom exception handlers for FastAPI to ensure
 consistent error responses across all endpoints using ResponseBuilder.
 """
 import logging
+from typing import Any
 
 from fastapi import Request, status
 from fastapi.exceptions import RequestValidationError
@@ -121,7 +122,7 @@ async def http_exception_handler(
     # branchst auf `errors.code` (z.B. „VERSION_ALREADY_EXISTS") und kann
     # `errors.details` als Datenträger nutzen, statt den `message`-String
     # per Regex zu parsen.
-    errors_payload = None
+    errors_payload: dict[str, Any] | None = None
     if isinstance(exc, BadRequestException) and exc.code:
         errors_payload = {"code": exc.code}
         if exc.details:

--- a/src/core/exceptions.py
+++ b/src/core/exceptions.py
@@ -31,10 +31,28 @@ class ForbiddenException(StarletteHTTPException):
 
 
 class BadRequestException(StarletteHTTPException):
-    """Exception raised for invalid client requests."""
-    
-    def __init__(self, message: str = "Invalid request"):
+    """Exception raised for invalid client requests.
+
+    Trägt optional einen strukturierten ``code`` und ``details``-Payload, damit
+    Clients gezielt darauf branchen können (z.B. „Version-String bereits
+    vergeben → Replace-Pfad anbieten") statt Fehlertexte per Regex zu parsen.
+    Der ``message`` bleibt menschenlesbar; ``code`` ist eine kurze
+    SCREAMING_SNAKE-Konvention, ``details`` ein beliebiges JSON-fähiges Dict.
+
+    Wenn nur ``message`` gesetzt ist, verhält sich die Exception identisch zu
+    vorher — Bestandscode bleibt 1:1 kompatibel.
+    """
+
+    def __init__(
+        self,
+        message: str = "Invalid request",
+        *,
+        code: str | None = None,
+        details: dict | None = None,
+    ):
         super().__init__(status_code=status.HTTP_400_BAD_REQUEST, detail=message)
+        self.code = code
+        self.details = details or None
 
 
 class ConflictException(StarletteHTTPException):
@@ -98,11 +116,22 @@ async def http_exception_handler(
             "event": "http_exception"
         }
     )
-    
+
+    # Strukturierte BadRequest-Codes mitgeben, wenn vorhanden: das Frontend
+    # branchst auf `errors.code` (z.B. „VERSION_ALREADY_EXISTS") und kann
+    # `errors.details` als Datenträger nutzen, statt den `message`-String
+    # per Regex zu parsen.
+    errors_payload = None
+    if isinstance(exc, BadRequestException) and exc.code:
+        errors_payload = {"code": exc.code}
+        if exc.details:
+            errors_payload["details"] = exc.details
+
     return ResponseBuilder.error(
         message=str(exc.detail),
         status_code=exc.status_code,
         request_id=request_id,
+        errors=errors_payload,
     )
 
 

--- a/src/models/template.py
+++ b/src/models/template.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from uuid import uuid4
 
-from sqlalchemy import String, DateTime, Enum as SQLEnum, Text, ForeignKey
+from sqlalchemy import String, DateTime, Enum as SQLEnum, Text, ForeignKey, Boolean
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.core.database import Base
@@ -33,6 +33,19 @@ class Template(Base):
     visibility: Mapped[TemplateVisibility] = mapped_column(
         SQLEnum(TemplateVisibility),
         default=TemplateVisibility.PRIVATE
+    )
+    # Owner-Wunsch „bitte veröffentlichen, sobald erste Version approved ist".
+    # Wir flippen das Template NICHT direkt auf PUBLIC, wenn der Owner beim
+    # Erstellen „öffentlich" wählt — stattdessen bleibt es PRIVATE und dieses
+    # Flag merkt sich den Veröffentlichungswunsch. Beim ersten admin-approve
+    # einer Version flippt die Service-Logik atomar `visibility → PUBLIC` und
+    # `publish_requested → False`. Bei reject wird der Wunsch verworfen;
+    # Owner muss erneut über PATCH `visibility: public` anstoßen.
+    publish_requested: Mapped[bool] = mapped_column(
+        Boolean,
+        default=False,
+        nullable=False,
+        server_default="false",
     )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))

--- a/src/models/template_version.py
+++ b/src/models/template_version.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
-from sqlalchemy import String, DateTime, Boolean, ForeignKey, Text, Enum as SQLEnum
+from sqlalchemy import String, DateTime, Boolean, ForeignKey, Text, Enum as SQLEnum, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.core.database import Base
@@ -27,6 +27,19 @@ class TemplateVersion(Base):
     """Template Version database model."""
 
     __tablename__ = "template_versions"
+    __table_args__ = (
+        # Pro Template darf jede Versionsnummer nur einmal vorkommen.
+        # Der UI-Pfad „neue Versionen importieren" landete sonst bei
+        # ``2.0.0, 2.0.0, 2.0.0, …`` für Repos, die `app.yaml.app.version`
+        # nicht bumpen. Validierung läuft zusätzlich im Service-Layer
+        # (``src/utils/version_validator.py``), damit der Owner eine
+        # erklärende Fehlermeldung statt eines IntegrityError sieht.
+        UniqueConstraint(
+            'template_id',
+            'version',
+            name='uq_template_versions_template_id_version',
+        ),
+    )
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
     template_id: Mapped[str] = mapped_column(

--- a/src/repositories/template_version_repository.py
+++ b/src/repositories/template_version_repository.py
@@ -151,6 +151,7 @@ class TemplateVersionRepository(BaseRepository[TemplateVersion]):
         template_id: Optional[str | UUID] = None,
         visibility: Optional[TemplateVisibility] = None,
         sort: QueueSort = "created_at_desc",
+        include_publish_requested: bool = True,
     ) -> tuple[list[tuple[TemplateVersion, Template]], int]:
         """List versions filtered by approval status, joined with their template.
 
@@ -161,6 +162,14 @@ class TemplateVersionRepository(BaseRepository[TemplateVersion]):
         Optional filters narrow the queue: `template_id` to a single template,
         `visibility` to public/private templates only. `sort` selects ordering;
         default is newest-first by `created_at`.
+
+        ``include_publish_requested`` (default ``True``): wenn ``visibility`` auf
+        ``PUBLIC`` gesetzt ist, schließt die Queue zusätzlich Templates ein, die
+        zwar noch ``PRIVATE`` sind, aber ``publish_requested=True`` tragen —
+        also „wartet auf die Erst-Genehmigung, danach wird's PUBLIC". Diese
+        Versionen sind logisch im Marketplace-Pfad und sollen sichtbar sein.
+        Wenn der Admin explizit ``include_publish_requested=False`` setzt,
+        sieht er nur die Versionen tatsächlich-öffentlicher Templates.
         """
         query = (
             self.db.query(self.model, Template)
@@ -172,7 +181,20 @@ class TemplateVersionRepository(BaseRepository[TemplateVersion]):
             query = query.filter(self.model.template_id == str(template_id))
 
         if visibility is not None:
-            query = query.filter(Template.visibility == visibility)
+            if (
+                visibility == TemplateVisibility.PUBLIC
+                and include_publish_requested
+            ):
+                # PUBLIC OR (PRIVATE AND publish_requested)
+                query = query.filter(
+                    (Template.visibility == TemplateVisibility.PUBLIC)
+                    | (
+                        (Template.visibility == TemplateVisibility.PRIVATE)
+                        & (Template.publish_requested.is_(True))
+                    )
+                )
+            else:
+                query = query.filter(Template.visibility == visibility)
 
         total = query.with_entities(func.count(self.model.id)).scalar() or 0
 

--- a/src/schemas/template.py
+++ b/src/schemas/template.py
@@ -61,6 +61,16 @@ class TemplateResponse(BaseModel):
     repo_url: str = Field(..., description="Git repository URL")
     icon_url: Optional[str] = Field(None, description="Icon URL or identifier")
     visibility: str = Field(..., description="Template visibility")
+    publish_requested: bool = Field(
+        default=False,
+        description=(
+            "True wenn der Owner das Template als 'öffentlich' angelegt hat, "
+            "aber noch keine Version genehmigt wurde — Template ist aktuell "
+            "PRIVATE und wartet auf die Erst-Freigabe. Sobald ein Admin die "
+            "erste Version approved, flippt visibility auf PUBLIC und dieses "
+            "Flag wird zurückgesetzt."
+        ),
+    )
     versions: Optional[list[TemplateVersionResponse]] = Field(None, description="List of template versions")
     created_at: datetime = Field(..., description="Creation timestamp")
     updated_at: datetime = Field(..., description="Last update timestamp")
@@ -170,6 +180,16 @@ class GithubImportNewVersion(BaseModel):
     github_url: str = Field(..., description=GITHUB_URL_DESCRIPTION, max_length=1000)
     app_yaml_path: Optional[str] = Field(default=None, max_length=500)
     is_active: bool = Field(default=True, description="Mark the imported version as active")
+    replace_existing: bool = Field(
+        default=False,
+        description=(
+            "Wenn der `app.version`-String im neuen Import bereits existiert: "
+            "True → bestehende Version-Row (inkl. Files) löschen und durch den "
+            "neuen Import ersetzen (blockiert wenn aktive Deployments hängen). "
+            "False (Default) → Backend antwortet mit VERSION_ALREADY_EXISTS, "
+            "Owner soll im Repo bumpen oder explizit ersetzen wählen."
+        ),
+    )
 
     model_config = ConfigDict(
         json_schema_extra={
@@ -177,6 +197,7 @@ class GithubImportNewVersion(BaseModel):
                 "github_url": "https://github.com/dozilab/templates/tree/v1.1",
                 "app_yaml_path": "postgres/app.yaml",
                 "is_active": True,
+                "replace_existing": False,
             }
         }
     )

--- a/src/schemas/template_version.py
+++ b/src/schemas/template_version.py
@@ -156,6 +156,13 @@ class TemplateQueueInfo(BaseModel):
     name: str
     owner_id: str
     visibility: str
+    publish_requested: bool = Field(
+        default=False,
+        description=(
+            "True when this PRIVATE template is awaiting its first approval "
+            "before being promoted to PUBLIC. Admin UI shows a hint."
+        ),
+    )
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/src/services/github_import_service.py
+++ b/src/services/github_import_service.py
@@ -34,6 +34,7 @@ import yaml
 from sqlalchemy.orm import Session
 
 from src.core.exceptions import BadRequestException, NotFoundException, ForbiddenException
+from src.models.deployment import Deployment
 from src.models.template import Template, TemplateVisibility
 from src.models.template_version import TemplateVersion, TemplateVersionApprovalStatus
 from src.models.template_version_file import TemplateVersionFile, FileType
@@ -43,6 +44,7 @@ from src.repositories.template_version_repository import TemplateVersionReposito
 from src.repositories.template_version_file_repository import TemplateVersionFileRepository
 from src.services.github_app_service import GITHUB_API_VERSION, GithubAppService
 from src.services.github_installation_service import GithubInstallationService
+from src.utils import version_validator
 from src.utils.app_manifest_parser import AppManifestParser
 
 logger = logging.getLogger(__name__)
@@ -339,10 +341,27 @@ class GithubImportService:
     ) -> Template:
         """Create a brand-new Template + first TemplateVersion populated from GitHub.
 
-        ``visibility`` defaults to PRIVATE. Pass PUBLIC explicitly to make the
-        template marketplace-visible; the first version then enters the
-        per-version approval flow (PENDING unless caller is admin).
+        ``visibility`` defaults to PRIVATE. Wird PUBLIC explizit übergeben,
+        landet das Template als PRIVATE + ``publish_requested=True`` in der DB:
+        Es bleibt bis zur ersten admin-Genehmigung versteckt und flippt beim
+        ``approve_version()`` atomar auf PUBLIC. So sieht der Owner sofort
+        „wartet auf Erst-Freigabe" statt eines fälschlich-öffentlichen
+        Templates ohne approved Version.
+
+        Admin-Caller umgehen den Wunsch-Umweg nicht — die admin-spezifische
+        Auto-Approval setzt direkt approval_status=APPROVED auf der Version
+        und löst dadurch im approve_version()-Pfad den Flip aus. Hier in
+        ``import_to_new_template`` wird approve_version() aber NICHT
+        aufgerufen, daher müssen wir den Flip für Admin-Caller hier explizit
+        machen.
         """
+        # Wenn der Caller PUBLIC will: Template als PRIVATE + publish_requested
+        # anlegen. ``_initial_approval`` erkennt das (via publish_requested) und
+        # vergibt PENDING/APPROVED genauso wie auf einem echten PUBLIC-Template.
+        wants_public = visibility == TemplateVisibility.PUBLIC
+        effective_visibility = (
+            TemplateVisibility.PRIVATE if wants_public else visibility
+        )
         template = Template(
             id=str(uuid4()),
             name=name,
@@ -350,13 +369,14 @@ class GithubImportService:
             owner_id=owner_user_id,
             repo_url=github_url,
             icon_url=icon_url,
-            visibility=visibility,
+            visibility=effective_visibility,
+            publish_requested=wants_public,
         )
         self.db.add(template)
         self.db.flush()
 
         try:
-            self._import_version_for_template(
+            version = self._import_version_for_template(
                 template=template,
                 github_url=github_url,
                 app_yaml_path=app_yaml_path,
@@ -367,6 +387,25 @@ class GithubImportService:
         except Exception:
             self.db.rollback()
             raise
+
+        # Admin-Caller, die sich ein „öffentlich" gewünscht haben: die erste
+        # Version ist bereits APPROVED (via _initial_approval), also gilt der
+        # Promotion-Trigger sofort. Wir flippen Template-State hier atomar
+        # statt einen separaten approve_version-Roundtrip zu verlangen.
+        if (
+            wants_public
+            and version.approval_status == TemplateVersionApprovalStatus.APPROVED
+        ):
+            template.visibility = TemplateVisibility.PUBLIC
+            template.publish_requested = False
+            logger.info(
+                "Template promoted to public on admin-import (auto-approval)",
+                extra={
+                    "template_id": template.id,
+                    "version_id": str(version.id),
+                    "owner_id": owner_user_id,
+                },
+            )
 
         self.db.commit()
         self.db.refresh(template)
@@ -381,8 +420,16 @@ class GithubImportService:
         is_active: bool,
         user_id: str,
         user_roles: list[str],
+        replace_existing: bool = False,
     ) -> TemplateVersion:
-        """Append a new TemplateVersion (with files) to an existing Template."""
+        """Append a new TemplateVersion (with files) to an existing Template.
+
+        ``replace_existing`` aktiviert den Replace-Pfad bei Kollision auf der
+        Versionsnummer: existiert bereits eine Row mit demselben
+        ``version``-String, wird sie inkl. ihrer Files gelöscht und durch
+        die neu importierte ersetzt. Blockiert, wenn aktive Deployments an
+        der Bestands-Row hängen (`VERSION_REPLACE_BLOCKED_BY_DEPLOYMENTS`).
+        """
         template = self.template_repo.get_by_id(template_id)
         if not template:
             raise NotFoundException(f"Template with ID {template_id} not found")
@@ -400,6 +447,7 @@ class GithubImportService:
             user_id=user_id,
             user_roles=user_roles,
             is_active=is_active,
+            replace_existing=replace_existing,
         )
         self.db.commit()
         self.db.refresh(version)
@@ -418,6 +466,7 @@ class GithubImportService:
         user_id: str,
         user_roles: list[str],
         is_active: bool,
+        replace_existing: bool = False,
     ) -> TemplateVersion:
         parsed_url = self.parse_github_url(github_url)
 
@@ -516,15 +565,89 @@ class GithubImportService:
                     "size": len(content.encode("utf-8")),
                 })
 
-        # Determine version string
+        # Versions-String: ``app.yaml.app.version`` ist Pflicht und einzige
+        # Quelle. Kein Timestamp-Fallback mehr — fehlende oder leere Versionen
+        # sind ein expliziter Fehler, damit das UI dem Owner einen
+        # verlinkbaren „im Repo bumpen"-Pfad anbieten kann (siehe
+        # version_validator.ERR_MISSING_IN_MANIFEST).
         manifest_version = ((parsed_manifest.get("app") or {}).get("version") or "").strip()
-        version_string = manifest_version or self._derive_fallback_version(template.id)
+        if not manifest_version:
+            raise BadRequestException(
+                "`app.yaml` enthält kein `app.version`-Feld (oder es ist leer). "
+                "Bitte ergänze z. B. `app:\\n  version: 1.0.0` im Repo und versuche erneut.",
+                code=version_validator.ERR_MISSING_IN_MANIFEST,
+                details={"manifest_path": effective_app_yaml_path},
+            )
 
-        # Refuse duplicate (template_id, git_commit_sha) - existing constraint
-        existing = self.version_repo.get_by_commit_sha(template.id, commit_sha)
-        if existing:
+        version_validator.assert_valid_semver(manifest_version)
+        version_string = manifest_version
+
+        # Refuse duplicate (template_id, git_commit_sha) - existing constraint.
+        # Wird BEVOR der Versions-String-Check gemacht, weil derselbe Commit
+        # garantiert dieselbe app.yaml und damit dieselbe Versionsnummer hat —
+        # die Fehlermeldung „commit bereits importiert" ist hier präziser.
+        existing_by_sha = self.version_repo.get_by_commit_sha(template.id, commit_sha)
+        if existing_by_sha:
             raise BadRequestException(
                 f"This template already has a version for commit {commit_sha[:8]}"
+            )
+
+        # Versions-String-Uniqueness + Monotonie gegen die existierenden
+        # Versionen. Bei Kollision schlägt der Validator mit
+        # ERR_ALREADY_EXISTS an, was das Frontend differenziert (Replace-
+        # Pfad anbieten) — außer der Caller hat replace_existing=True
+        # mitgegeben, dann lassen wir die Bestands-Row gleich austauschen.
+        existing_versions = template.versions or self.version_repo.get_by_template_id(
+            template.id, active_only=False
+        )
+        existing_strings = [v.version for v in existing_versions]
+
+        replace_target: TemplateVersion | None = None
+        if replace_existing and version_string in existing_strings:
+            # Replace-Pfad: existierende Row mit demselben String identifizieren,
+            # auf Deployment-Refs prüfen, dann löschen. Files sind via
+            # ``cascade="all, delete-orphan"`` an der Version verbunden.
+            replace_target = next(
+                (v for v in existing_versions if v.version == version_string),
+                None,
+            )
+            if replace_target is None:
+                # Race oder Inkonsistenz — defensiv mit klarer Meldung.
+                raise BadRequestException(
+                    f"Cannot find existing version row for '{version_string}' to replace.",
+                )
+
+            deployment_count = (
+                self.db.query(Deployment)
+                .filter(Deployment.template_version_id == replace_target.id)
+                .count()
+            )
+            if deployment_count > 0:
+                raise BadRequestException(
+                    f"Version '{version_string}' kann nicht ersetzt werden: "
+                    f"{deployment_count} aktive Deployment(s) verwenden sie. "
+                    "Bitte bumpe `app.version` im Repo statt zu ersetzen.",
+                    code=version_validator.ERR_REPLACE_BLOCKED_BY_DEPLOYMENTS,
+                    details={
+                        "version": version_string,
+                        "deployment_count": deployment_count,
+                        "existing_version_id": replace_target.id,
+                    },
+                )
+
+            # Replace genehmigt — alte Row löschen. Die Monotonie-Vergleichs-
+            # Liste schließt die Replace-Target-Version aus, weil sie gleich
+            # ersetzt wird; sonst würde ``assert_strictly_greater`` immer
+            # auf ALREADY_EXISTS triggern.
+            self.db.delete(replace_target)
+            self.db.flush()
+            existing_strings = [s for s in existing_strings if s != version_string]
+        else:
+            # Kein Replace gewünscht / Kollision möglich → Validator wirft
+            # entweder ALREADY_EXISTS oder NOT_STRICTLY_GREATER mit Details.
+            version_validator.assert_strictly_greater(
+                version_string,
+                existing_strings,
             )
 
         approval_status = self._initial_approval(template, user_roles)
@@ -603,14 +726,21 @@ class GithubImportService:
     ) -> TemplateVersionApprovalStatus | None:
         """Map (template, caller) to the initial approval status of a new version.
 
-        - Private templates: ``None`` — approval doesn't apply (owner-only).
-        - Public templates, admin caller: ``APPROVED`` (auto-promote).
-        - Public templates, other caller: ``PENDING`` (admin review needed).
+        - PUBLIC templates: admin caller → ``APPROVED`` (auto-promote);
+          everyone else → ``PENDING`` (admin review needed).
+        - PRIVATE templates WITH ``publish_requested=True``: same as PUBLIC.
+          The template hasn't been promoted to PUBLIC yet — that happens
+          atomically on the first approve_version() call — but the approval
+          flow is already running, so new versions must enter PENDING.
+        - PRIVATE templates without publish_requested: ``None`` — approval
+          doesn't apply (owner-only).
 
-        Mirrors ``TemplateVersionService._initial_approval``; both services
-        create versions through different paths but with identical semantics.
+        Mirrored helper — keep in sync with the identical copy in
+        ``TemplateVersionService._initial_approval`` (template_version_service.py).
         """
-        if template.visibility != TemplateVisibility.PUBLIC:
+        is_public = template.visibility == TemplateVisibility.PUBLIC
+        is_pending_public = bool(getattr(template, "publish_requested", False))
+        if not is_public and not is_pending_public:
             return None
         is_admin = UserRole.ADMIN.value in (user_roles or [])
         return (
@@ -618,9 +748,3 @@ class GithubImportService:
             if is_admin
             else TemplateVersionApprovalStatus.PENDING
         )
-
-    @staticmethod
-    def _derive_fallback_version(template_id: str) -> str:
-        """Fallback if app.yaml has no `app.version` field."""
-        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
-        return f"0.0.0+{timestamp}"

--- a/src/services/template_service.py
+++ b/src/services/template_service.py
@@ -229,15 +229,27 @@ class TemplateService:
         
         try:
             # Visibility transition — owner-or-admin (already enforced above for
-            # the whole update payload). The transition itself resets the per-
-            # version approval state so the two views (marketplace vs. private)
-            # don't get mixed up:
-            #   private → public:  any version that was unset (NULL) flips to
-            #                      PENDING, awaiting admin review.
-            #   public → private:  every version's approval state is cleared
-            #                      (NULL) plus approved_by/at/reason are wiped.
+            # the whole update payload). Das Modell ist „Veröffentlichungswunsch
+            # statt Direktflip":
+            #
+            #   private → public, keine APPROVED Version vorhanden:
+            #       wir lassen das Template als PRIVATE stehen und setzen
+            #       ``publish_requested = True``. Das Approval-Flow startet:
+            #       jede ``approval_status=None``-Version flippt auf PENDING
+            #       und landet damit in der Admin-Queue. Erst beim ersten
+            #       erfolgreichen approve_version() flippt der Template-State
+            #       atomar auf PUBLIC.
+            #
+            #   private → public, mindestens eine APPROVED Version:
+            #       der Approval-Umweg ist hier nicht nötig (der Inhalt ist
+            #       schon admin-freigegeben). Wir flippen direkt auf PUBLIC.
+            #
+            #   public → private:
+            #       jeder Versions-Approval-State wird gewischt (NULL +
+            #       Metadaten leer). ``publish_requested`` wird ebenfalls
+            #       zurückgesetzt — ein vorheriger Wunsch ist obsolet, weil
+            #       der Owner gerade explizit auf privat schaltet.
             if "visibility" in update_data:
-                # Validate visibility value
                 try:
                     new_visibility = TemplateVisibility(update_data["visibility"])
                 except ValueError:
@@ -245,14 +257,26 @@ class TemplateService:
 
                 if new_visibility != template.visibility:
                     if new_visibility == TemplateVisibility.PUBLIC:
-                        # private → public: untyped versions enter the approval flow.
-                        # Versions that already carry an explicit state (legacy
-                        # data, or someone toggled back-and-forth) keep theirs.
-                        for v in template.versions:
-                            if v.approval_status is None:
-                                v.approval_status = TemplateVersionApprovalStatus.PENDING
+                        has_approved_version = any(
+                            v.approval_status == TemplateVersionApprovalStatus.APPROVED
+                            for v in template.versions
+                        )
+                        if has_approved_version:
+                            # Direkter Flip; ``publish_requested`` ggf. mit zurücksetzen.
+                            update_data["publish_requested"] = False
+                        else:
+                            # Veröffentlichungswunsch statt Direktflip — wir
+                            # blocken die ``visibility``-Änderung im Update,
+                            # damit das Template PRIVATE bleibt, und setzen
+                            # stattdessen das Wunsch-Flag.
+                            del update_data["visibility"]
+                            update_data["publish_requested"] = True
+                            for v in template.versions:
+                                if v.approval_status is None:
+                                    v.approval_status = TemplateVersionApprovalStatus.PENDING
                     else:
-                        # public → private: approval state is no longer meaningful.
+                        # public → private: Approval-State wischen, Wunsch löschen.
+                        update_data["publish_requested"] = False
                         for v in template.versions:
                             v.approval_status = None
                             v.approved_by_id = None

--- a/src/services/template_version_service.py
+++ b/src/services/template_version_service.py
@@ -19,6 +19,7 @@ from src.schemas.template_version import (
     TemplateVersionWithFilesCreate,
 )
 from src.core.exceptions import NotFoundException, BadRequestException, ForbiddenException
+from src.utils import version_validator
 from src.utils.app_manifest_parser import AppManifestParser
 
 logger = logging.getLogger(__name__)
@@ -115,11 +116,24 @@ class TemplateVersionService:
     ) -> TemplateVersionApprovalStatus | None:
         """Map (template, caller) to the initial approval status of a new version.
 
-        - Private templates: ``None`` — approval doesn't apply (owner-only).
-        - Public templates, admin caller: ``APPROVED`` (auto-promote).
-        - Public templates, other caller: ``PENDING`` (admin review needed).
+        - PUBLIC templates: admin caller → ``APPROVED`` (auto-promote);
+          everyone else → ``PENDING`` (admin review needed).
+        - PRIVATE templates WITH ``publish_requested=True``: same as PUBLIC.
+          The template hasn't been promoted to PUBLIC yet — that happens
+          atomically on the first approve_version() call — but the approval
+          flow is already running, so new versions must enter PENDING and
+          show up in the admin queue.
+        - PRIVATE templates without publish_requested: ``None`` — approval
+          doesn't apply (owner-only).
+
+        Mirrored helper — keep in sync with the identical copy in
+        ``GithubImportService._initial_approval`` (github_import_service.py).
+        Both services create versions through different paths but with
+        identical semantics.
         """
-        if template.visibility != TemplateVisibility.PUBLIC:
+        is_public = template.visibility == TemplateVisibility.PUBLIC
+        is_pending_public = bool(getattr(template, "publish_requested", False))
+        if not is_public and not is_pending_public:
             return None
         is_admin = UserRole.ADMIN.value in (user_roles or [])
         return (
@@ -139,6 +153,12 @@ class TemplateVersionService:
 
         Approval status is decided by `_initial_approval`. If `user_roles` is
         not provided, falls back to is_admin to keep older callers compatible.
+
+        Versionsnummer-Regeln (auch hier durchgesetzt, nicht nur im
+        GitHub-Import-Pfad):
+        - Muss valid Semver-2.0 sein.
+        - Muss innerhalb des Templates eindeutig sein.
+        - Muss strikt größer als die höchste existierende Semver-Version sein.
         """
         template = self.template_repo.get_by_id(version_data.template_id)
         if not template:
@@ -155,6 +175,19 @@ class TemplateVersionService:
             raise BadRequestException(
                 f"Version with commit SHA {version_data.git_commit_sha} already exists for this template"
             )
+
+        # Semver + Uniqueness + Monotonie. Wirft strukturiert mit den
+        # ERR_*-Codes, das Frontend kann pro Code unterschiedlich reagieren.
+        existing_strings = [
+            v.version
+            for v in self.version_repo.get_by_template_id(
+                version_data.template_id, active_only=False
+            )
+        ]
+        version_validator.assert_strictly_greater(
+            version_data.version,
+            existing_strings,
+        )
 
         roles = user_roles if user_roles is not None else ([UserRole.ADMIN.value] if is_admin else [])
         approval_status = self._initial_approval(template, roles)
@@ -203,6 +236,20 @@ class TemplateVersionService:
             raise BadRequestException(
                 f"Version with commit SHA {payload.git_commit_sha} already exists for this template"
             )
+
+        # Versionsnummer-Validierung (semver, eindeutig, strikt monoton).
+        # Selbe Regeln wie im GitHub-Import-Pfad, hier aber auf den vom
+        # User direkt übergebenen Payload-String angewendet.
+        existing_strings = [
+            v.version
+            for v in self.version_repo.get_by_template_id(
+                payload.template_id, active_only=False
+            )
+        ]
+        version_validator.assert_strictly_greater(
+            payload.version,
+            existing_strings,
+        )
 
         # Build merged file set: base_version's files first, payload.files overlay by file_path
         merged: dict[str, dict] = {}
@@ -310,16 +357,30 @@ class TemplateVersionService:
     ) -> TemplateVersion:
         """Admin-only: mark a pending version as approved.
 
-        Raises ``BadRequestException`` if the parent template is private —
-        the approval concept doesn't apply there (visit /templates/{id} with
-        ``visibility=public`` first).
+        Erlaubt für:
+        - ``visibility == PUBLIC`` (Standard-Approval-Flow auf bereits
+          öffentlichen Templates).
+        - ``visibility == PRIVATE`` UND ``publish_requested == True``
+          (Erst-Veröffentlichung: das Template wurde mit „öffentlich"
+          angelegt, ist bis zur ersten Genehmigung aber privat geblieben).
+          In diesem Fall flippt diese Methode atomar
+          ``template.visibility → PUBLIC`` und
+          ``template.publish_requested → False``.
+
+        Wirft ``BadRequestException`` für genuinly-private Templates ohne
+        publish_requested — dort macht der Approval-Begriff keinen Sinn.
         """
         version = self.version_repo.get_by_id(version_id)
         if not version:
             raise NotFoundException(f"Template version with ID {version_id} not found")
 
         template = self.template_repo.get_by_id(version.template_id)
-        if not template or template.visibility != TemplateVisibility.PUBLIC:
+        if not template:
+            raise NotFoundException(f"Template with ID {version.template_id} not found")
+
+        is_public = template.visibility == TemplateVisibility.PUBLIC
+        is_pending_public = bool(getattr(template, "publish_requested", False))
+        if not is_public and not is_pending_public:
             raise BadRequestException(
                 "Approval flow applies only to public templates"
             )
@@ -328,8 +389,28 @@ class TemplateVersionService:
         version.approved_by_id = admin_user_id
         version.approved_at = datetime.now(timezone.utc)
         version.rejection_reason = None
+
+        # Erst-Veröffentlichung: Template jetzt atomar auf PUBLIC heben.
+        # Wir loggen den Promotion-Event separat, weil er für Audit-Zwecke
+        # bedeutsamer ist als ein normales approve.
+        promoted_to_public = False
+        if not is_public and is_pending_public:
+            template.visibility = TemplateVisibility.PUBLIC
+            template.publish_requested = False
+            promoted_to_public = True
+
         self.db.commit()
         self.db.refresh(version)
+
+        if promoted_to_public:
+            logger.info(
+                "Template promoted to public on first approval",
+                extra={
+                    "template_id": template.id,
+                    "version_id": str(version.id),
+                    "approved_by": admin_user_id,
+                },
+            )
 
         logger.info(
             "Template version approved",
@@ -337,6 +418,7 @@ class TemplateVersionService:
                 "version_id": str(version.id),
                 "template_id": version.template_id,
                 "approved_by": admin_user_id,
+                "promoted_to_public": promoted_to_public,
             },
         )
         return version
@@ -351,15 +433,26 @@ class TemplateVersionService:
 
         ``reason`` is optional free-text persisted on the version.
 
-        Raises ``BadRequestException`` if the parent template is private —
-        the approval concept doesn't apply there.
+        Erlaubt für die gleichen Fälle wie ``approve_version`` (siehe dort).
+        Bei Rejection eines Templates mit ``publish_requested=True`` wird
+        der Veröffentlichungswunsch verworfen: das Template bleibt PRIVATE
+        und ``publish_requested → False``. Der Owner muss eine neue
+        Veröffentlichung explizit über PATCH `visibility: public` anstoßen
+        — so wird verhindert, dass jeder neue Versions-Import einer
+        bereits abgelehnten Initiative automatisch erneut in die
+        Admin-Queue rutscht.
         """
         version = self.version_repo.get_by_id(version_id)
         if not version:
             raise NotFoundException(f"Template version with ID {version_id} not found")
 
         template = self.template_repo.get_by_id(version.template_id)
-        if not template or template.visibility != TemplateVisibility.PUBLIC:
+        if not template:
+            raise NotFoundException(f"Template with ID {version.template_id} not found")
+
+        is_public = template.visibility == TemplateVisibility.PUBLIC
+        is_pending_public = bool(getattr(template, "publish_requested", False))
+        if not is_public and not is_pending_public:
             raise BadRequestException(
                 "Approval flow applies only to public templates"
             )
@@ -368,6 +461,12 @@ class TemplateVersionService:
         version.approved_by_id = admin_user_id
         version.approved_at = datetime.now(timezone.utc)
         version.rejection_reason = reason
+
+        publish_request_cleared = False
+        if not is_public and is_pending_public:
+            template.publish_requested = False
+            publish_request_cleared = True
+
         self.db.commit()
         self.db.refresh(version)
 
@@ -378,6 +477,7 @@ class TemplateVersionService:
                 "template_id": version.template_id,
                 "rejected_by": admin_user_id,
                 "has_reason": reason is not None,
+                "publish_request_cleared": publish_request_cleared,
             },
         )
         return version
@@ -464,6 +564,24 @@ class TemplateVersionService:
 
         update_data = version_data.model_dump(exclude_unset=True)
 
+        # Versions-String-Änderungen validieren: Semver + Uniqueness +
+        # Monotonie. Wir prüfen NUR, wenn der Caller das Feld setzt; sonst
+        # bleibt die existierende Versionsnummer wie sie ist (auch dann,
+        # wenn sie z.B. nach Dedupe-Migration "+dedupe-..." enthält).
+        new_version_str = update_data.get("version")
+        if new_version_str is not None and new_version_str != version.version:
+            existing_strings = [
+                v.version
+                for v in self.version_repo.get_by_template_id(
+                    version.template_id, active_only=False
+                )
+                if v.id != version.id  # eigene Row aus der Vergleichsmenge raus
+            ]
+            version_validator.assert_strictly_greater(
+                new_version_str,
+                existing_strings,
+            )
+
         if update_data.get("is_active") is True:
             self.version_repo.deactivate_other_versions(
                 version.template_id,
@@ -512,7 +630,14 @@ class TemplateVersionService:
         user_id: str,
         is_admin: bool = False
     ) -> TemplateVersion:
-        """Activate a version (owner-or-admin)."""
+        """Activate a version (owner-or-admin).
+
+        Setzt ``is_active=True`` auf der gewählten Version und deaktiviert
+        alle anderen Versionen desselben Templates. Es gibt keine Sperre
+        gegen Downgrades — der Owner darf eine ältere Version wieder zur
+        aktiven (= im DeploymentWizard vorausgewählten) Version machen,
+        falls die jüngste Version z.B. einen Bug hat.
+        """
         version = self.version_repo.get_by_id(version_id)
         if not version:
             raise NotFoundException(f"Template version with ID {version_id} not found")
@@ -542,6 +667,7 @@ class TemplateVersionService:
         template_id: Optional[str | UUID] = None,
         visibility: Optional[TemplateVisibility] = None,
         sort: QueueSort = "created_at_desc",
+        include_publish_requested: bool = True,
     ) -> tuple[list[tuple[TemplateVersion, Template]], int]:
         """Admin approval queue: list versions filtered by approval status.
 
@@ -549,6 +675,12 @@ class TemplateVersionService:
         admin-only authorization before invoking this.
 
         Returns `(rows, total)` where each row is `(version, template)`.
+
+        ``include_publish_requested`` (default ``True``): siehe
+        ``TemplateVersionRepository.list_by_approval_status``. Mit dem Default
+        sieht der Admin auch Versionen aus PRIVATE-Templates, die auf ihre
+        Erst-Genehmigung warten — sonst würden Neu-Anlagen via „öffentlich"
+        unauffindbar in der Queue versanden.
         """
         return self.version_repo.list_by_approval_status(
             approval_status=approval_status,
@@ -557,6 +689,7 @@ class TemplateVersionService:
             template_id=template_id,
             visibility=visibility,
             sort=sort,
+            include_publish_requested=include_publish_requested,
         )
 
     def get_version_parameters(self, version_id: str | UUID) -> list[dict]:

--- a/src/utils/version_validator.py
+++ b/src/utils/version_validator.py
@@ -61,7 +61,12 @@ def _parse_prerelease_key(prerelease: str | None) -> tuple:
     """
     if prerelease is None:
         return (1,)  # ranks higher than any (0, …) prerelease key
-    parts = []
+    # Jeder Identifier wird zu (kind, value): kind=0 für numeric, kind=1 für
+    # alphanumeric. ``value`` ist also int oder str, je nach Identifier —
+    # die Typ-Annotation muss das mit ``int | str`` ausdrücken, sonst engt
+    # mypy den Listen-Typ nach dem ersten append() auf ``tuple[int, int]``
+    # ein und das zweite append() (mit str) bricht.
+    parts: list[tuple[int, int | str]] = []
     for ident in prerelease.split("."):
         if ident.isdigit():
             # (0, numeric_value) sortiert unter (1, alphanum_value)

--- a/src/utils/version_validator.py
+++ b/src/utils/version_validator.py
@@ -1,0 +1,187 @@
+"""Semver validation and ordering for template-version strings.
+
+Background
+----------
+Vor dieser Datei hat das Backend an mehreren Stellen unkontrolliert
+Versions-Strings übernommen (aus `app.version` in app.yaml, aus manuellem
+Create-Body) ohne Format-Check oder Eindeutigkeit pro Template. Dadurch
+landeten z.B. mehrere Versionen mit `version="2.0.0"` parallel im selben
+Template (nur `(template_id, commit_sha)` war unique).
+
+Diese Helper-Funktionen sind die einzige zentrale Stelle, an der wir
+Versions-Strings gegen Semver-2.0 prüfen und in eine vergleichbare Form
+bringen. Aufrufer sind:
+- ``GithubImportService`` (importiert Versionsnummer aus `app.yaml`)
+- ``TemplateVersionService.create_version`` / ``create_version_with_files``
+  / ``update_version`` (Versionsnummer aus Request)
+
+Auf DB-Ebene gibt es zusätzlich einen ``UniqueConstraint`` auf
+``(template_id, version)`` (Migration ``ebc91d7b5d43``); diese Helper sind
+der user-friendly Vor-Check, damit die Antwort nicht „IntegrityError" lautet.
+"""
+import re
+from typing import Iterable
+
+from src.core.exceptions import BadRequestException
+
+
+# Semver 2.0.0 — `MAJOR.MINOR.PATCH(-PRERELEASE)?(+BUILD)?`. Keine
+# führenden Nullen in den Zahlen, Identifier in Prerelease/Build sind
+# ASCII-alnum + Punkt + Bindestrich. Sehr nah an der offiziellen Referenz-
+# Regex, aber zur Lesbarkeit ungroupt; wir validieren hier nur das Format,
+# das Sortieren übernimmt ``parse_semver``.
+SEMVER_RE = re.compile(
+    r"^(?P<major>0|[1-9]\d*)"
+    r"\.(?P<minor>0|[1-9]\d*)"
+    r"\.(?P<patch>0|[1-9]\d*)"
+    r"(?:-(?P<prerelease>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?"
+    r"(?:\+(?P<build>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
+)
+
+
+# Strukturierte Fehler-Codes für das Frontend-Branching.
+# Konvention: ``BadRequestException(message=…, code=…, details={…})`` —
+# Handler in src/core/exceptions.py reicht beide ins API-`errors`-Feld weiter.
+ERR_NOT_SEMVER = "VERSION_NOT_SEMVER"
+ERR_MISSING_IN_MANIFEST = "VERSION_MISSING_IN_MANIFEST"
+ERR_NOT_STRICTLY_GREATER = "VERSION_NOT_STRICTLY_GREATER"
+ERR_ALREADY_EXISTS = "VERSION_ALREADY_EXISTS"
+ERR_REPLACE_BLOCKED_BY_DEPLOYMENTS = "VERSION_REPLACE_BLOCKED_BY_DEPLOYMENTS"
+
+
+def _parse_prerelease_key(prerelease: str | None) -> tuple:
+    """Build a comparable key for the prerelease portion per semver §11.
+
+    Semver-Sortierung:
+    - Eine fehlende Prerelease ist *größer* als eine vorhandene (1.0.0 > 1.0.0-alpha).
+      Wir kodieren das als ``(1,)`` für „kein prerelease, sortiert oben" und
+      ``(0, …identifier…)`` für „mit prerelease, sortiert unten".
+    - Numerische Identifier vergleichen numerisch, alphanumerische lexikalisch;
+      numerische Identifier sind „kleiner" als alphanumerische bei gleicher Position.
+    """
+    if prerelease is None:
+        return (1,)  # ranks higher than any (0, …) prerelease key
+    parts = []
+    for ident in prerelease.split("."):
+        if ident.isdigit():
+            # (0, numeric_value) sortiert unter (1, alphanum_value)
+            parts.append((0, int(ident)))
+        else:
+            parts.append((1, ident))
+    return (0, tuple(parts))
+
+
+def parse_semver(version: str) -> tuple:
+    """Return a comparable tuple representation of a semver string.
+
+    Build-Metadata (alles nach ``+``) wird laut Semver-Spezifikation NICHT
+    in den Vergleich einbezogen — ``1.0.0+a`` == ``1.0.0+b`` ordnungsweise.
+    Aufrufer, die Eindeutigkeit auf String-Ebene wollen, müssen das selbst
+    prüfen (DB-Constraint übernimmt das).
+
+    Wirft ``ValueError``, wenn der String kein Semver ist. Aufrufer nutzen
+    typischerweise ``is_valid_semver`` zur Vorab-Prüfung.
+    """
+    m = SEMVER_RE.match(version)
+    if not m:
+        raise ValueError(f"Not a valid semver: {version!r}")
+    major = int(m.group("major"))
+    minor = int(m.group("minor"))
+    patch = int(m.group("patch"))
+    pre_key = _parse_prerelease_key(m.group("prerelease"))
+    return (major, minor, patch, pre_key)
+
+
+def is_valid_semver(version: str) -> bool:
+    """Pure boolean check — used by Pydantic validators that already have
+    their own raising path. The raising assert_* below is for service code."""
+    return bool(version) and SEMVER_RE.match(version) is not None
+
+
+def assert_valid_semver(version: str) -> None:
+    """Raise ``BadRequestException(ERR_NOT_SEMVER)`` if invalid.
+
+    Klar formulierte Fehlermeldung mit Beispiel — die meisten Owner kommen
+    aus „mein App-Store-Repo hatte vorher keine Versionsnummer-Disziplin"
+    und wissen nicht intuitiv, was Semver verlangt.
+    """
+    if not is_valid_semver(version):
+        raise BadRequestException(
+            f"Versionsnummer '{version}' ist kein gültiges Semver. "
+            f"Format: MAJOR.MINOR.PATCH, z. B. '1.0.0' oder '2.0.1-beta'.",
+            code=ERR_NOT_SEMVER,
+            details={"version": version},
+        )
+
+
+def assert_strictly_greater(
+    new_version: str,
+    existing_versions: Iterable[str],
+    *,
+    allow_equal_replace_target: bool = False,
+) -> str | None:
+    """Stell sicher, dass ``new_version`` strikt größer ist als jede existierende.
+
+    Wirft entweder:
+    - ``ERR_NOT_STRICTLY_GREATER`` wenn eine existierende Version >= ist
+      und der String nicht identisch zu ihr ist.
+    - ``ERR_ALREADY_EXISTS`` wenn der String identisch zu einer existierenden
+      ist und ``allow_equal_replace_target`` nicht gesetzt ist. Frontend
+      branchst darauf und bietet den Replace-Pfad an.
+
+    Gibt den String der existierenden „Kollisions-Version" zurück, wenn
+    ``allow_equal_replace_target=True`` und eine Kollision vorliegt — sonst
+    None (kein Konflikt). Aufrufer im Replace-Pfad nutzen den Rückgabewert
+    nicht direkt (sie haben die Row schon), aber er ist konsistent mit der
+    Erwartung „diese Funktion sagt mir, was kollidiert".
+
+    Nicht-semver-Strings unter den existierenden werden defensiv
+    übersprungen — sie können nur über Legacy-Daten/Dedupe-Suffixe
+    entstehen und sollen keinen neuen Insert blockieren.
+    """
+    # Vorab-Check: new_version muss valid sein. assert_valid_semver hebt sonst.
+    assert_valid_semver(new_version)
+    new_key = parse_semver(new_version)
+
+    # Existierende Strings, die nicht Semver sind (z.B. „2.0.0+dedupe-abc"
+    # nach der Dedupe-Migration), als Block-Vergleich überspringen — sie
+    # zählen weder zur Monotonie-Vergleichsmenge noch zur Identitäts-Kollision.
+    max_existing: tuple | None = None
+    max_existing_str: str | None = None
+    identical: str | None = None
+    for ev in existing_versions:
+        if ev == new_version:
+            identical = ev
+            continue
+        try:
+            ev_key = parse_semver(ev)
+        except ValueError:
+            continue
+        if max_existing is None or ev_key > max_existing:
+            max_existing = ev_key
+            max_existing_str = ev
+
+    if identical is not None and not allow_equal_replace_target:
+        raise BadRequestException(
+            f"Version '{new_version}' ist in diesem Template bereits vorhanden. "
+            f"Bitte bumpe `app.version` im Repo oder ersetze die bestehende Version.",
+            code=ERR_ALREADY_EXISTS,
+            details={"version": new_version},
+        )
+
+    # Replace-Pfad: wir ersetzen eine bestehende Version mit demselben String.
+    # In dem Fall bewusst KEIN Monotonie-Check — der String ist absichtlich
+    # gleich (kleiner-oder-gleich Max ist normal); der Caller hat die
+    # existierende Row schon zur Löschung markiert.
+    if identical is not None and allow_equal_replace_target:
+        return identical
+
+    if max_existing is not None and new_key <= max_existing:
+        raise BadRequestException(
+            f"Version '{new_version}' ist nicht strikt größer als die bestehende "
+            f"höchste Version '{max_existing_str}'. Bitte bumpe `app.version` im Repo.",
+            code=ERR_NOT_STRICTLY_GREATER,
+            details={"version": new_version, "current_max": max_existing_str},
+        )
+
+    return identical

--- a/tests/api/test_templates_api_access.py
+++ b/tests/api/test_templates_api_access.py
@@ -726,11 +726,14 @@ class TestRejectVersionWithReason:
     def pending_version(self, db_session, public_approved_template):
         from src.models.template_version import TemplateVersionApprovalStatus
 
+        # Auf demselben PUBLIC-Template gibt es schon v1.0.0 APPROVED — wir
+        # legen v1.1.0 PENDING an, damit der UniqueConstraint auf
+        # (template_id, version) nicht stört.
         v = TemplateVersion(
             template_id=public_approved_template.id,
-            version="1.0.0",
+            version="1.1.0",
             git_commit_sha="reject-test-sha",
-            is_active=True,
+            is_active=False,
             approval_status=TemplateVersionApprovalStatus.PENDING,
         )
         db_session.add(v)

--- a/tests/unit/test_approval_only_for_public.py
+++ b/tests/unit/test_approval_only_for_public.py
@@ -4,7 +4,9 @@ Covers:
 - Visibility-switch resets/sets ``approval_status`` correctly on each version.
 - Visibility can now be changed by the template owner (not only admins).
 - Deploy-time gate: private templates can only be deployed by their owner.
-- Approve/reject endpoints reject private templates with 400.
+- Approve/reject endpoints reject **genuinely** private templates (no
+  publish_requested) with 400. Templates that are PRIVATE + publish_requested
+  ARE legitimate approval targets — they're awaiting their first approval.
 """
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
@@ -25,13 +27,19 @@ from src.services.template_version_service import TemplateVersionService
 # ---------------------------------------------------------------------------
 
 
-def _make_template(visibility=TemplateVisibility.PRIVATE, owner_id=None, versions=None):
+def _make_template(
+    visibility=TemplateVisibility.PRIVATE,
+    owner_id=None,
+    versions=None,
+    publish_requested: bool = False,
+):
     t = Template()
     t.id = str(uuid4())
     t.owner_id = owner_id or str(uuid4())
     t.name = "demo"
     t.repo_url = "https://example.com"
     t.visibility = visibility
+    t.publish_requested = publish_requested
     t.versions = versions or []
     return t
 
@@ -63,15 +71,17 @@ def template_service(mock_db):
 
 
 # ---------------------------------------------------------------------------
-# Visibility-switch resets approval_status
+# Visibility-switch — publish_requested-aware
 # ---------------------------------------------------------------------------
 
 
 class TestVisibilityToggleResetsApproval:
     """When a template flips private↔public, the version-level approval state
-    has to follow — otherwise a previously-rejected public version would slip
-    back into the marketplace via a private→public bounce, or a private
-    version would carry a meaningless PENDING badge after going public."""
+    has to follow. Seit der Einführung von ``publish_requested`` ist der
+    private→public-Pfad nicht mehr ein Direkt-Flip auf PUBLIC, sondern ein
+    Veröffentlichungs-Wunsch: das Template BLEIBT PRIVATE, der Wunsch wird
+    festgehalten, die Versionen flippen in den Approval-Flow. Erst beim
+    ersten approve_version() flippt das Template wirklich auf PUBLIC."""
 
     def test_private_to_public_sets_null_versions_to_pending(self, template_service, mock_db):
         owner = str(uuid4())
@@ -91,6 +101,66 @@ class TestVisibilityToggleResetsApproval:
 
         # Version that was unset before now enters the approval flow.
         assert v_null.approval_status == TemplateVersionApprovalStatus.PENDING
+
+    def test_private_to_public_keeps_visibility_private_without_approved_versions(
+        self, template_service, mock_db,
+    ):
+        """Der „möchte öffentlich werden"-Wunsch landet als ``publish_requested``
+        am Template. Der ``visibility``-Wert in der DB-Aktualisierung wird
+        bewusst NICHT auf ``public`` durchgereicht — Service entfernt das
+        Feld aus dem Update, damit das Template bis zur ersten Genehmigung
+        privat bleibt."""
+        owner = str(uuid4())
+        tid = str(uuid4())
+        v_null = _make_version(tid, None)
+        t = _make_template(TemplateVisibility.PRIVATE, owner_id=owner, versions=[v_null])
+        t.id = tid
+        template_service.template_repo.get_by_id.return_value = t
+        template_service.template_repo.update.return_value = t
+
+        template_service.update_template(
+            template_id=t.id,
+            template_data=TemplateUpdate(visibility="public"),
+            user_id=owner,
+            is_admin=False,
+        )
+
+        # ``template_repo.update`` wird aufgerufen — wir prüfen das Payload:
+        # `visibility` muss raus, `publish_requested=True` muss drin sein.
+        args, kwargs = template_service.template_repo.update.call_args
+        assert "visibility" not in kwargs, (
+            "Direktflip auf PUBLIC ist unerwünscht solange keine Version "
+            "approved ist — Service muss `visibility` aus dem Update entfernen."
+        )
+        assert kwargs.get("publish_requested") is True
+
+    def test_private_to_public_flips_directly_with_approved_version(
+        self, template_service,
+    ):
+        """Wenn das Template (z.B. nach demote-to-private und re-promote)
+        schon eine APPROVED Version hat, ist der Approval-Umweg unnötig —
+        wir flippen direkt auf PUBLIC."""
+        owner = str(uuid4())
+        tid = str(uuid4())
+        v_approved = _make_version(tid, TemplateVersionApprovalStatus.APPROVED)
+        t = _make_template(TemplateVisibility.PRIVATE, owner_id=owner, versions=[v_approved])
+        t.id = tid
+        template_service.template_repo.get_by_id.return_value = t
+        template_service.template_repo.update.return_value = t
+
+        template_service.update_template(
+            template_id=t.id,
+            template_data=TemplateUpdate(visibility="public"),
+            user_id=owner,
+            is_admin=False,
+        )
+
+        args, kwargs = template_service.template_repo.update.call_args
+        # Direktflip: visibility bleibt im Update-Payload, publish_requested
+        # wird auf False gesetzt (defensiv — falls ein Vorgänger-Wunsch da war).
+        assert kwargs.get("visibility") == "public"
+        assert kwargs.get("publish_requested") is False
+        assert v_approved.approval_status == TemplateVersionApprovalStatus.APPROVED
 
     def test_private_to_public_does_not_re_pend_already_approved(self, template_service):
         """If a version somehow already carries APPROVED (e.g. legacy data
@@ -116,12 +186,18 @@ class TestVisibilityToggleResetsApproval:
     def test_public_to_private_wipes_approval_state(self, template_service):
         """Going private clears the approval state on every version — the
         concept doesn't apply anymore, and stale APPROVED records would
-        leak back to PUBLIC if someone flipped a third time."""
+        leak back to PUBLIC if someone flipped a third time. Plus the
+        ``publish_requested``-Wunsch wird gelöscht."""
         owner = str(uuid4())
         tid = str(uuid4())
         v_approved = _make_version(tid, TemplateVersionApprovalStatus.APPROVED)
         v_pending = _make_version(tid, TemplateVersionApprovalStatus.PENDING)
-        t = _make_template(TemplateVisibility.PUBLIC, owner_id=owner, versions=[v_approved, v_pending])
+        t = _make_template(
+            TemplateVisibility.PUBLIC,
+            owner_id=owner,
+            versions=[v_approved, v_pending],
+            publish_requested=False,
+        )
         t.id = tid
         template_service.template_repo.get_by_id.return_value = t
         template_service.template_repo.update.return_value = t
@@ -138,6 +214,9 @@ class TestVisibilityToggleResetsApproval:
             assert v.approved_by_id is None
             assert v.approved_at is None
             assert v.rejection_reason is None
+
+        args, kwargs = template_service.template_repo.update.call_args
+        assert kwargs.get("publish_requested") is False
 
     def test_no_change_when_visibility_stays_same(self, template_service):
         """If the PATCH sets visibility to the same value, nothing should
@@ -286,18 +365,20 @@ class TestDeployPrivateTemplateOwnerOnly:
 
 
 # ---------------------------------------------------------------------------
-# Approve/Reject reject 400 for private templates
-# (Mirror of the public-only path; complements TestApproveRejectVersion.)
+# Approve/Reject — Genuine-private vs. publish_requested
 # ---------------------------------------------------------------------------
 
 
 class TestApproveRejectGate:
-    def test_approve_400_when_template_private(self):
+    def test_approve_400_when_template_genuinely_private(self):
+        """Approve auf einem GENUINELY-privaten Template (kein
+        publish_requested-Wunsch) ist weiterhin verboten — der Begriff
+        Approval ergibt dort keinen Sinn."""
         s = TemplateVersionService(MagicMock())
         s.version_repo = MagicMock()
         s.template_repo = MagicMock()
 
-        priv = _make_template(TemplateVisibility.PRIVATE)
+        priv = _make_template(TemplateVisibility.PRIVATE, publish_requested=False)
         v = _make_version(priv.id, None)
         s.version_repo.get_by_id.return_value = v
         s.template_repo.get_by_id.return_value = priv
@@ -306,15 +387,54 @@ class TestApproveRejectGate:
             s.approve_version(v.id, admin_user_id="admin-1")
         assert "public" in str(exc.value).lower()
 
-    def test_reject_400_when_template_private(self):
+    def test_reject_400_when_template_genuinely_private(self):
         s = TemplateVersionService(MagicMock())
         s.version_repo = MagicMock()
         s.template_repo = MagicMock()
 
-        priv = _make_template(TemplateVisibility.PRIVATE)
+        priv = _make_template(TemplateVisibility.PRIVATE, publish_requested=False)
         v = _make_version(priv.id, None)
         s.version_repo.get_by_id.return_value = v
         s.template_repo.get_by_id.return_value = priv
 
         with pytest.raises(BadRequestException):
             s.reject_version(v.id, admin_user_id="admin-1")
+
+    def test_approve_succeeds_on_private_with_publish_requested(self, mock_db):
+        """Erst-Veröffentlichungs-Pfad: PRIVATE + publish_requested = True
+        ist ein legitimer Approval-Kandidat. Beim Approve flippt der
+        Template-State atomar auf PUBLIC + publish_requested=False."""
+        s = TemplateVersionService(mock_db)
+        s.version_repo = MagicMock()
+        s.template_repo = MagicMock()
+
+        tpl = _make_template(TemplateVisibility.PRIVATE, publish_requested=True)
+        v = _make_version(tpl.id, TemplateVersionApprovalStatus.PENDING)
+        s.version_repo.get_by_id.return_value = v
+        s.template_repo.get_by_id.return_value = tpl
+
+        s.approve_version(v.id, admin_user_id="admin-1")
+
+        assert v.approval_status == TemplateVersionApprovalStatus.APPROVED
+        # Template wurde auf PUBLIC promoted und Wunsch gelöscht.
+        assert tpl.visibility == TemplateVisibility.PUBLIC
+        assert tpl.publish_requested is False
+
+    def test_reject_succeeds_on_private_with_publish_requested(self, mock_db):
+        """Reject auf PRIVATE + publish_requested verwirft den Wunsch:
+        Template bleibt PRIVATE und publish_requested → False."""
+        s = TemplateVersionService(mock_db)
+        s.version_repo = MagicMock()
+        s.template_repo = MagicMock()
+
+        tpl = _make_template(TemplateVisibility.PRIVATE, publish_requested=True)
+        v = _make_version(tpl.id, TemplateVersionApprovalStatus.PENDING)
+        s.version_repo.get_by_id.return_value = v
+        s.template_repo.get_by_id.return_value = tpl
+
+        s.reject_version(v.id, admin_user_id="admin-1", reason="needs work")
+
+        assert v.approval_status == TemplateVersionApprovalStatus.REJECTED
+        assert v.rejection_reason == "needs work"
+        assert tpl.visibility == TemplateVisibility.PRIVATE
+        assert tpl.publish_requested is False

--- a/tests/unit/test_template_publish_flow.py
+++ b/tests/unit/test_template_publish_flow.py
@@ -1,0 +1,160 @@
+"""Tests für den Erst-Veröffentlichungs-Flow.
+
+Owner klickt beim Anlegen „öffentlich" → Template landet als PRIVATE +
+publish_requested=True. Erst beim ersten approve_version() flippt das
+Template atomar auf PUBLIC. Bei reject bleibt es PRIVATE und der Wunsch
+wird verworfen.
+
+Diese Tests decken nur die Service-Logik ab (Unit-Level, mit MagicMock-DB).
+Die End-to-End-Validierung läuft als Frontend-Smoke-Test bzw. im API-Layer.
+"""
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from src.models.template import Template, TemplateVisibility
+from src.models.template_version import TemplateVersion, TemplateVersionApprovalStatus
+from src.models.user import UserRole
+from src.services.template_version_service import TemplateVersionService
+
+
+def _tpl(visibility=TemplateVisibility.PRIVATE, publish_requested=False):
+    t = Template()
+    t.id = str(uuid4())
+    t.owner_id = "owner-1"
+    t.name = "demo"
+    t.repo_url = "https://example.com"
+    t.visibility = visibility
+    t.publish_requested = publish_requested
+    t.versions = []
+    return t
+
+
+def _ver(template_id, approval_status, is_active=False, version_str="1.0.0"):
+    v = TemplateVersion()
+    v.id = str(uuid4())
+    v.template_id = template_id
+    v.version = version_str
+    v.git_commit_sha = "sha-" + v.id[:8]
+    v.is_active = is_active
+    v.approval_status = approval_status
+    v.approved_by_id = None
+    v.approved_at = None
+    v.rejection_reason = None
+    return v
+
+
+class TestInitialApproval:
+    """``_initial_approval`` bildet (template, caller) → approval_status ab.
+    Wir testen die drei relevanten Eingangs-Konstellationen für
+    `publish_requested` (neu) + den unveränderten Standard-Flow."""
+
+    def test_genuinely_private_returns_none(self):
+        tpl = _tpl(TemplateVisibility.PRIVATE, publish_requested=False)
+        assert TemplateVersionService._initial_approval(tpl, [UserRole.LECTURER.value]) is None
+        assert TemplateVersionService._initial_approval(tpl, [UserRole.ADMIN.value]) is None
+
+    def test_public_template_lecturer_caller_gets_pending(self):
+        tpl = _tpl(TemplateVisibility.PUBLIC, publish_requested=False)
+        result = TemplateVersionService._initial_approval(tpl, [UserRole.LECTURER.value])
+        assert result == TemplateVersionApprovalStatus.PENDING
+
+    def test_public_template_admin_caller_gets_approved(self):
+        tpl = _tpl(TemplateVisibility.PUBLIC, publish_requested=False)
+        result = TemplateVersionService._initial_approval(tpl, [UserRole.ADMIN.value])
+        assert result == TemplateVersionApprovalStatus.APPROVED
+
+    def test_private_with_publish_requested_lecturer_gets_pending(self):
+        """Erst-Veröffentlichungs-Pfad: Template ist noch PRIVATE, aber der
+        Wunsch ist gesetzt → Approval-Flow läuft schon, neue Versionen
+        starten PENDING."""
+        tpl = _tpl(TemplateVisibility.PRIVATE, publish_requested=True)
+        result = TemplateVersionService._initial_approval(tpl, [UserRole.LECTURER.value])
+        assert result == TemplateVersionApprovalStatus.PENDING
+
+    def test_private_with_publish_requested_admin_gets_approved(self):
+        tpl = _tpl(TemplateVisibility.PRIVATE, publish_requested=True)
+        result = TemplateVersionService._initial_approval(tpl, [UserRole.ADMIN.value])
+        assert result == TemplateVersionApprovalStatus.APPROVED
+
+
+class TestApproveFlipsToPublic:
+    """``approve_version`` flippt PRIVATE+publish_requested atomar zu
+    PUBLIC + publish_requested=False — und nur dann."""
+
+    def test_approve_on_publish_requested_promotes_to_public(self):
+        s = TemplateVersionService(MagicMock())
+        s.version_repo = MagicMock()
+        s.template_repo = MagicMock()
+
+        tpl = _tpl(TemplateVisibility.PRIVATE, publish_requested=True)
+        v = _ver(tpl.id, TemplateVersionApprovalStatus.PENDING)
+        s.version_repo.get_by_id.return_value = v
+        s.template_repo.get_by_id.return_value = tpl
+
+        s.approve_version(v.id, admin_user_id="admin-1")
+
+        assert tpl.visibility == TemplateVisibility.PUBLIC
+        assert tpl.publish_requested is False
+        assert v.approval_status == TemplateVersionApprovalStatus.APPROVED
+        assert v.approved_by_id == "admin-1"
+        assert v.approved_at is not None
+
+    def test_approve_on_already_public_template_does_not_touch_publish_requested(self):
+        """Approves auf bereits-PUBLIC Templates lassen die Spalte unangetastet."""
+        s = TemplateVersionService(MagicMock())
+        s.version_repo = MagicMock()
+        s.template_repo = MagicMock()
+
+        tpl = _tpl(TemplateVisibility.PUBLIC, publish_requested=False)
+        v = _ver(tpl.id, TemplateVersionApprovalStatus.PENDING)
+        s.version_repo.get_by_id.return_value = v
+        s.template_repo.get_by_id.return_value = tpl
+
+        s.approve_version(v.id, admin_user_id="admin-1")
+
+        assert tpl.visibility == TemplateVisibility.PUBLIC
+        assert tpl.publish_requested is False
+        assert v.approval_status == TemplateVersionApprovalStatus.APPROVED
+
+
+class TestRejectClearsPublishRequest:
+    """``reject_version`` verwirft den Veröffentlichungs-Wunsch, lässt das
+    Template aber PRIVATE."""
+
+    def test_reject_on_publish_requested_clears_wish_keeps_private(self):
+        s = TemplateVersionService(MagicMock())
+        s.version_repo = MagicMock()
+        s.template_repo = MagicMock()
+
+        tpl = _tpl(TemplateVisibility.PRIVATE, publish_requested=True)
+        v = _ver(tpl.id, TemplateVersionApprovalStatus.PENDING)
+        s.version_repo.get_by_id.return_value = v
+        s.template_repo.get_by_id.return_value = tpl
+
+        s.reject_version(v.id, admin_user_id="admin-1", reason="format")
+
+        assert tpl.visibility == TemplateVisibility.PRIVATE
+        assert tpl.publish_requested is False
+        assert v.approval_status == TemplateVersionApprovalStatus.REJECTED
+        assert v.rejection_reason == "format"
+
+    def test_reject_on_public_template_does_not_alter_publish_requested(self):
+        """Reject auf einem bereits-PUBLIC Template: publish_requested
+        bleibt wie es war (typischerweise False), Template-State bleibt."""
+        s = TemplateVersionService(MagicMock())
+        s.version_repo = MagicMock()
+        s.template_repo = MagicMock()
+
+        tpl = _tpl(TemplateVisibility.PUBLIC, publish_requested=False)
+        v = _ver(tpl.id, TemplateVersionApprovalStatus.PENDING)
+        s.version_repo.get_by_id.return_value = v
+        s.template_repo.get_by_id.return_value = tpl
+
+        s.reject_version(v.id, admin_user_id="admin-1")
+
+        assert tpl.visibility == TemplateVisibility.PUBLIC
+        assert tpl.publish_requested is False
+        assert v.approval_status == TemplateVersionApprovalStatus.REJECTED

--- a/tests/unit/test_template_publish_flow.py
+++ b/tests/unit/test_template_publish_flow.py
@@ -8,11 +8,8 @@ wird verworfen.
 Diese Tests decken nur die Service-Logik ab (Unit-Level, mit MagicMock-DB).
 Die End-to-End-Validierung läuft als Frontend-Smoke-Test bzw. im API-Layer.
 """
-from datetime import datetime, timezone
 from unittest.mock import MagicMock
 from uuid import uuid4
-
-import pytest
 
 from src.models.template import Template, TemplateVisibility
 from src.models.template_version import TemplateVersion, TemplateVersionApprovalStatus

--- a/tests/unit/test_template_version_activate.py
+++ b/tests/unit/test_template_version_activate.py
@@ -11,7 +11,7 @@ from uuid import uuid4
 
 import pytest
 
-from src.core.exceptions import BadRequestException, ForbiddenException
+from src.core.exceptions import ForbiddenException
 from src.models.template import Template, TemplateVisibility
 from src.models.template_version import TemplateVersion, TemplateVersionApprovalStatus
 from src.services.template_version_service import TemplateVersionService
@@ -53,7 +53,9 @@ class TestActivateVersionSwitch:
         s.template_repo = MagicMock()
 
         tpl = _tpl()
-        v_old = _ver(tpl.id, "2.0.0", is_active=True)
+        # Ältere Version existiert bereits als die aktive — wird im Service
+        # über deactivate_other_versions implizit deaktiviert.
+        _ver(tpl.id, "2.0.0", is_active=True)
         v_new = _ver(tpl.id, "2.1.0", is_active=False)
         s.version_repo.get_by_id.return_value = v_new
         s.template_repo.get_by_id.return_value = tpl
@@ -76,7 +78,9 @@ class TestActivateVersionSwitch:
 
         tpl = _tpl()
         v_old = _ver(tpl.id, "2.0.0", is_active=False)
-        v_new = _ver(tpl.id, "2.1.0", is_active=True)
+        # Aktuell aktive Version, die durch das Activate der älteren Version
+        # implizit deaktiviert wird.
+        _ver(tpl.id, "2.1.0", is_active=True)
         s.version_repo.get_by_id.return_value = v_old
         s.template_repo.get_by_id.return_value = tpl
         s.version_repo.update.return_value = v_old

--- a/tests/unit/test_template_version_activate.py
+++ b/tests/unit/test_template_version_activate.py
@@ -1,0 +1,132 @@
+"""Tests für „Aktive Version ändern" — Switch zwischen Versionen, auch
+zu älteren. Backend-Service muss das beidseitig erlauben; das Frontend
+hat heute keinen Strict-Newer-Filter mehr.
+
+Wir mocken die DB-Schicht; der eigentliche SQL-Update läuft im
+TemplateVersionRepository und ist dort separat covered.
+"""
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from src.core.exceptions import BadRequestException, ForbiddenException
+from src.models.template import Template, TemplateVisibility
+from src.models.template_version import TemplateVersion, TemplateVersionApprovalStatus
+from src.services.template_version_service import TemplateVersionService
+
+
+def _tpl(owner_id="owner-1"):
+    t = Template()
+    t.id = str(uuid4())
+    t.owner_id = owner_id
+    t.name = "demo"
+    t.repo_url = "https://example.com"
+    t.visibility = TemplateVisibility.PUBLIC
+    t.publish_requested = False
+    t.versions = []
+    return t
+
+
+def _ver(template_id, version_str, is_active):
+    v = TemplateVersion()
+    v.id = str(uuid4())
+    v.template_id = template_id
+    v.version = version_str
+    v.git_commit_sha = "sha-" + v.id[:8]
+    v.is_active = is_active
+    v.approval_status = TemplateVersionApprovalStatus.APPROVED
+    v.approved_by_id = "admin-1"
+    v.approved_at = datetime.now(timezone.utc)
+    v.rejection_reason = None
+    return v
+
+
+class TestActivateVersionSwitch:
+    """``activate_version`` darf den active-Flag in beide Richtungen
+    switchen — kein Strict-Newer-Filter im Backend."""
+
+    def test_activate_newer_version_works(self):
+        s = TemplateVersionService(MagicMock())
+        s.version_repo = MagicMock()
+        s.template_repo = MagicMock()
+
+        tpl = _tpl()
+        v_old = _ver(tpl.id, "2.0.0", is_active=True)
+        v_new = _ver(tpl.id, "2.1.0", is_active=False)
+        s.version_repo.get_by_id.return_value = v_new
+        s.template_repo.get_by_id.return_value = tpl
+        s.version_repo.update.return_value = v_new
+
+        result = s.activate_version(v_new.id, user_id=tpl.owner_id, is_admin=False)
+        assert result is v_new
+        # deactivate_other_versions wurde mit der NEUEN id aufgerufen, damit
+        # die OLD-Row passiv mit-deaktiviert wird.
+        s.version_repo.deactivate_other_versions.assert_called_once_with(
+            tpl.id, v_new.id,
+        )
+
+    def test_activate_older_version_works(self):
+        """Downgrade-Pfad: ältere Version wieder aktivieren. Service darf
+        das genauso wie ein Upgrade durchwinken."""
+        s = TemplateVersionService(MagicMock())
+        s.version_repo = MagicMock()
+        s.template_repo = MagicMock()
+
+        tpl = _tpl()
+        v_old = _ver(tpl.id, "2.0.0", is_active=False)
+        v_new = _ver(tpl.id, "2.1.0", is_active=True)
+        s.version_repo.get_by_id.return_value = v_old
+        s.template_repo.get_by_id.return_value = tpl
+        s.version_repo.update.return_value = v_old
+
+        result = s.activate_version(v_old.id, user_id=tpl.owner_id, is_admin=False)
+        assert result is v_old
+        s.version_repo.deactivate_other_versions.assert_called_once_with(
+            tpl.id, v_old.id,
+        )
+
+    def test_activate_requires_owner_or_admin(self):
+        s = TemplateVersionService(MagicMock())
+        s.version_repo = MagicMock()
+        s.template_repo = MagicMock()
+
+        tpl = _tpl(owner_id="owner-1")
+        v = _ver(tpl.id, "1.0.0", is_active=False)
+        s.version_repo.get_by_id.return_value = v
+        s.template_repo.get_by_id.return_value = tpl
+
+        with pytest.raises(ForbiddenException):
+            s.activate_version(v.id, user_id="someone-else", is_admin=False)
+
+
+class TestActivateVersionWithVersionString:
+    """Wenn ``update_version`` einen neuen Versions-String übergibt, läuft
+    der Validator. Hier sicherstellen, dass die Activate-Logik selbst
+    unabhängig davon funktioniert (versions-Spalte unverändert)."""
+
+    def test_update_with_only_is_active_skips_version_validation(self):
+        from src.schemas.template_version import TemplateVersionUpdate
+
+        s = TemplateVersionService(MagicMock())
+        s.version_repo = MagicMock()
+        s.template_repo = MagicMock()
+
+        tpl = _tpl()
+        v = _ver(tpl.id, "2.0.0", is_active=False)
+        s.version_repo.get_by_id.return_value = v
+        s.template_repo.get_by_id.return_value = tpl
+        s.version_repo.update.return_value = v
+
+        # update_version(is_active=True) ohne version-Feld: Validator darf
+        # nicht angeschmissen werden (würde sonst die existierende Version
+        # gegen sich selbst vergleichen).
+        s.update_version(
+            v.id,
+            TemplateVersionUpdate(is_active=True),
+            user_id=tpl.owner_id,
+            is_admin=False,
+        )
+        # deactivate_other_versions wurde aufgerufen.
+        s.version_repo.deactivate_other_versions.assert_called_once_with(tpl.id, v.id)

--- a/tests/unit/test_version_validator.py
+++ b/tests/unit/test_version_validator.py
@@ -1,0 +1,157 @@
+"""Unit tests für ``src/utils/version_validator.py``.
+
+Wir testen sowohl die Regex (Format-Check) als auch die Monotonie-
+Vergleichs-Logik separat, weil beide unabhängige Failure-Modi haben.
+"""
+import pytest
+
+from src.core.exceptions import BadRequestException
+from src.utils import version_validator
+from src.utils.version_validator import (
+    ERR_ALREADY_EXISTS,
+    ERR_NOT_SEMVER,
+    ERR_NOT_STRICTLY_GREATER,
+    assert_strictly_greater,
+    assert_valid_semver,
+    is_valid_semver,
+    parse_semver,
+)
+
+
+class TestSemverFormat:
+    @pytest.mark.parametrize(
+        "version",
+        [
+            "0.0.0",
+            "1.0.0",
+            "10.20.30",
+            "1.0.0-alpha",
+            "1.0.0-alpha.1",
+            "1.0.0+build",
+            "1.0.0-alpha+build.5",
+            "1.0.0-0.3.7",
+            "1.0.0-x.7.z.92",
+        ],
+    )
+    def test_valid_strings_accepted(self, version):
+        assert is_valid_semver(version)
+        # Sollte auch ohne Exception parsen
+        parse_semver(version)
+
+    @pytest.mark.parametrize(
+        "version",
+        [
+            "",
+            "foo",
+            "1",
+            "1.0",
+            "01.0.0",  # leading zero
+            "1.0.0.0",
+            "v1.0.0",
+            "1.0.0-",
+            "1.0.0+",
+            "1.0.0-α",  # nicht-ASCII
+        ],
+    )
+    def test_invalid_strings_rejected(self, version):
+        assert not is_valid_semver(version)
+        with pytest.raises(BadRequestException) as exc:
+            assert_valid_semver(version)
+        assert exc.value.code == ERR_NOT_SEMVER
+
+
+class TestSemverOrdering:
+    def test_release_is_greater_than_prerelease(self):
+        # Semver §11: 1.0.0 > 1.0.0-alpha
+        assert parse_semver("1.0.0") > parse_semver("1.0.0-alpha")
+
+    def test_prerelease_numeric_lower_than_alpha(self):
+        # 1.0.0-1 < 1.0.0-alpha (numerische Identifier sortieren niedriger
+        # als alphanumerische, Semver §11.3).
+        assert parse_semver("1.0.0-1") < parse_semver("1.0.0-alpha")
+
+    def test_build_metadata_ignored_for_ordering(self):
+        # 1.0.0+a und 1.0.0+b sind ordnungsweise gleich (Semver §10).
+        assert parse_semver("1.0.0+a") == parse_semver("1.0.0+b")
+
+    def test_patch_minor_major_ordering(self):
+        assert parse_semver("2.0.0") > parse_semver("1.9.9")
+        assert parse_semver("1.10.0") > parse_semver("1.9.0")
+        assert parse_semver("1.0.1") > parse_semver("1.0.0")
+
+
+class TestAssertStrictlyGreater:
+    def test_first_version_accepted(self):
+        # Keine existierenden Versionen → jede valid-semver-Version geht.
+        result = assert_strictly_greater("1.0.0", [])
+        assert result is None
+
+    def test_strictly_greater_accepted(self):
+        result = assert_strictly_greater("2.0.0", ["1.0.0", "1.5.0", "1.9.9"])
+        assert result is None
+
+    def test_already_exists_raises_with_code(self):
+        with pytest.raises(BadRequestException) as exc:
+            assert_strictly_greater("1.5.0", ["1.0.0", "1.5.0", "1.9.0"])
+        assert exc.value.code == ERR_ALREADY_EXISTS
+        assert exc.value.details == {"version": "1.5.0"}
+
+    def test_not_strictly_greater_raises_with_max(self):
+        with pytest.raises(BadRequestException) as exc:
+            assert_strictly_greater("1.5.0", ["1.0.0", "2.0.0", "1.9.0"])
+        assert exc.value.code == ERR_NOT_STRICTLY_GREATER
+        assert exc.value.details["current_max"] == "2.0.0"
+
+    def test_invalid_existing_versions_skipped(self):
+        # „2.0.0+dedupe-abc12345" ist valid semver (Build-Metadata), aber
+        # die alte Dedupe-Variante mit Suffix darf den Vergleich nicht
+        # blockieren. Hier testen wir gleich beide: ein offen-defektes
+        # „foo" UND ein semver-mit-Build "2.0.0+dedupe-abc12345" — beide
+        # sollen den Insert von "2.0.1" zulassen.
+        existing = ["1.0.0", "foo", "2.0.0+dedupe-abc12345"]
+        # Beachte: "2.0.0+dedupe-..." parst zu (2,0,0,…) und ist
+        # ordnungsweise gleich 2.0.0. Wir versuchen also 2.0.1 → ok.
+        result = assert_strictly_greater("2.0.1", existing)
+        assert result is None
+
+    def test_replace_target_allows_equal(self):
+        result = assert_strictly_greater(
+            "2.0.0",
+            ["1.0.0", "2.0.0"],
+            allow_equal_replace_target=True,
+        )
+        assert result == "2.0.0"
+
+    def test_replace_target_does_not_bypass_monotonic_check(self):
+        # 2.0.0 ist identisch zur existierenden 2.0.0 (Replace ok), aber
+        # 3.0.0 ist auch da — der Replace-Wert ist also nicht das Maximum,
+        # heißt nicht „kleiner als max" muss greifen. In dem Szenario
+        # geben wir aber denselben String, also Replace-Pfad aktiv und
+        # wir wollen keinen NOT_STRICTLY_GREATER-Fehler.
+        # (Edge-Case: Replace-Pfad ist ein „ich ersetze eine Bestands-Row"
+        # — der String ist bewusst kleiner als max, das ist normal.)
+        result = assert_strictly_greater(
+            "2.0.0",
+            ["2.0.0", "3.0.0"],
+            allow_equal_replace_target=True,
+        )
+        assert result == "2.0.0"
+
+
+class TestErrorCodesAreExported:
+    """Die Codes müssen Strings auf Modulebene sein — das Frontend
+    spiegelt sie als const-Werte. Wenn sie wegrefactored werden,
+    schlägt der Aufruf hier hart fehl statt stillschweigend zu
+    driften."""
+
+    def test_codes_are_uppercase_snake_strings(self):
+        for name in (
+            "ERR_NOT_SEMVER",
+            "ERR_MISSING_IN_MANIFEST",
+            "ERR_NOT_STRICTLY_GREATER",
+            "ERR_ALREADY_EXISTS",
+            "ERR_REPLACE_BLOCKED_BY_DEPLOYMENTS",
+        ):
+            value = getattr(version_validator, name)
+            assert isinstance(value, str) and value.isupper()
+            assert value.startswith("VERSION_")


### PR DESCRIPTION
Drei gekoppelte Änderungen, die die UX-Inkonsistenzen rund um „Template hinzufügen" und „Versionen importieren" auflösen. Frontend-Companion-PR: DoziLab/appstore-frontend (folgt direkt).

## 1) „Öffentlich" beim Anlegen flippt visibility nicht mehr sofort

Wenn ein Lecturer ein Template mit `visibility=public` anlegt, bleibt es jetzt in der DB als `visibility=PRIVATE` und bekommt das neue Flag `publish_requested=True`. Die erste Version läuft durch den Standard-Approval-Flow (`PENDING` für Lecturer, `APPROVED` für Admin-Caller). Der atomare Flip auf `PUBLIC` passiert in `approve_version()` beim ersten Admin-Approve; `reject_version()` setzt den Wunsch zurück, damit der Owner ihn explizit erneut anstoßen muss.

**Warum ein Boolean statt eines dritten Enum-Werts?** Bestehender Zwei-Wert-Enum bleibt, jeder Access-Control-Pfad (`_can_access_template`, `_can_access_version`) unverändert. Boolean-Filter genügt der Approval-Queue.

Migration `e3a91d7b5c42` fügt die Spalte hinzu **und** backfilled bestehende PUBLIC-Templates ohne APPROVED-Version → die waren genau der Bug, der korrekte Daten-Zustand ist `PRIVATE + publish_requested=True`.

## 2) Versions-Strings müssen semver, eindeutig und strikt monoton sein

Neues Modul [`src/utils/version_validator.py`](src/utils/version_validator.py) ist die Single Source of Truth: Semver-2.0-Regex, vergleichbares Tuple, `assert_strictly_greater()`-Helper, der `BadRequestException` mit strukturierten Codes wirft, auf die das Frontend gezielt branchen kann:

- `VERSION_NOT_SEMVER`
- `VERSION_MISSING_IN_MANIFEST`
- `VERSION_NOT_STRICTLY_GREATER`
- `VERSION_ALREADY_EXISTS`
- `VERSION_REPLACE_BLOCKED_BY_DEPLOYMENTS`

Validierung läuft jetzt in `github_import_service._import_version_for_template`, `template_version_service.create_version`, `.create_version_with_files` und `.update_version` — überall, wo Versions-Rows entstehen.

**`app.yaml` muss `app.version` setzen** — der alte `_derive_fallback_version`-Timestamp-Fallback ist raus. Wenn die Manifest-Version mit einer existierenden Row kollidiert, antwortet die API mit `VERSION_ALREADY_EXISTS` und Details, sodass das UI zwei Pfade anbieten kann: „im Repo bumpen" (Link) oder „bestehende Version ersetzen" (neues `replace_existing=true`-Flag im Request). Der Replace-Pfad ist blockiert, solange aktive Deployments noch auf die zu ersetzende Row zeigen.

Migration `ebc91d7b5d43` fügt den `UniqueConstraint(template_id, version)` hinzu plus ein einmaliges Dedupe (`+dedupe-<sha>`-Suffix auf Duplikate), damit die Constraint auf Bestandsdaten greifen kann.

## 3) Approval-Queue inkludiert publish_requested-Templates

`list_by_approval_status` behandelt `visibility=public` jetzt per Default als „PUBLIC OR (PRIVATE AND publish_requested)", damit die `PENDING`-Version eines frisch publish-requesteten Templates nicht aus der Admin-Queue rausfällt. Override über `include_publish_requested=false`.

## Strukturierte `BadRequestException`

`BadRequestException` trägt jetzt optional `code` und `details`; der HTTP-Exception-Handler reicht beides ins `errors`-Feld des Standard-Envelopes weiter. Vertrag ist additiv: Bestandscode, der nur eine `message` übergibt, bleibt unverändert.

## Tests

- `test_version_validator.py` (31 cases): Regex-Edge-Cases, Ordering, Error-Codes, Replace-Target-Semantik
- `test_template_publish_flow.py`: `_initial_approval`-Logik über die vier `(visibility, publish_requested)`-Kombinationen + approve/reject-Promote-&-Demote-Wish-Flips
- `test_template_version_activate.py`: Active-Switch in beide Richtungen, kein Strict-Newer-Gate
- `test_approval_only_for_public.py`: Aktualisiert auf die neue Semantik („private→public flippt nicht sofort")
- `test_templates_api_access.py`: Fixture auf `v1.1.0` gebumpt, damit der neue `(template_id, version)`-Constraint sie nicht blockt

**Suite: 462 passed, 4 skipped, 0 failures.**

## Plan

Volle Plan-Datei mit Kontext, Migrationspfaden und Edge-Cases: [`.claude/plans/frontend-und-backend-woher-curried-thompson.md`](https://github.com/DoziLab/appstore-backend/blob/feat/publish-flow-and-version-validation/.claude/plans/frontend-und-backend-woher-curried-thompson.md) (lokale Plan-Datei, nicht in dem Repo eingecheckt).

## Migration-Reihenfolge

```
d5e8c2a91b34 (HEAD auf staging)
    ↑
e3a91d7b5c42 (add publish_requested + Backfill)
    ↑
ebc91d7b5d43 (unique (template_id, version) + Dedupe)
```

Beide Migrationen sind idempotent designt, das Dedupe loggt jede Umbenennung als Postgres `RAISE NOTICE`.