### PR TITLE
Feat #179: 36 Monate (3 Jahre) Laufzeit erlauben

### DIFF
--- a/src/schemas/deployment.py
+++ b/src/schemas/deployment.py
@@ -6,7 +6,7 @@ from typing import Optional, Any
 
 # Allowed lifetime presets matching the Wizard dropdown.
 # Keep this in sync with appstore-frontend/src/pages/DeploymentWizard.tsx.
-ALLOWED_RUNTIME_MONTHS = (1, 3, 4, 6, 12, 24)
+ALLOWED_RUNTIME_MONTHS = (1, 3, 4, 6, 12, 24, 36)
 DEFAULT_RUNTIME_MONTHS = 4
 
 

--- a/src/utils/deployment_expiry.py
+++ b/src/utils/deployment_expiry.py
@@ -19,7 +19,7 @@ MAX_WARNING_DAYS = 14
 WARNING_FRACTION_OF_RUNTIME = 0.25
 
 # Average month length used to derive timedelta from ``runtime_months``. Calendar
-# months vary; over 1..24 months this ~30.44-day approximation drifts at most a
+# months vary; over 1..36 months this ~30.44-day approximation drifts at most a
 # day or two from the calendar date — acceptable for an expiry deadline.
 DAYS_PER_MONTH = 30
 

--- a/tests/unit/test_deployment_expiry_helpers.py
+++ b/tests/unit/test_deployment_expiry_helpers.py
@@ -20,7 +20,7 @@ def _now() -> datetime:
     return datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
 
 
-@pytest.mark.parametrize("months", [1, 3, 4, 6, 12, 24])
+@pytest.mark.parametrize("months", [1, 3, 4, 6, 12, 24, 36])
 def test_compute_expiry_returns_two_future_timestamps(months: int):
     """expires_at and expiry_warning_at must both be in the future."""
     now = _now()

--- a/tests/unit/test_deployment_runtime_validation.py
+++ b/tests/unit/test_deployment_runtime_validation.py
@@ -16,17 +16,17 @@ def test_default_runtime_months_is_4():
 
 def test_allowed_set_matches_wizard_dropdown():
     """Backend's allowed set must match the Wizard <Select> options exactly."""
-    assert set(ALLOWED_RUNTIME_MONTHS) == {1, 3, 4, 6, 12, 24}
+    assert set(ALLOWED_RUNTIME_MONTHS) == {1, 3, 4, 6, 12, 24, 36}
 
 
-@pytest.mark.parametrize("months", [1, 3, 4, 6, 12, 24])
+@pytest.mark.parametrize("months", [1, 3, 4, 6, 12, 24, 36])
 def test_extend_accepts_each_allowed_runtime(months: int):
     """Every dropdown option must validate."""
     extend = DeploymentExtend(runtime_months=months)
     assert extend.runtime_months == months
 
 
-@pytest.mark.parametrize("bad", [0, -1, 2, 5, 7, 18, 36, 100])
+@pytest.mark.parametrize("bad", [0, -1, 2, 5, 7, 18, 48, 100])
 def test_extend_rejects_disallowed_runtime(bad: int):
     """Anything outside the wizard's offered set must fail validation."""
     with pytest.raises(ValidationError):


### PR DESCRIPTION
Teil des Two-Repo-Changes fuer #179 — Backend-Seite.

Erlaubt Deployments mit einer Laufzeit von bis zu **36 Monaten (3 Jahre, Dauer des Studiums)**, beim Erstellen und beim Verlaengern.

## Aenderungen
- `src/schemas/deployment.py`: `ALLOWED_RUNTIME_MONTHS` um `36` erweitert `(1, 3, 4, 6, 12, 24, 36)`. Der `field_validator` auf `DeploymentCreate` und `DeploymentExtend` lehnt sonst jeden Wert ausserhalb der Menge mit 422 ab.
- `src/utils/deployment_expiry.py`: Monats-Arithmetik ist bereits generisch (kein 24-Limit im Code) — nur der Doku-Kommentar `1..24` -> `1..36` angepasst.
- `tests/unit/test_deployment_runtime_validation.py`: allowed-set-Assertion + `parametrize` um 36 ergaenzt; 36 aus der rejected-Liste entfernt (durch 48 ersetzt).
- `tests/unit/test_deployment_expiry_helpers.py`: `parametrize`-Liste um 36 ergaenzt.

## Verifikation
- `uv run --extra dev pytest tests/unit/test_deployment_runtime_validation.py tests/unit/test_deployment_expiry_helpers.py` -> **32 passed**.

## Hinweis
Frontend-Gegenstueck (Wizard + Verlaengern-Dialog) folgt als separater PR in `appstore-frontend` und wird hier verlinkt.