### PR TITLE
fix(deployments): persist non-SSH app credentials per group and teacher

### DIFF
--- a/src/services/deployment_credential_service.py
+++ b/src/services/deployment_credential_service.py
@@ -109,6 +109,13 @@ class DeploymentCredentialService:
                     "access_type": AccessType.DATABASE,
                     "username": cred.get("email") or cred.get("db_user") or cred.get("username"),
                     "password": cred.get("password"),
+                    # course_groups.id stamped by deploy_tasks from the
+                    # per-group ``course_group_id`` carried through
+                    # ``generated["deployment_groups"]``. Without this,
+                    # student self-service would never see app credentials
+                    # (postgres/pgAdmin/...) because the filter requires a
+                    # non-NULL group_id matching the student's membership.
+                    "group_id": cred.get("group_id"),
                     "connection_url": pgadmin_url if is_pgadmin else None,
                     "port": 80 if is_pgadmin else None,
                 })
@@ -119,6 +126,9 @@ class DeploymentCredentialService:
                     "access_type": AccessType.DATABASE,
                     "username": app_admin.get("email") or app_admin.get("db_user") or app_admin.get("username"),
                     "password": app_admin.get("password"),
+                    # Admin (teacher) app credentials: group_id intentionally
+                    # NULL — mirrors the SSH admin block. Lecturer-only.
+                    "group_id": None,
                     "connection_url": pgadmin_url if is_pgadmin else None,
                     "port": 80 if is_pgadmin else None,
                 })

--- a/src/tasks/deploy_tasks.py
+++ b/src/tasks/deploy_tasks.py
@@ -251,31 +251,102 @@ def deploy_stack(self, deployment_id: str) -> dict:
                 )
 
                 try:
-                    # Build user_json from `generated` so DB passwords match what Ansible sets
+                    # Build user_json from `generated` so DB passwords match what Ansible sets.
+                    #
+                    # Two-section layout:
+                    #   - ``instance.credentials`` / ``instance.admin_credentials``:
+                    #     SSH (Linux) credentials. Only emitted for templates whose
+                    #     app.yaml declares ``per_group.linux``; teacher always has
+                    #     an auto-generated linux block (admin key), so the admin
+                    #     SSH row is written for every template.
+                    #   - ``applications[]``: every NON-linux credential type
+                    #     declared in app.yaml (postgres, pgadmin, web_url, …).
+                    #     One ``applications`` entry per credential type, with
+                    #     a ``credentials`` list for the groups and an
+                    #     ``admin_credentials`` block for the teacher. Without
+                    #     this, templates like ansible-postgres-group-db that
+                    #     declare only ``per_group.postgres`` + ``per_group.pgadmin``
+                    #     would produce zero student-visible access rows.
+                    NON_APP_KEYS = {
+                        "username", "email", "group_name", "group_index",
+                        "course_group_id", "students", "linux",
+                    }
+
+                    group_entries = generated.get("deployment_groups", []) or []
+                    teacher_entry = generated.get("teacher", {}) or {}
+
+                    # SSH rows — same shape as before. Filter on linux.password
+                    # is preserved: templates without per_group.linux simply
+                    # don't get SSH access rows for their groups, which is
+                    # correct (those students log into the app, not the VM).
+                    ssh_credentials = [
+                        {
+                            "username": s["linux"]["username"],
+                            "password": s["linux"]["password"],
+                            "ssh_private_key": (s.get("linux", {}).get("ssh_key") or {}).get("private_key"),
+                            # course_groups.id this group corresponds to
+                            # (passed in from the wizard via GroupInfo.course_group_id).
+                            # Stamped onto DeploymentInstanceAccess.group_id so
+                            # student self-service can filter on it. None when
+                            # the wizard didn't supply it — row stays NULL and
+                            # remains invisible to students.
+                            "group_id": s.get("course_group_id"),
+                        }
+                        for s in group_entries
+                        if s.get("linux", {}).get("password")
+                    ]
+                    ssh_admin = (
+                        {
+                            "username": teacher_entry["linux"]["username"],
+                            "password": teacher_entry["linux"]["password"],
+                            "ssh_private_key": (teacher_entry["linux"].get("ssh_key") or {}).get("private_key"),
+                        }
+                        if teacher_entry.get("linux", {}).get("password")
+                        else None
+                    )
+
+                    # App-credentials section — collected per credential type
+                    # by union of keys across all group entries and the teacher
+                    # entry (minus the bookkeeping keys above and ``linux``,
+                    # which has its own SSH section).
+                    app_cred_types: list[str] = []
+                    for source in (*group_entries, teacher_entry):
+                        for key in source.keys():
+                            if key in NON_APP_KEYS or key in app_cred_types:
+                                continue
+                            app_cred_types.append(key)
+
+                    applications = []
+                    for cred_type in app_cred_types:
+                        group_creds = []
+                        for s in group_entries:
+                            cred = s.get(cred_type)
+                            if not isinstance(cred, dict) or not cred.get("password"):
+                                continue
+                            group_creds.append({
+                                **cred,
+                                "group_id": s.get("course_group_id"),
+                            })
+                        admin_cred = teacher_entry.get(cred_type)
+                        admin_block = (
+                            admin_cred
+                            if isinstance(admin_cred, dict) and admin_cred.get("password")
+                            else None
+                        )
+                        if not group_creds and not admin_block:
+                            continue
+                        applications.append({
+                            "name": cred_type,
+                            "credentials": group_creds,
+                            "admin_credentials": admin_block,
+                        })
+
                     credentials_for_db = {
                         "instance": {
-                            "credentials": [
-                                {
-                                    "username": s["linux"]["username"],
-                                    "password": s["linux"]["password"],
-                                    "ssh_private_key": (s.get("linux", {}).get("ssh_key") or {}).get("private_key"),
-                                    # course_groups.id this group corresponds to
-                                    # (passed in from the wizard via GroupInfo.course_group_id).
-                                    # Stamped onto DeploymentInstanceAccess.group_id so
-                                    # student self-service can filter on it. None when
-                                    # the wizard didn't supply it — row stays NULL and
-                                    # remains invisible to students.
-                                    "group_id": s.get("course_group_id"),
-                                }
-                                for s in generated.get("deployment_groups", [])
-                                if s.get("linux", {}).get("password")
-                            ],
-                            "admin_credentials": {
-                                "username": generated["teacher"]["linux"]["username"],
-                                "password": generated["teacher"]["linux"]["password"],
-                                "ssh_private_key": (generated["teacher"]["linux"].get("ssh_key") or {}).get("private_key"),
-                            } if generated.get("teacher", {}).get("linux", {}).get("password") else None,
+                            "credentials": ssh_credentials,
+                            "admin_credentials": ssh_admin,
                         },
+                        "applications": applications,
                     }
                     # Bind the returned DeploymentInstance so the post-Ansible
                     # activation-link fetch below can append rows to it. None


### PR DESCRIPTION
## Summary

Persist **non-SSH credentials** (postgres, pgadmin, web_url, …) into `deployment_instance_access` for both groups and the teacher, so the lecturer UI's "Gruppen"-Tab is populated and students see their credentials via `/api/v1/student/`.

## Problem

For templates whose `app.yaml` declares `per_group` credentials of any type other than `linux` (e.g. `ansible-postgres-group-db` with `per_group: postgres + pgadmin`), the lecturer UI showed only the teacher's auto-generated SSH row — no Gruppen-Tab, no per-group entries. Students saw nothing at all.

Root cause in `src/tasks/deploy_tasks.py:253-279`: the builder for `credentials_for_db` was hardcoded to SSH/Linux:

```python
"credentials": [
    { "username": s["linux"]["username"], "password": s["linux"]["password"], ... }
    for s in generated.get("deployment_groups", [])
    if s.get("linux", {}).get("password")    # ← filters out groups without linux
],
"admin_credentials": { "username": generated["teacher"]["linux"]["username"], ... },
```

Templates without `per_group.linux` produced an empty `credentials[]`. `applications[]` was never built. The teacher row only survived because `credential_generator_service` auto-generates a `linux` block for the teacher unconditionally (admin SSH key).

A secondary issue: `_extract_access_entries` already supported `user_json["applications"][*]`, but didn't read `group_id` from those entries — so even if `applications[]` had been populated, every database row would have landed with `group_id=NULL` and been invisible to students.

## Changes

**`src/tasks/deploy_tasks.py`**
- SSH section unchanged in behaviour: groups without `per_group.linux` still don't get SSH access rows (correct — there's no Linux user on the VM to log into).
- New: build `applications[]` by discovering every non-bookkeeping key in `generated["deployment_groups"][*]` and `generated["teacher"]`. Bookkeeping keys excluded: `username`, `email`, `group_name`, `group_index`, `course_group_id`, `students`, `linux`.
- One `applications` entry per credential type. `credentials[]` carries `group_id` per group (from `course_group_id`); `admin_credentials` carries the teacher's block (group_id forced to `None` downstream).

**`src/services/deployment_credential_service.py`**
- `_extract_access_entries` now reads `group_id` from each per-group application credential and sets it explicitly to `None` for `admin_credentials` — mirrors the existing SSH admin handling.

## Effect on existing templates

| Template | Before | After |
|---|---|---|
| `ansible-postgres-group-db` (`per_group: postgres + pgadmin`) | 1 row (teacher SSH) | 1 SSH + 2 groups × 2 cred types + 2 teacher cred types = 7 rows |
| `ansible-multiuser` (`per_group: linux`) | Group SSH rows + teacher SSH | Same as before — no `applications[]` produced because the template has no non-linux per_group / teacher creds |
| Future templates with mixed cred types | Only linux persisted | All cred types persisted, group-stamped |

## Verified

Tested locally against the staging `dilo-pg` template (`ansible-postgres-group-db`). After the fix, the lecturer UI shows the Gruppen-Tab with two groups, each with their postgres + pgadmin entries, and the Dozent-Tab shows the SSH admin row plus the teacher's postgres + pgadmin entries.

## Migration / backfill

**Existing deployments are not retroactively backfilled** — passwords aren't persisted before reaching this stage, so there's nothing to reconstruct them from. Deployments created before this fix will continue to show only the teacher SSH row. Re-deploy to get the full credential set.

## Risks

- The dynamic key discovery loop trusts `credential_generator_service.py`'s output shape. If a future credential generator adds a new top-level bookkeeping key (e.g. `metadata`), it would leak into `applications[]` as a cred type. Mitigation: the `NON_APP_KEYS` set is one line to update.
- `pgadmin_url` is read from `heat_outputs` and applied globally per stack — unchanged behaviour, just exercised more often now.